### PR TITLE
Fix TypeScript resolver stack overflow on recursive types

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>io.github.hadi-technology</groupId>
 	<artifactId>clarpse</artifactId>
-	<version>9.5.3</version>
+	<version>9.5.4</version>
 	<packaging>jar</packaging>
 
 	<name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/java/com/hadi/clarpse/compiler/FailureCode.java
+++ b/src/main/java/com/hadi/clarpse/compiler/FailureCode.java
@@ -16,6 +16,7 @@ public final class FailureCode {
     public static final int PARSE_FAILED = 2003;
     public static final int DAEMON_ERROR = 2004;
     public static final int FILE_EXCLUDED = 2005;
+    public static final int RESOLUTION_FAILED = 2006;
 
     private FailureCode() {
     }

--- a/src/main/java/com/hadi/clarpse/compiler/typescript/ClarpseTypeScriptCompiler.java
+++ b/src/main/java/com/hadi/clarpse/compiler/typescript/ClarpseTypeScriptCompiler.java
@@ -109,7 +109,8 @@ public class ClarpseTypeScriptCompiler implements ClarpseCompiler {
         if (e == null) {
             return false;
         }
-        return e.code() == TypeScriptDaemonException.CODE_FILE_NOT_FOUND;
+        return e.code() == TypeScriptDaemonException.CODE_FILE_NOT_FOUND
+                || e.code() == TypeScriptDaemonException.CODE_RESOLUTION_FAILED;
     }
 
     private static void addInvalidConfigFailures(final TypeScriptDaemon.InitResult initResult,

--- a/src/main/java/com/hadi/clarpse/compiler/typescript/TypeScriptDaemonException.java
+++ b/src/main/java/com/hadi/clarpse/compiler/typescript/TypeScriptDaemonException.java
@@ -15,6 +15,7 @@ public class TypeScriptDaemonException extends Exception {
     public static final int CODE_FILE_NOT_IN_PROGRAM = FailureCode.FILE_OUT_OF_SCOPE;
     public static final int CODE_FILE_NOT_FOUND = FailureCode.FILE_NOT_FOUND;
     public static final int CODE_DAEMON_ERROR = FailureCode.DAEMON_ERROR;
+    public static final int CODE_RESOLUTION_FAILED = FailureCode.RESOLUTION_FAILED;
 
     private final int code;
 

--- a/src/main/resources/typescript/daemon.js
+++ b/src/main/resources/typescript/daemon.js
@@ -8,8 +8,11 @@ const ERROR_CODES = {
   CONFIG_PARSE_FAILED: 1003,
   PROGRAM_CREATE_FAILED: 1004,
   FILE_NOT_IN_PROGRAM: 2001,
-  FILE_NOT_FOUND: 2002
+  FILE_NOT_FOUND: 2002,
+  RESOLUTION_FAILED: 2006
 };
+
+const MAX_TYPE_DEPTH = 10;
 
 let state = {
   repoRoot: null,
@@ -383,9 +386,13 @@ function getReturnTypeObject(checker, node) {
   return checker.getReturnTypeOfSignature(signature);
 }
 
-function normalizeReturnType(type, checker) {
+function normalizeReturnType(type, checker, depth) {
   if (!type || !checker || !state.ts) {
     return "";
+  }
+  depth = depth || 0;
+  if (depth >= MAX_TYPE_DEPTH) {
+    return checker.typeToString(type);
   }
   const ts = state.ts;
   const flags = type.flags || 0;
@@ -406,7 +413,7 @@ function normalizeReturnType(type, checker) {
   if (type.isUnion && type.isUnion() && Array.isArray(type.types)) {
     const parts = [];
     for (const subType of type.types) {
-      const normalized = normalizeReturnType(subType, checker);
+      const normalized = normalizeReturnType(subType, checker, depth + 1);
       if (!normalized) {
         continue;
       }
@@ -419,7 +426,7 @@ function normalizeReturnType(type, checker) {
   if (type.isIntersection && type.isIntersection() && Array.isArray(type.types)) {
     const parts = [];
     for (const subType of type.types) {
-      const normalized = normalizeReturnType(subType, checker);
+      const normalized = normalizeReturnType(subType, checker, depth + 1);
       if (!normalized) {
         continue;
       }
@@ -467,13 +474,21 @@ function resolveSymbolName(symbol, checker) {
   return actual.getName();
 }
 
-function collectSymbolEntries(type, checker, entries) {
+function collectSymbolEntries(type, checker, entries, depth) {
   if (!type) {
+    return;
+  }
+  depth = depth || 0;
+  if (depth >= MAX_TYPE_DEPTH) {
+    const symbol = type.aliasSymbol || type.symbol;
+    if (symbol) {
+      entries.push({ symbol, type });
+    }
     return;
   }
   if (type.isUnionOrIntersection && type.isUnionOrIntersection()) {
     for (const sub of type.types) {
-      collectSymbolEntries(sub, checker, entries);
+      collectSymbolEntries(sub, checker, entries, depth + 1);
     }
     return;
   }
@@ -482,7 +497,7 @@ function collectSymbolEntries(type, checker, entries) {
       if (arg && arg.isThisType) {
         continue;
       }
-      collectSymbolEntries(arg, checker, entries);
+      collectSymbolEntries(arg, checker, entries, depth + 1);
     }
   }
   if (type.typeArguments) {
@@ -490,7 +505,7 @@ function collectSymbolEntries(type, checker, entries) {
       if (arg && arg.isThisType) {
         continue;
       }
-      collectSymbolEntries(arg, checker, entries);
+      collectSymbolEntries(arg, checker, entries, depth + 1);
     }
   }
   const symbol = type.aliasSymbol || type.symbol;
@@ -499,13 +514,17 @@ function collectSymbolEntries(type, checker, entries) {
   }
 }
 
-function collectDisplayNames(type, checker, names) {
+function collectDisplayNames(type, checker, names, depth) {
   if (!type) {
+    return;
+  }
+  depth = depth || 0;
+  if (depth >= MAX_TYPE_DEPTH) {
     return;
   }
   if (type.isUnionOrIntersection && type.isUnionOrIntersection()) {
     for (const sub of type.types) {
-      collectDisplayNames(sub, checker, names);
+      collectDisplayNames(sub, checker, names, depth + 1);
     }
     return;
   }
@@ -514,7 +533,7 @@ function collectDisplayNames(type, checker, names) {
       if (arg && arg.isThisType) {
         continue;
       }
-      collectDisplayNames(arg, checker, names);
+      collectDisplayNames(arg, checker, names, depth + 1);
     }
   }
   if (type.typeArguments) {
@@ -522,7 +541,7 @@ function collectDisplayNames(type, checker, names) {
       if (arg && arg.isThisType) {
         continue;
       }
-      collectDisplayNames(arg, checker, names);
+      collectDisplayNames(arg, checker, names, depth + 1);
     }
   }
   const symbol = type.aliasSymbol || type.symbol;
@@ -1057,7 +1076,17 @@ async function handleGetFileModel(params) {
     throw err;
   }
   const checker = entryInfo.entry.checker || entryInfo.entry.program.getTypeChecker();
-  const declarations = collectTopLevelDeclarations(ts, entryInfo.source, checker);
+  let declarations;
+  try {
+    declarations = collectTopLevelDeclarations(ts, entryInfo.source, checker);
+  } catch (err) {
+    if (err instanceof RangeError || (err.message && err.message.includes("Maximum call stack size exceeded"))) {
+      console.warn(`[clarpse] Stack overflow during type resolution for ${filePath}. Returning partial model.`);
+      declarations = [];
+    } else {
+      throw err;
+    }
+  }
   return {
     filePath: normalized,
     declarations
@@ -1084,7 +1113,9 @@ async function handleRequest(request) {
       const result = await handleGetFileModel(params);
       writeResponse(id, result);
     } catch (err) {
-      if (err.code) {
+      if (err instanceof RangeError || (err.message && err.message.includes("Maximum call stack size exceeded"))) {
+        writeError(id, ERROR_CODES.RESOLUTION_FAILED, "Maximum call stack size exceeded");
+      } else if (err.code) {
         writeError(id, err.code, err.message, err.data);
       } else {
         writeError(id, ERROR_CODES.PROGRAM_CREATE_FAILED, err.message);

--- a/src/test/java/com/hadi/test/typescript/TypeScriptRecursiveTypeTest.java
+++ b/src/test/java/com/hadi/test/typescript/TypeScriptRecursiveTypeTest.java
@@ -1,0 +1,71 @@
+package com.hadi.test.typescript;
+
+import com.hadi.clarpse.compiler.CompileResult;
+import com.hadi.clarpse.compiler.typescript.NodeRuntime;
+import com.hadi.clarpse.sourcemodel.Component;
+import org.junit.Assume;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Verifies that the TypeScript resolver handles deeply recursive type structures
+ * gracefully without crashing (issue #144).
+ */
+public class TypeScriptRecursiveTypeTest {
+
+    @Test
+    public void recursiveTypesDoNotCrashResolver() throws Exception {
+        Assume.assumeTrue(NodeRuntime.isNodeAvailable());
+        CompileResult result = TypeScriptTestUtil.compileFixture("recursive-types");
+
+        assertNotNull(result);
+        assertNotNull(result.model());
+        // The model should be returned without throwing CompileException
+        assertFalse(result.failures().isEmpty() && result.model().components().count() == 0);
+    }
+
+    @Test
+    public void recursiveTypesProduceClassComponent() throws Exception {
+        Assume.assumeTrue(NodeRuntime.isNodeAvailable());
+        CompileResult result = TypeScriptTestUtil.compileFixture("recursive-types");
+
+        assertNotNull(result);
+        assertTrue("TreeNode class should be resolved",
+                result.model().getComponent("src.index.TreeNode").isPresent());
+    }
+
+    @Test
+    public void recursiveTypesProduceFunctionComponent() throws Exception {
+        Assume.assumeTrue(NodeRuntime.isNodeAvailable());
+        CompileResult result = TypeScriptTestUtil.compileFixture("recursive-types");
+
+        assertNotNull(result);
+        assertTrue("processNode function should be resolved",
+                result.model().components().anyMatch(c ->
+                        c.name().equals("processNode")));
+    }
+
+    @Test
+    public void recursiveTypesProduceInterfaceComponent() throws Exception {
+        Assume.assumeTrue(NodeRuntime.isNodeAvailable());
+        CompileResult result = TypeScriptTestUtil.compileFixture("recursive-types");
+
+        assertNotNull(result);
+        assertTrue("Container interface should be resolved",
+                result.model().getComponent("src.index.Container").isPresent());
+    }
+
+    @Test
+    public void recursiveTypeResolutionFailuresAreFileLevel() throws Exception {
+        Assume.assumeTrue(NodeRuntime.isNodeAvailable());
+        CompileResult result = TypeScriptTestUtil.compileFixture("recursive-types");
+
+        assertNotNull(result);
+        // If there are failures, the compilation should still produce results
+        // rather than throwing an exception
+        assertTrue(result.model().components().count() > 0);
+    }
+}

--- a/src/test/resources/typescript/recursive-types/src/index.ts
+++ b/src/test/resources/typescript/recursive-types/src/index.ts
@@ -1,0 +1,52 @@
+// Deeply nested recursive type that would cause stack overflow without depth limits
+type DeepRecursive<T> = {
+  value: T;
+  next: DeepRecursive<T>;
+};
+
+// Mutual recursion between types
+type NodeA = {
+  b: NodeB | null;
+};
+
+type NodeB = {
+  a: NodeA | null;
+};
+
+// Deeply nested generics
+type Level1<T> = T;
+type Level2<T> = Level1<Level1<T>>;
+type Level3<T> = Level2<Level2<T>>;
+type Level4<T> = Level3<Level3<T>>;
+type Level5<T> = Level4<Level4<T>>;
+type Level6<T> = Level5<Level5<T>>;
+type Level7<T> = Level6<Level6<T>>;
+type Level8<T> = Level7<Level7<T>>;
+
+// Class using recursive types
+class TreeNode {
+  value: string;
+  left: DeepRecursive<TreeNode> | null;
+  right: DeepRecursive<TreeNode> | null;
+
+  constructor(value: string) {
+    this.value = value;
+    this.left = null;
+    this.right = null;
+  }
+
+  getLeft(): NodeA | null {
+    return null;
+  }
+}
+
+// Interface with deeply nested type parameter
+interface Container<T> {
+  data: T;
+  wrap(): Container<Container<T>>;
+}
+
+// Function using deeply recursive types
+function processNode(node: DeepRecursive<string>): string {
+  return node.value;
+}

--- a/src/test/resources/typescript/recursive-types/tsconfig.json
+++ b/src/test/resources/typescript/recursive-types/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "CommonJS",
+    "strict": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
Fixes #144

- Add `MAX_TYPE_DEPTH` (10) recursion limit to `normalizeReturnType`, `collectSymbolEntries`, and `collectDisplayNames` in `daemon.js` to prevent stack overflow on deeply/mutually recursive type structures
- Add try-catch around `collectTopLevelDeclarations` to gracefully handle any remaining `RangeError`, returning a partial model instead of crashing
- Add `RESOLUTION_FAILED` error code (`2006`) and treat it as a file-level failure so one file doesn't abort the entire project compilation
- Bump version to 9.5.4

## Test plan
- [x] New `TypeScriptRecursiveTypeTest` with 5 test cases covering recursive types
- [x] Test fixture with deeply recursive types, mutual recursion, and deeply nested generics
- [x] All existing TypeScript tests pass without regression