### PR TITLE
Expose config files from ProjectFiles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>io.github.hadi-technology</groupId>
 	<artifactId>clarpse</artifactId>
-	<version>9.5.2</version>
+	<version>9.5.3</version>
 	<packaging>jar</packaging>
 
 	<name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/java/com/hadi/clarpse/compiler/ProjectFiles.java
+++ b/src/main/java/com/hadi/clarpse/compiler/ProjectFiles.java
@@ -178,11 +178,9 @@ public class ProjectFiles implements AutoCloseable {
         Iterator<File> it = FileUtils.iterateFiles(projectFiles, null, true);
         while (it.hasNext()) {
             File nextFile = it.next();
-            if (nextFile.isFile() && Lang.langFromExtn(FilenameUtils.getExtension(nextFile.getName())) != null) {
-                this.insertFile(new ProjectFile(
-                        nextFile.getAbsolutePath(),
-                        FileUtils.readFileToString(nextFile, StandardCharsets.UTF_8))
-                );
+            if (nextFile.isFile()) {
+                String content = FileUtils.readFileToString(nextFile, StandardCharsets.UTF_8);
+                this.insertFile(new ProjectFile(nextFile.getAbsolutePath(), content));
             }
         }
         LOGGER.info("Read " + this.size + " files.");
@@ -309,6 +307,8 @@ public class ProjectFiles implements AutoCloseable {
         Lang fileLang = Lang.langFromExtn(file.extension());
         if (fileLang != null) {
             this.insertFile(file, fileLang);
+        } else if (isConfigFile(file.path())) {
+            this.insertConfigFile(file);
         } else {
             LOGGER.debug("Skipping file: " + file.path() + ".");
         }
@@ -323,6 +323,12 @@ public class ProjectFiles implements AutoCloseable {
         }
         this.size += 1;
         LOGGER.debug("Inserted file " + file + ".");
+    }
+
+    private void insertConfigFile(final ProjectFile file) {
+        this.configFiles.put(normalizeConfigPath(file.path()), file.content());
+        this.size += 1;
+        LOGGER.debug("Inserted config file " + file + ".");
     }
 
     /**
@@ -342,8 +348,15 @@ public class ProjectFiles implements AutoCloseable {
         if (removedCount > 0) {
             this.size -= removedCount;
             LOGGER.debug("Removed " + removedCount + " file(s) at path: " + path + ".");
+            return true;
         }
-        return removedCount > 0;
+        String normalizedConfigPath = normalizeConfigPath(path);
+        if (this.configFiles.remove(normalizedConfigPath) != null) {
+            this.size -= 1;
+            LOGGER.debug("Removed config file at path: " + normalizedConfigPath + ".");
+            return true;
+        }
+        return false;
     }
 
     /**
@@ -366,6 +379,7 @@ public class ProjectFiles implements AutoCloseable {
     public final Collection<ProjectFile> files() {
         Set<ProjectFile> allFiles = new HashSet<>();
         this.langToFilesMap.forEach((lang, files) -> allFiles.addAll(files));
+        this.configFiles.forEach((path, content) -> allFiles.add(new ProjectFile(path, content)));
         return Set.copyOf(allFiles);
     }
 
@@ -460,6 +474,48 @@ public class ProjectFiles implements AutoCloseable {
         Set<ProjectFile> result = new HashSet<>();
         this.langToFilesMap.forEach((lang, files) -> result.addAll(files.stream().filter(
                 file -> file.name().equals(matchName)).collect(Collectors.toList())));
+        this.configFiles.forEach((path, content) -> {
+            ProjectFile file = new ProjectFile(path, content);
+            if (file.name().equals(matchName)) {
+                result.add(file);
+            }
+        });
         return result;
+    }
+
+    private boolean isConfigFile(String path) {
+        if (path == null || path.isBlank()) {
+            return false;
+        }
+        String normalized = normalizeConfigPath(path).toLowerCase(Locale.ROOT);
+        return normalized.equals("tsconfig.json")
+                || normalized.endsWith("/tsconfig.json")
+                || normalized.matches(".*/tsconfig\\.[^/]+\\.json$")
+                || normalized.equals("jsconfig.json")
+                || normalized.endsWith("/jsconfig.json")
+                || normalized.equals("package.json")
+                || normalized.endsWith("/package.json")
+                || normalized.equals("pyrightconfig.json")
+                || normalized.endsWith("/pyrightconfig.json")
+                || normalized.equals("pyproject.toml")
+                || normalized.endsWith("/pyproject.toml");
+    }
+
+    private String normalizeConfigPath(String path) {
+        if (path == null || path.isBlank()) {
+            return path;
+        }
+        String normalized = path.replace('\\', '/');
+        if (CompilerSupport.isAbsolutePath(normalized)) {
+            if (normalized.length() > 2
+                    && Character.isLetter(normalized.charAt(0))
+                    && normalized.charAt(1) == ':') {
+                normalized = normalized.substring(2);
+            }
+        }
+        while (normalized.startsWith("/")) {
+            normalized = normalized.substring(1);
+        }
+        return normalized;
     }
 }

--- a/src/main/java/com/hadi/clarpse/compiler/ProjectFiles.java
+++ b/src/main/java/com/hadi/clarpse/compiler/ProjectFiles.java
@@ -178,7 +178,7 @@ public class ProjectFiles implements AutoCloseable {
         Iterator<File> it = FileUtils.iterateFiles(projectFiles, null, true);
         while (it.hasNext()) {
             File nextFile = it.next();
-            if (nextFile.isFile()) {
+            if (nextFile.isFile() && shouldLoadPath(nextFile.getAbsolutePath())) {
                 String content = FileUtils.readFileToString(nextFile, StandardCharsets.UTF_8);
                 this.insertFile(new ProjectFile(nextFile.getAbsolutePath(), content));
             }
@@ -279,11 +279,8 @@ public class ProjectFiles implements AutoCloseable {
 
     private void handlePotentialConfigFile(String safeName, String content) {
         String normalizedSafeName = safeName.replace("\\", "/");
-        String lower = normalizedSafeName.toLowerCase(Locale.ROOT);
-        if (lower.endsWith("tsconfig.json")
-                || lower.endsWith("pyrightconfig.json")
-                || lower.endsWith("pyproject.toml")) {
-            this.configFiles.put(normalizedSafeName, content);
+        if (isConfigFile(normalizedSafeName)) {
+            insertConfigFile(new ProjectFile(normalizedSafeName, content));
         }
     }
 
@@ -499,6 +496,14 @@ public class ProjectFiles implements AutoCloseable {
                 || normalized.endsWith("/pyrightconfig.json")
                 || normalized.equals("pyproject.toml")
                 || normalized.endsWith("/pyproject.toml");
+    }
+
+    private boolean shouldLoadPath(String path) {
+        if (path == null || path.isBlank()) {
+            return false;
+        }
+        return isConfigFile(path)
+                || Lang.langFromExtn(FilenameUtils.getExtension(path)) != null;
     }
 
     private String normalizeConfigPath(String path) {

--- a/src/test/java/com/hadi/test/ProjectFilesTest.java
+++ b/src/test/java/com/hadi/test/ProjectFilesTest.java
@@ -243,6 +243,27 @@ public class ProjectFilesTest {
     }
 
     @Test
+    public void testZipLoadedConfigFileCountsTowardSizeAndCanBeRemoved() throws Exception {
+        Path zipPath = Files.createTempFile("zip-config-only", ".zip");
+        try (ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(zipPath.toFile()))) {
+            ZipEntry configEntry = new ZipEntry("project/tsconfig.json");
+            zos.putNextEntry(configEntry);
+            zos.write("{\"compilerOptions\":{}}".getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+        }
+
+        ProjectFiles projectFiles;
+        try (var in = Files.newInputStream(zipPath)) {
+            projectFiles = new ProjectFiles(in);
+        }
+
+        assertEquals(1, projectFiles.size());
+        assertTrue(projectFiles.removeFile("/project/tsconfig.json"));
+        assertEquals(0, projectFiles.size());
+        assertEquals(0, projectFiles.files().size());
+    }
+
+    @Test
     public void testConfigFilesFromDirAreExposed() throws Exception {
         Path tempDir = Files.createTempDirectory("clarpse-project-files");
         try {

--- a/src/test/java/com/hadi/test/ProjectFilesTest.java
+++ b/src/test/java/com/hadi/test/ProjectFilesTest.java
@@ -5,6 +5,7 @@ import com.hadi.clarpse.compiler.Lang;
 import com.hadi.clarpse.compiler.ProjectFile;
 import com.hadi.clarpse.compiler.ProjectFiles;
 import com.hadi.clarpse.compiler.typescript.NodeRuntime;
+import org.apache.commons.io.FileUtils;
 import org.junit.BeforeClass;
 import org.junit.Assume;
 import org.junit.Test;
@@ -139,6 +140,24 @@ public class ProjectFilesTest {
     }
 
     @Test
+    public void testInsertConfigFileIsExposedByFiles() {
+        ProjectFiles pfs = new ProjectFiles();
+        pfs.insertFile(new ProjectFile("/tsconfig.json", "{}"));
+        assertEquals(1, pfs.size());
+        assertEquals(1, pfs.files().size());
+        assertTrue(pfs.files().stream().anyMatch(file -> "/tsconfig.json".equals(file.path())));
+    }
+
+    @Test
+    public void testRemoveConfigFileRemovesItFromAllFiles() {
+        ProjectFiles pfs = new ProjectFiles();
+        pfs.insertFile(new ProjectFile("/package.json", "{\"name\":\"demo\"}"));
+        assertTrue(pfs.removeFile("/package.json"));
+        assertEquals(0, pfs.size());
+        assertEquals(0, pfs.files().size());
+    }
+
+    @Test
     public void testEmptyProjectFilesSize() {
         ProjectFiles pfs = new ProjectFiles();
         assertEquals(0, pfs.size());
@@ -156,6 +175,13 @@ public class ProjectFilesTest {
         ProjectFiles pfs = new ProjectFiles();
         pfs.insertFile(new ProjectFile("/test.java", "{}"));
         assertEquals(0, pfs.matchingFilesByName("missing.java").size());
+    }
+
+    @Test
+    public void testMatchingFilesByNameIncludesConfigFiles() {
+        ProjectFiles pfs = new ProjectFiles();
+        pfs.insertFile(new ProjectFile("/tsconfig.json", "{}"));
+        assertEquals(1, pfs.matchingFilesByName("tsconfig.json").size());
     }
 
     @Test
@@ -214,6 +240,24 @@ public class ProjectFilesTest {
         assertTrue("tsconfig should be persisted", Files.exists(tsconfig));
         assertEquals("{\"compilerOptions\":{\"allowJs\":true}}",
                 Files.readString(tsconfig, StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void testConfigFilesFromDirAreExposed() throws Exception {
+        Path tempDir = Files.createTempDirectory("clarpse-project-files");
+        try {
+            Files.writeString(tempDir.resolve("tsconfig.json"), "{\"compilerOptions\":{}}", StandardCharsets.UTF_8);
+            Files.createDirectories(tempDir.resolve("src"));
+            Files.writeString(tempDir.resolve("src").resolve("app.ts"), "export const app = 1;", StandardCharsets.UTF_8);
+
+            ProjectFiles projectFiles = new ProjectFiles(tempDir.toString());
+
+            assertEquals(2, projectFiles.size());
+            assertTrue(projectFiles.files().stream().anyMatch(file -> "tsconfig.json".equals(file.name())));
+            assertTrue(projectFiles.files(Lang.TYPESCRIPT).stream().anyMatch(file -> "app.ts".equals(file.name())));
+        } finally {
+            FileUtils.deleteQuietly(tempDir.toFile());
+        }
     }
 
     @Test


### PR DESCRIPTION
The change makes `ProjectFiles` expose config/support files through `files()`, and also:
 - loads them from directories
 - allows `insertFile()` for them
 - allows `removeFile()` for them
 - includes them in `matchingFilesByName()`