### PR TITLE
Feat/csharp support pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Clarpse is a multi-language parsing and analysis library that converts source co
 # Features
 
  - Supports **Java** with a lightweight, architecture-focused parser.
+ - Supports **C#** with JVM-based parsing, partial type merging, namespace-aware indexing, and fast in-repo symbol resolution.
  - Supports **TypeScript** with compiler-accurate, tsconfig-aware parsing and resolution, including constructor parameter property detection and monorepo support.
  - Supports **Python** with Pyright-backed parsing, including nested classes, comment parsing, cyclomatic complexity, code hashing, and visibility inference.
  - Runtime configuration through bundled properties file
@@ -242,7 +243,7 @@ System.out.println(methodComponent.codeFragment());
 ```
 
 ## Failure Contract
-- Java/TypeScript/Python all report recoverable issues in `CompileResult.failures()` using
+- Java/C#/TypeScript/Python all report recoverable issues in `CompileResult.failures()` using
   language-agnostic error codes.
 - `CompileException` is reserved for non-recoverable compiler errors.
 

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,13 @@
 		<url>https://github.com/hadi-technology/clarpse.git</url>
 	</scm>
 
+	<repositories>
+		<repository>
+			<id>jetbrains-intellij-deps</id>
+			<url>https://packages.jetbrains.team/maven/p/ij/intellij-dependencies</url>
+		</repository>
+	</repositories>
+
 	<dependencies>
 		<!-- https://mvnrepository.com/artifact/com.tunnelvisionlabs/antlr4-runtime -->
 		<dependency>
@@ -82,6 +89,31 @@
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
 			<version>2.18.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.jetbrains</groupId>
+			<artifactId>csharp-parser</artifactId>
+			<version>0.3.355</version>
+		</dependency>
+		<dependency>
+			<groupId>org.jetbrains</groupId>
+			<artifactId>ij-parsing-core</artifactId>
+			<version>0.3.355</version>
+		</dependency>
+		<dependency>
+			<groupId>org.jetbrains.kotlin</groupId>
+			<artifactId>kotlin-stdlib</artifactId>
+			<version>2.2.20-RC</version>
+		</dependency>
+		<dependency>
+			<groupId>org.jetbrains</groupId>
+			<artifactId>annotations</artifactId>
+			<version>26.0.2</version>
+		</dependency>
+		<dependency>
+			<groupId>org.jetbrains.intellij.deps.fastutil</groupId>
+			<artifactId>intellij-deps-fastutil</artifactId>
+			<version>8.5.4-9</version>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>io.github.hadi-technology</groupId>
 	<artifactId>clarpse</artifactId>
-	<version>9.5.4</version>
+	<version>9.6.0</version>
 	<packaging>jar</packaging>
 
 	<name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/java/com/hadi/clarpse/compiler/ClarpseJavaCompiler.java
+++ b/src/main/java/com/hadi/clarpse/compiler/ClarpseJavaCompiler.java
@@ -17,7 +17,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 
 /**
  * JavaParser based compiler to process source code.
@@ -25,7 +24,6 @@ import java.util.concurrent.TimeUnit;
 public class ClarpseJavaCompiler implements ClarpseCompiler {
 
     private static final Logger LOGGER = LogManager.getLogger(ClarpseJavaCompiler.class);
-    private static final String PARALLELISM_ENV = "CLARPSE_PARALLELISM";
 
     @Override
     public CompileResult compile(final ProjectFiles projectFiles,
@@ -54,7 +52,7 @@ public class ClarpseJavaCompiler implements ClarpseCompiler {
 
     @SuppressWarnings("PMD.CloseResource")
     private ParseResults parseJavaFiles(final List<ProjectFile> files, final String persistDir) {
-        final int parallelism = resolveParallelism(files.size());
+        final int parallelism = CompilerParallelismSupport.resolveParallelism(files.size());
         if (parallelism > 1) {
             LOGGER.info("Parsing Java files in parallel using " + parallelism + " threads.");
         }
@@ -90,39 +88,7 @@ public class ClarpseJavaCompiler implements ClarpseCompiler {
             }
             return new ParseResults(mergedModel, compileFailures);
         } finally {
-            shutdownExecutor(executor);
+            CompilerParallelismSupport.shutdownExecutor(executor);
         }
-    }
-
-    private void shutdownExecutor(final ExecutorService executor) {
-        executor.shutdown();
-        try {
-            if (!executor.awaitTermination(30, TimeUnit.SECONDS)) {
-                executor.shutdownNow();
-            }
-        } catch (InterruptedException e) {
-            executor.shutdownNow();
-            Thread.currentThread().interrupt();
-        }
-    }
-
-    private int resolveParallelism(final int fileCount) {
-        if (fileCount == 0) {
-            return 1;
-        }
-        final String override = System.getenv(PARALLELISM_ENV);
-        if (override != null) {
-            try {
-                final int requested = Integer.parseInt(override.trim());
-                if (requested <= 0) {
-                    return 1;
-                }
-                return Math.min(requested, fileCount);
-            } catch (NumberFormatException ignored) {
-                // Use default parallelism
-            }
-        }
-        final int available = Runtime.getRuntime().availableProcessors();
-        return Math.min(available, fileCount);
     }
 }

--- a/src/main/java/com/hadi/clarpse/compiler/CompilerFactory.java
+++ b/src/main/java/com/hadi/clarpse/compiler/CompilerFactory.java
@@ -2,6 +2,7 @@ package com.hadi.clarpse.compiler;
 
 import com.hadi.clarpse.compiler.typescript.ClarpseTypeScriptCompiler;
 import com.hadi.clarpse.compiler.python.ClarpsePythonCompiler;
+import com.hadi.clarpse.compiler.csharp.ClarpseCSharpCompiler;
 
 /**
  * Factory to retrieve appropriate parsing tool for our projects.
@@ -13,6 +14,8 @@ public class CompilerFactory {
 
             case JAVA:
             return new ClarpseJavaCompiler();
+            case CSHARP:
+            return new ClarpseCSharpCompiler();
             case TYPESCRIPT:
             return new ClarpseTypeScriptCompiler();
             case PYTHON:

--- a/src/main/java/com/hadi/clarpse/compiler/CompilerParallelismSupport.java
+++ b/src/main/java/com/hadi/clarpse/compiler/CompilerParallelismSupport.java
@@ -1,0 +1,46 @@
+package com.hadi.clarpse.compiler;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Shared helpers for compiler worker-pool sizing and shutdown behavior.
+ */
+public final class CompilerParallelismSupport {
+
+    public static final String PARALLELISM_ENV = "CLARPSE_PARALLELISM";
+
+    private CompilerParallelismSupport() {
+    }
+
+    public static int resolveParallelism(final int fileCount) {
+        if (fileCount <= 1) {
+            return 1;
+        }
+        final String override = System.getenv(PARALLELISM_ENV);
+        if (override != null) {
+            try {
+                final int requested = Integer.parseInt(override.trim());
+                if (requested > 0) {
+                    return Math.min(requested, fileCount);
+                }
+                return 1;
+            } catch (NumberFormatException ignored) {
+                // Fall back to processor count.
+            }
+        }
+        return Math.min(Runtime.getRuntime().availableProcessors(), fileCount);
+    }
+
+    public static void shutdownExecutor(final ExecutorService executor) {
+        executor.shutdown();
+        try {
+            if (!executor.awaitTermination(30, TimeUnit.SECONDS)) {
+                executor.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            executor.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/src/main/java/com/hadi/clarpse/compiler/CompilerParallelismSupport.java
+++ b/src/main/java/com/hadi/clarpse/compiler/CompilerParallelismSupport.java
@@ -4,7 +4,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Shared helpers for compiler worker-pool sizing and shutdown behavior.
+ * Shared helpers for compiler worker-pool sizing and shutdown behavior. Java
+ * and C# use this to honor the same environment-variable override and the same
+ * executor termination policy.
  */
 public final class CompilerParallelismSupport {
 

--- a/src/main/java/com/hadi/clarpse/compiler/Lang.java
+++ b/src/main/java/com/hadi/clarpse/compiler/Lang.java
@@ -19,6 +19,7 @@ import java.util.Set;
 public enum Lang {
 
     JAVA("java", new HashSet<>(List.of("java")), Collections.emptySet()),
+    CSHARP("csharp", new HashSet<>(List.of("cs")), Collections.emptySet()),
     TYPESCRIPT("typescript", new HashSet<>(List.of("ts", "tsx")), Collections.emptySet()),
     PYTHON("python", new HashSet<>(List.of("py")), Collections.emptySet());
 
@@ -26,6 +27,7 @@ public enum Lang {
 
     static {
         NAMES_MAP.put(JAVA.value, JAVA);
+        NAMES_MAP.put(CSHARP.value, CSHARP);
         NAMES_MAP.put(TYPESCRIPT.value, TYPESCRIPT);
         NAMES_MAP.put(PYTHON.value, PYTHON);
     }

--- a/src/main/java/com/hadi/clarpse/compiler/csharp/CSharpFileParser.java
+++ b/src/main/java/com/hadi/clarpse/compiler/csharp/CSharpFileParser.java
@@ -140,7 +140,7 @@ final class CSharpFileParser {
         final String type = node.type;
         if ("cs:namespace-file-scope-declaration".equals(type)
                 || "cs:namespace-block-declaration".equals(type)) {
-            final String namespaceName = namespaceName(node);
+            final String namespaceName = combineNamespace(currentNamespace, namespaceName(node));
             for (final SyntaxNode child : node.children) {
                 if ("cs:block-list".equals(child.type)) {
                     for (final SyntaxNode nested : child.children) {
@@ -862,6 +862,20 @@ final class CSharpFileParser {
             return null;
         }
         return normalizeWhitespace(child.text);
+    }
+
+    private static String combineNamespace(final String currentNamespace, final String declaredNamespace) {
+        if (currentNamespace == null || currentNamespace.isEmpty()) {
+            return declaredNamespace == null ? "" : declaredNamespace;
+        }
+        if (declaredNamespace == null || declaredNamespace.isEmpty()) {
+            return currentNamespace;
+        }
+        if (declaredNamespace.equals(currentNamespace)
+                || declaredNamespace.startsWith(currentNamespace + ".")) {
+            return declaredNamespace;
+        }
+        return currentNamespace + "." + declaredNamespace;
     }
 
     private static SyntaxNode firstChild(final SyntaxNode node, final String type) {

--- a/src/main/java/com/hadi/clarpse/compiler/csharp/CSharpFileParser.java
+++ b/src/main/java/com/hadi/clarpse/compiler/csharp/CSharpFileParser.java
@@ -22,6 +22,12 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+/**
+ * Syntax-first C# file parser that converts JetBrains PSI productions into
+ * lightweight Clarpse intermediate models. This stage is responsible for
+ * declaration extraction, local/body token harvesting, and cheap structural
+ * validation before the model assembler performs repo-local resolution.
+ */
 final class CSharpFileParser {
 
     private static final Set<String> TYPE_DECLARATIONS = Set.of(

--- a/src/main/java/com/hadi/clarpse/compiler/csharp/CSharpFileParser.java
+++ b/src/main/java/com/hadi/clarpse/compiler/csharp/CSharpFileParser.java
@@ -1,0 +1,929 @@
+package com.hadi.clarpse.compiler.csharp;
+
+import com.hadi.clarpse.compiler.CompileFailure;
+import com.hadi.clarpse.compiler.CompilerSupport;
+import com.hadi.clarpse.compiler.FailureCode;
+import com.hadi.clarpse.compiler.ProjectFile;
+import fleet.com.intellij.lang.PsiBuilder;
+import fleet.com.intellij.lang.SyntaxTreeBuilder.Production;
+import fleet.com.intellij.lexer.Lexer;
+import fleet.com.intellij.psi.ArrayTokenSequence;
+import fleet.com.intellij.psi.FleetPsiParser;
+import fleet.com.jetbrains.csharp.CSharpFleetParser;
+import fleet.com.jetbrains.lang.parsing.builder.MarkerPsiBuilder;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+final class CSharpFileParser {
+
+    private static final Set<String> TYPE_DECLARATIONS = Set.of(
+            "cs:class-declaration",
+            "cs:interface-declaration",
+            "cs:struct-declaration",
+            "cs:record-declaration",
+            "cs:struct-record-declaration",
+            "cs:enum-declaration",
+            "cs:delegate-declaration"
+    );
+
+    private static final Set<String> MEMBER_DECLARATIONS = Set.of(
+            "cs:property-declaration",
+            "cs:event-declaration",
+            "cs:field-declaration",
+            "cs:multiple-fields-declaration",
+            "cs:ctor-declaration",
+            "cs:method-declaration",
+            "cs:inplace-record-field-declaration",
+            "cs:enum-member-declaration"
+    );
+
+    private static final Pattern TYPE_TOKEN_PATTERN = Pattern.compile("[A-Za-z_][A-Za-z0-9_\\.]*");
+    private static final Pattern THIS_MEMBER_ASSIGN_PATTERN =
+            Pattern.compile("\\bthis\\.(\\w+)\\s*=\\s*(\\w+)\\b");
+    private static final Pattern STATIC_RECEIVER_PATTERN =
+            Pattern.compile("\\b([A-Z][A-Za-z0-9_\\.]*)\\s*\\.");
+
+    private CSharpFileParser() {
+    }
+
+    static CSharpModel.ParseOutcome parseFile(final ProjectFile file, final int index) {
+        try {
+            String sourceText = file.content();
+            if (sourceText == null) {
+                sourceText = "";
+            }
+            validateBalancedDelimiters(sourceText);
+            final CSharpModel.CSharpFileModel fileModel = new CSharpModel.CSharpFileModel(
+                    file,
+                    sourceText,
+                    CompilerSupport.moduleNameForFile(file.path())
+            );
+            final SyntaxNode root = parseSyntaxTree(sourceText);
+            for (final SyntaxNode child : root.children) {
+                parseTopLevelNode(child, fileModel, "");
+            }
+            return new CSharpModel.ParseOutcome(index, fileModel, null);
+        } catch (final Exception e) {
+            return new CSharpModel.ParseOutcome(
+                    index,
+                    null,
+                    new CompileFailure(file, e.getMessage(), FailureCode.PARSE_FAILED)
+            );
+        }
+    }
+
+    private static SyntaxNode parseSyntaxTree(final String sourceText) {
+        final FleetPsiParser parser = new CSharpFleetParser();
+        final Lexer lexer = parser.getLexer();
+        final ArrayTokenSequence tokens = new ArrayTokenSequence.Builder(sourceText, lexer).performLexing();
+        final PsiBuilder builder = new MarkerPsiBuilder(
+                sourceText,
+                tokens,
+                parser.getWhitespaces(),
+                parser.getComments(),
+                0,
+                tokens.getLexemeCount()
+        );
+        parser.parse(builder);
+        final List<Production> productions = builder.getProductions();
+        final Deque<SyntaxNode> stack = new ArrayDeque<>();
+        SyntaxNode root = null;
+        for (final Production production : productions) {
+            final String type = String.valueOf(production.getTokenType());
+            final SyntaxNode current = new SyntaxNode(type, production.getStartOffset(), production.getEndOffset());
+            if (!stack.isEmpty() && stack.peek().sameRange(current)) {
+                stack.pop();
+                continue;
+            }
+            if (root == null) {
+                root = current;
+            } else if (!stack.isEmpty()) {
+                current.parent = stack.peek();
+                current.parent.children.add(current);
+            }
+            stack.push(current);
+        }
+        if (root == null) {
+            throw new IllegalStateException("No syntax nodes produced for source.");
+        }
+        attachText(root, sourceText);
+        return root;
+    }
+
+    private static void attachText(final SyntaxNode node, final String sourceText) {
+        node.text = safeSubstring(sourceText, node.startOffset, node.endOffset);
+        for (final SyntaxNode child : node.children) {
+            attachText(child, sourceText);
+        }
+    }
+
+    private static void parseTopLevelNode(final SyntaxNode node,
+                                          final CSharpModel.CSharpFileModel fileModel,
+                                          final String currentNamespace) {
+        if (node == null) {
+            return;
+        }
+        final String type = node.type;
+        if ("cs:namespace-file-scope-declaration".equals(type)
+                || "cs:namespace-block-declaration".equals(type)) {
+            final String namespaceName = namespaceName(node);
+            for (final SyntaxNode child : node.children) {
+                if ("cs:block-list".equals(child.type)) {
+                    for (final SyntaxNode nested : child.children) {
+                        parseTopLevelNode(nested, fileModel, namespaceName);
+                    }
+                } else if (!"cs:namespace-header-node-statement".equals(child.type)
+                        && !"cs:id-role".equals(child.type)) {
+                    parseTopLevelNode(child, fileModel, namespaceName);
+                }
+            }
+            return;
+        }
+        if ("cs:block-list".equals(type)) {
+            for (final SyntaxNode child : node.children) {
+                parseTopLevelNode(child, fileModel, currentNamespace);
+            }
+            return;
+        }
+        if ("cs:using-list-role".equals(type)) {
+            for (final SyntaxNode child : node.children) {
+                if ("cs:using-directive-statement".equals(child.type)) {
+                    fileModel.usings.add(parseUsing(child));
+                }
+            }
+            return;
+        }
+        if (TYPE_DECLARATIONS.contains(type)) {
+            fileModel.types.add(parseType(node, fileModel, currentNamespace, null));
+        }
+    }
+
+    private static void validateBalancedDelimiters(final String sourceText) {
+        int braces = 0;
+        int parens = 0;
+        int brackets = 0;
+        boolean inString = false;
+        boolean verbatimString = false;
+        char stringDelimiter = 0;
+        for (int i = 0; i < sourceText.length(); i += 1) {
+            final char ch = sourceText.charAt(i);
+            if (inString) {
+                if (verbatimString) {
+                    if (ch == '"' && i + 1 < sourceText.length() && sourceText.charAt(i + 1) == '"') {
+                        i += 1;
+                        continue;
+                    }
+                    if (ch == stringDelimiter) {
+                        inString = false;
+                        verbatimString = false;
+                    }
+                } else if (ch == stringDelimiter && !isEscapedByOddBackslashes(sourceText, i)) {
+                    inString = false;
+                }
+                continue;
+            }
+            if (ch == '/' && i + 1 < sourceText.length()) {
+                final char next = sourceText.charAt(i + 1);
+                if (next == '/') {
+                    i += 2;
+                    while (i < sourceText.length() && sourceText.charAt(i) != '\n') {
+                        i += 1;
+                    }
+                    continue;
+                }
+                if (next == '*') {
+                    i += 2;
+                    while (i + 1 < sourceText.length()
+                            && !(sourceText.charAt(i) == '*' && sourceText.charAt(i + 1) == '/')) {
+                        i += 1;
+                    }
+                    i += 1;
+                    continue;
+                }
+            }
+            if (isVerbatimStringStart(sourceText, i)) {
+                inString = true;
+                verbatimString = true;
+                stringDelimiter = '"';
+                if (sourceText.charAt(i) == '@' && i + 1 < sourceText.length()
+                        && sourceText.charAt(i + 1) == '"') {
+                    i += 1;
+                } else {
+                    i += 2;
+                }
+                continue;
+            }
+            if (ch == '"' || ch == '\'') {
+                inString = true;
+                verbatimString = false;
+                stringDelimiter = ch;
+                continue;
+            }
+            switch (ch) {
+                case '{':
+                    braces += 1;
+                    break;
+                case '}':
+                    braces -= 1;
+                    break;
+                case '(':
+                    parens += 1;
+                    break;
+                case ')':
+                    parens -= 1;
+                    break;
+                case '[':
+                    brackets += 1;
+                    break;
+                case ']':
+                    brackets -= 1;
+                    break;
+                default:
+                    break;
+            }
+        }
+        if (braces != 0 || parens != 0 || brackets != 0) {
+            throw new IllegalStateException("Unbalanced delimiters in C# source.");
+        }
+    }
+
+    private static boolean isEscapedByOddBackslashes(final String sourceText, final int index) {
+        int backslashCount = 0;
+        for (int i = index - 1; i >= 0 && sourceText.charAt(i) == '\\'; i -= 1) {
+            backslashCount += 1;
+        }
+        return backslashCount % 2 == 1;
+    }
+
+    private static boolean isVerbatimStringStart(final String sourceText, final int index) {
+        if (index < 0 || index >= sourceText.length()) {
+            return false;
+        }
+        if (sourceText.charAt(index) == '@') {
+            if (index + 1 < sourceText.length() && sourceText.charAt(index + 1) == '"') {
+                return true;
+            }
+            return index + 2 < sourceText.length()
+                    && sourceText.charAt(index + 1) == '$'
+                    && sourceText.charAt(index + 2) == '"';
+        }
+        return sourceText.charAt(index) == '$'
+                && index + 2 < sourceText.length()
+                && sourceText.charAt(index + 1) == '@'
+                && sourceText.charAt(index + 2) == '"';
+    }
+
+    private static CSharpModel.CSharpUsingModel parseUsing(final SyntaxNode node) {
+        final String normalized = normalizeWhitespace(node.text).toLowerCase(Locale.ROOT);
+        final boolean globalImport = normalized.startsWith("global using ");
+        final boolean staticImport = normalized.contains(" using static ")
+                || normalized.startsWith("using static ")
+                || normalized.startsWith("global using static ");
+        String raw = normalizeWhitespace(node.text);
+        if (raw.startsWith("global ")) {
+            raw = raw.substring("global ".length()).trim();
+        }
+        if (raw.startsWith("using ")) {
+            raw = raw.substring("using ".length()).trim();
+        }
+        if (raw.startsWith("static ")) {
+            raw = raw.substring("static ".length()).trim();
+        }
+        if (raw.endsWith(";")) {
+            raw = raw.substring(0, raw.length() - 1).trim();
+        }
+        if (raw.isEmpty()) {
+            return new CSharpModel.CSharpUsingModel(null, "", false, globalImport, staticImport);
+        }
+        final int equalsIndex = raw.indexOf('=');
+        if (equalsIndex >= 0) {
+            final String alias = raw.substring(0, equalsIndex).trim();
+            final String target = raw.substring(equalsIndex + 1).trim();
+            return new CSharpModel.CSharpUsingModel(alias, target, true, globalImport, staticImport);
+        }
+        return new CSharpModel.CSharpUsingModel(null, raw, false, globalImport, staticImport);
+    }
+
+    private static CSharpModel.CSharpTypeModel parseType(final SyntaxNode node,
+                                                         final CSharpModel.CSharpFileModel fileModel,
+                                                         final String namespaceName,
+                                                         final String parentTypeComponentName) {
+        final CSharpModel.CSharpTypeModel typeModel = new CSharpModel.CSharpTypeModel();
+        typeModel.kind = mapTypeKind(node.type);
+        if ("record".equals(typeModel.kind)) {
+            final String normalized = normalizeWhitespace(node.text).toLowerCase(Locale.ROOT);
+            if (normalized.startsWith("record struct ")
+                    || normalized.contains(" partial record struct ")
+                    || normalized.contains(" public record struct ")
+                    || normalized.contains(" private record struct ")
+                    || normalized.contains(" protected record struct ")
+                    || normalized.contains(" internal record struct ")) {
+                typeModel.kind = "recordStruct";
+            }
+        }
+        typeModel.name = firstIdentifier(node);
+        if (namespaceName == null) {
+            typeModel.namespaceName = "";
+        } else {
+            typeModel.namespaceName = namespaceName;
+        }
+        typeModel.moduleName = fileModel.moduleName;
+        typeModel.sourcePath = fileModel.sourceFile.path();
+        typeModel.sourceText = fileModel.sourceText;
+        typeModel.comment = extractLeadingComment(fileModel.sourceText, node.startOffset);
+        typeModel.modifiers = parseModifiers(node.text);
+        typeModel.partial = typeModel.modifiers.contains("partial");
+        typeModel.startOffset = node.startOffset;
+        typeModel.endOffset = node.endOffset;
+        typeModel.imports = importTargets(fileModel.usings);
+        typeModel.usingAliases = usingAliases(fileModel.usings);
+        if (parentTypeComponentName == null || parentTypeComponentName.isEmpty()) {
+            typeModel.componentName = typeModel.name;
+        } else {
+            typeModel.componentName = parentTypeComponentName + "." + typeModel.name;
+        }
+        typeModel.codeFragment = buildTypeCodeFragment(node.text);
+
+        for (final SyntaxNode child : node.children) {
+            if ("cs:type-usage-role".equals(child.type) && isDirectBaseType(child, node)) {
+                typeModel.baseTypes.add(trimTypeText(child.text));
+            }
+        }
+
+        final SyntaxNode blockNode = firstChild(node, "cs:block-list");
+        if (blockNode != null) {
+            for (final SyntaxNode child : blockNode.children) {
+                if (TYPE_DECLARATIONS.contains(child.type)) {
+                    typeModel.nestedTypes.add(parseType(child, fileModel, namespaceName, typeModel.componentName));
+                } else if (MEMBER_DECLARATIONS.contains(child.type)) {
+                    typeModel.members.addAll(parseMember(child, fileModel, typeModel));
+                }
+            }
+        }
+
+        if ("delegate".equals(typeModel.kind)) {
+            typeModel.members.addAll(parseParametersAsMembers(node, "parameter"));
+        }
+        if ("record".equals(typeModel.kind) || "recordStruct".equals(typeModel.kind)) {
+            final SyntaxNode parentList = firstChild(node, "cs:parent-list");
+            if (parentList != null) {
+                for (final SyntaxNode child : parentList.children) {
+                    if ("cs:inplace-record-field-declaration".equals(child.type)) {
+                        typeModel.members.addAll(parseMember(child, fileModel, typeModel));
+                    }
+                }
+            }
+        }
+        if ("enum".equals(typeModel.kind) && blockNode != null) {
+            for (final SyntaxNode child : blockNode.children) {
+                if ("cs:enum-member-declaration".equals(child.type)) {
+                    typeModel.members.addAll(parseMember(child, fileModel, typeModel));
+                }
+            }
+        }
+        return typeModel;
+    }
+
+    private static List<CSharpModel.CSharpMemberModel> parseMember(final SyntaxNode node,
+                                                                   final CSharpModel.CSharpFileModel fileModel,
+                                                                   final CSharpModel.CSharpTypeModel ownerType) {
+        final List<CSharpModel.CSharpMemberModel> members = new ArrayList<>();
+        switch (node.type) {
+            case "cs:field-declaration":
+            case "cs:multiple-fields-declaration":
+                members.addAll(parseFieldLike(node, fileModel, ownerType, "field"));
+                break;
+            case "cs:property-declaration":
+                members.add(buildSingleMember(node, fileModel, ownerType, "property",
+                        firstIdentifier(node),
+                        firstDirectChildText(node, "cs:type-usage-role"),
+                        null));
+                break;
+            case "cs:event-declaration":
+                members.add(buildSingleMember(node, fileModel, ownerType, "event",
+                        firstIdentifier(node),
+                        firstDirectChildText(node, "cs:type-usage-role"),
+                        null));
+                break;
+            case "cs:method-declaration":
+                members.add(parseCallable(node, fileModel, ownerType, "method"));
+                break;
+            case "cs:ctor-declaration":
+                members.add(parseCallable(node, fileModel, ownerType, "constructor"));
+                break;
+            case "cs:inplace-record-field-declaration":
+                members.add(buildSingleMember(node, fileModel, ownerType, "recordField",
+                        firstIdentifier(node),
+                        firstDirectChildText(node, "cs:type-usage-role"),
+                        null));
+                break;
+            case "cs:enum-member-declaration":
+                members.add(buildSingleMember(node, fileModel, ownerType, "enumMember",
+                        firstIdentifier(node), null, null));
+                break;
+            default:
+                break;
+        }
+        return members;
+    }
+
+    private static List<CSharpModel.CSharpMemberModel> parseFieldLike(final SyntaxNode node,
+                                                                      final CSharpModel.CSharpFileModel fileModel,
+                                                                      final CSharpModel.CSharpTypeModel ownerType,
+                                                                      final String kind) {
+        final List<CSharpModel.CSharpMemberModel> members = new ArrayList<>();
+        final String declaredType = firstDirectChildText(node, "cs:type-usage-role");
+        final List<String> names = directChildTexts(node, "cs:id-role");
+        if (names.isEmpty()) {
+            final Matcher matcher = Pattern.compile("([A-Za-z_][A-Za-z0-9_]*)\\s*(?:=|;|,)").matcher(node.text);
+            while (matcher.find()) {
+                names.add(matcher.group(1));
+            }
+        }
+        for (final String name : new LinkedHashSet<>(names)) {
+            members.add(buildSingleMember(node, fileModel, ownerType, kind, name, declaredType, null));
+        }
+        return members;
+    }
+
+    private static CSharpModel.CSharpMemberModel parseCallable(final SyntaxNode node,
+                                                               final CSharpModel.CSharpFileModel fileModel,
+                                                               final CSharpModel.CSharpTypeModel ownerType,
+                                                               final String kind) {
+        final CSharpModel.CSharpMemberModel member = buildSingleMember(
+                node,
+                fileModel,
+                ownerType,
+                kind,
+                firstIdentifier(node),
+                null,
+                firstDirectChildText(node, "cs:type-usage-role")
+        );
+        final SyntaxNode parentList = firstChild(node, "cs:parent-list");
+        if (parentList != null) {
+            for (final SyntaxNode child : parentList.children) {
+                if ("cs:parameter-declaration".equals(child.type)) {
+                    final CSharpModel.CSharpParameterModel parameter = new CSharpModel.CSharpParameterModel();
+                    parameter.name = firstIdentifier(child);
+                    parameter.declaredType = firstDirectChildText(child, "cs:type-usage-role");
+                    parameter.modifiers = parseModifiers(child.text);
+                    member.parameters.add(parameter);
+                }
+            }
+        }
+        final SyntaxNode block = firstChild(node, "cs:block-list");
+        if (block != null) {
+            member.cyclo = calculateCyclo(block.text);
+            member.locals.addAll(parseLocals(block, fileModel, ownerType));
+            collectBodyRefs(block, member);
+        }
+        return member;
+    }
+
+    private static List<CSharpModel.CSharpMemberModel> parseLocals(final SyntaxNode block,
+                                                                   final CSharpModel.CSharpFileModel fileModel,
+                                                                   final CSharpModel.CSharpTypeModel ownerType) {
+        final List<CSharpModel.CSharpMemberModel> locals = new ArrayList<>();
+        for (final SyntaxNode descendant : descendants(block)) {
+            if ("cs:var-def-statement".equals(descendant.type) || "cs:const-def-statement".equals(descendant.type)) {
+                final String localName = firstIdentifier(descendant);
+                if (localName == null || localName.isEmpty()) {
+                    continue;
+                }
+                String declaredType = firstDirectChildText(descendant, "cs:type-usage-role");
+                boolean inferred = false;
+                if (declaredType == null || declaredType.isEmpty() || "var".equals(trimTypeText(declaredType))) {
+                    final SyntaxNode newExpression = firstDescendant(descendant, "cs:new-expression");
+                    if (newExpression != null) {
+                        declaredType = firstDirectChildText(newExpression, "cs:type-usage-role");
+                        inferred = declaredType != null && !declaredType.isEmpty();
+                    }
+                }
+                final CSharpModel.CSharpMemberModel local = buildSingleMember(
+                        descendant,
+                        fileModel,
+                        ownerType,
+                        "local",
+                        localName,
+                        declaredType,
+                        null
+                );
+                local.inferredType = inferred;
+                locals.add(local);
+            }
+        }
+        return locals;
+    }
+
+    private static void collectBodyRefs(final SyntaxNode block, final CSharpModel.CSharpMemberModel member) {
+        for (final SyntaxNode descendant : descendants(block)) {
+            if ("cs:new-expression".equals(descendant.type)) {
+                final String typeText = firstDirectChildText(descendant, "cs:type-usage-role");
+                if (typeText != null && !typeText.isEmpty()) {
+                    member.simpleTypeUsages.add(typeText);
+                }
+            } else if ("cs:field-usage-role".equals(descendant.type)) {
+                final String fieldName = descendant.text.trim();
+                if (!fieldName.isEmpty()) {
+                    member.memberUsages.add(fieldName);
+                }
+            } else if ("cs:line-statement".equals(descendant.type)) {
+                final Matcher assignMatcher = THIS_MEMBER_ASSIGN_PATTERN.matcher(descendant.text);
+                while (assignMatcher.find()) {
+                    member.memberUsages.add(assignMatcher.group(1));
+                }
+                final Matcher staticReceiverMatcher = STATIC_RECEIVER_PATTERN.matcher(descendant.text);
+                while (staticReceiverMatcher.find()) {
+                    member.simpleTypeUsages.add(staticReceiverMatcher.group(1));
+                }
+            }
+        }
+    }
+
+    private static CSharpModel.CSharpMemberModel buildSingleMember(final SyntaxNode node,
+                                                                   final CSharpModel.CSharpFileModel fileModel,
+                                                                   final CSharpModel.CSharpTypeModel ownerType,
+                                                                   final String kind,
+                                                                   final String name,
+                                                                   final String declaredType,
+                                                                   final String returnType) {
+        final CSharpModel.CSharpMemberModel member = new CSharpModel.CSharpMemberModel();
+        member.kind = kind;
+        member.name = name;
+        member.declaredType = trimTypeText(declaredType);
+        member.returnType = trimTypeText(returnType);
+        member.sourcePath = fileModel.sourceFile.path();
+        member.sourceText = fileModel.sourceText;
+        member.moduleName = fileModel.moduleName;
+        member.ownerTypeUniqueName = ownerType.uniqueName;
+        member.modifiers = parseModifiers(node.text);
+        member.comment = extractLeadingComment(fileModel.sourceText, node.startOffset);
+        member.startOffset = node.startOffset;
+        member.endOffset = node.endOffset;
+        member.imports = new LinkedHashSet<>(ownerType.imports);
+        member.codeFragment = buildMemberCodeFragment(kind, name, member.declaredType, member.returnType, node.text);
+        if (member.declaredType != null && !member.declaredType.isEmpty()) {
+            member.simpleTypeUsages.add(member.declaredType);
+        }
+        if (member.returnType != null && !member.returnType.isEmpty()) {
+            member.simpleTypeUsages.add(member.returnType);
+        }
+        return member;
+    }
+
+    private static List<CSharpModel.CSharpMemberModel> parseParametersAsMembers(final SyntaxNode node,
+                                                                                 final String kind) {
+        final List<CSharpModel.CSharpMemberModel> members = new ArrayList<>();
+        final SyntaxNode parentList = firstChild(node, "cs:parent-list");
+        if (parentList == null) {
+            return members;
+        }
+        for (final SyntaxNode child : parentList.children) {
+            if ("cs:parameter-declaration".equals(child.type)) {
+                final CSharpModel.CSharpMemberModel member = new CSharpModel.CSharpMemberModel();
+                member.kind = kind;
+                member.name = firstIdentifier(child);
+                member.declaredType = firstDirectChildText(child, "cs:type-usage-role");
+                member.modifiers = parseModifiers(child.text);
+                member.codeFragment = trimTypeText(member.declaredType);
+                if (member.declaredType != null && !member.declaredType.isEmpty()) {
+                    member.simpleTypeUsages.add(member.declaredType);
+                }
+                members.add(member);
+            }
+        }
+        return members;
+    }
+
+    private static Set<String> importTargets(final List<CSharpModel.CSharpUsingModel> usings) {
+        final Set<String> imports = new LinkedHashSet<>();
+        for (final CSharpModel.CSharpUsingModel usingModel : usings) {
+            if (usingModel.target != null && !usingModel.target.isEmpty()) {
+                imports.add(usingModel.target);
+            }
+        }
+        return imports;
+    }
+
+    private static java.util.Map<String, String> usingAliases(final List<CSharpModel.CSharpUsingModel> usings) {
+        final java.util.Map<String, String> aliases = new java.util.LinkedHashMap<>();
+        for (final CSharpModel.CSharpUsingModel usingModel : usings) {
+            if (usingModel.aliasImport && usingModel.alias != null
+                    && !usingModel.alias.isEmpty() && usingModel.target != null) {
+                aliases.put(usingModel.alias, usingModel.target);
+            }
+        }
+        return aliases;
+    }
+
+    private static boolean isDirectBaseType(final SyntaxNode child, final SyntaxNode parent) {
+        if (child.parent != parent) {
+            return false;
+        }
+        final SyntaxNode block = firstChild(parent, "cs:block-list");
+        return block == null || child.endOffset <= block.startOffset;
+    }
+
+    private static String buildTypeCodeFragment(final String text) {
+        return normalizeWhitespace(cutAtAny(text, "{", ";"));
+    }
+
+    private static String buildMemberCodeFragment(final String kind,
+                                                  final String name,
+                                                  final String declaredType,
+                                                  final String returnType,
+                                                  final String text) {
+        if ("field".equals(kind) || "property".equals(kind) || "event".equals(kind)
+                || "recordField".equals(kind) || "local".equals(kind)) {
+            if (declaredType == null || declaredType.isEmpty()) {
+                return name;
+            }
+            return name + " : " + trimTypeText(declaredType);
+        }
+        if ("enumMember".equals(kind)) {
+            return name;
+        }
+        String fragment = normalizeWhitespace(cutAtAny(text, "{", ";"));
+        if ("method".equals(kind) && returnType != null && !returnType.isEmpty()
+                && !fragment.contains(" : ")) {
+            return fragment;
+        }
+        return fragment;
+    }
+
+    private static String cutAtAny(final String text, final String... markers) {
+        if (text == null) {
+            return null;
+        }
+        int end = text.length();
+        for (final String marker : markers) {
+            final int idx = text.indexOf(marker);
+            if (idx >= 0) {
+                end = Math.min(end, idx);
+            }
+        }
+        return text.substring(0, end).trim();
+    }
+
+    private static String normalizeWhitespace(final String text) {
+        if (text == null) {
+            return null;
+        }
+        return text.replace('\r', ' ').replace('\n', ' ').replaceAll("\\s+", " ").trim();
+    }
+
+    private static String trimTypeText(final String text) {
+        if (text == null) {
+            return null;
+        }
+        return normalizeWhitespace(text).replaceAll("\\s+([>\\],)])", "$1");
+    }
+
+    private static int calculateCyclo(final String text) {
+        if (text == null || text.isBlank()) {
+            return 0;
+        }
+        int cyclo = 1;
+        cyclo += countWord(text, "if");
+        cyclo += countWord(text, "for");
+        cyclo += countWord(text, "foreach");
+        cyclo += countWord(text, "while");
+        cyclo += countWord(text, "case");
+        cyclo += countWord(text, "catch");
+        cyclo += countLiteral(text, "&&");
+        cyclo += countLiteral(text, "||");
+        return cyclo;
+    }
+
+    private static int countWord(final String text, final String word) {
+        final Matcher matcher = Pattern.compile("\\b" + Pattern.quote(word) + "\\b").matcher(text);
+        int count = 0;
+        while (matcher.find()) {
+            count += 1;
+        }
+        return count;
+    }
+
+    private static int countLiteral(final String text, final String literal) {
+        int count = 0;
+        int index = text.indexOf(literal);
+        while (index >= 0) {
+            count += 1;
+            index = text.indexOf(literal, index + literal.length());
+        }
+        return count;
+    }
+
+    private static String extractLeadingComment(final String sourceText, final int startOffset) {
+        if (sourceText == null || sourceText.isEmpty() || startOffset <= 0) {
+            return "";
+        }
+        final String prefix = sourceText.substring(0, Math.min(startOffset, sourceText.length()));
+        final String[] lines = prefix.split("\\R", -1);
+        final List<String> commentLines = new ArrayList<>();
+        boolean inBlock = false;
+        for (int i = lines.length - 1; i >= 0; i -= 1) {
+            String line = lines[i].stripTrailing();
+            if (line.trim().isEmpty()) {
+                if (!commentLines.isEmpty() || inBlock) {
+                    break;
+                }
+                continue;
+            }
+            final String trimmed = line.trim();
+            if (trimmed.startsWith("///") || trimmed.startsWith("//")) {
+                commentLines.add(0, trimmed);
+                continue;
+            }
+            if (trimmed.endsWith("*/")) {
+                commentLines.add(0, trimmed);
+                inBlock = true;
+                continue;
+            }
+            if (inBlock) {
+                commentLines.add(0, trimmed);
+                if (trimmed.startsWith("/*")) {
+                    break;
+                }
+                continue;
+            }
+            break;
+        }
+        if (commentLines.isEmpty()) {
+            return "";
+        }
+        return String.join("\n", commentLines) + "\n";
+    }
+
+    private static List<String> parseModifiers(final String text) {
+        final List<String> modifiers = new ArrayList<>();
+        if (text == null || text.isBlank()) {
+            return modifiers;
+        }
+        final String header = normalizeWhitespace(cutAtAny(text, "{", "(", ";"));
+        final String[] parts = header.split(" ");
+        final Set<String> supported = Set.of(
+                "public", "private", "protected", "internal", "static", "abstract", "sealed",
+                "readonly", "partial", "virtual", "override", "async", "const", "unsafe"
+        );
+        for (final String part : parts) {
+            final String lower = part.toLowerCase(Locale.ROOT);
+            if (supported.contains(lower)) {
+                modifiers.add(lower);
+            }
+        }
+        return modifiers;
+    }
+
+    private static String mapTypeKind(final String type) {
+        switch (type) {
+            case "cs:class-declaration":
+                return "class";
+            case "cs:interface-declaration":
+                return "interface";
+            case "cs:struct-declaration":
+                return "struct";
+            case "cs:record-declaration":
+                return "record";
+            case "cs:struct-record-declaration":
+                return "recordStruct";
+            case "cs:enum-declaration":
+                return "enum";
+            case "cs:delegate-declaration":
+                return "delegate";
+            default:
+                throw new IllegalArgumentException("Unsupported type declaration: " + type);
+        }
+    }
+
+    static List<String> extractTypeTokens(final String rawType) {
+        final List<String> results = new ArrayList<>();
+        if (rawType == null || rawType.isBlank()) {
+            return results;
+        }
+        final Matcher matcher = TYPE_TOKEN_PATTERN.matcher(rawType);
+        while (matcher.find()) {
+            final String token = matcher.group();
+            if ("new".equals(token) || "var".equals(token) || "global".equals(token)) {
+                continue;
+            }
+            if (Character.isLowerCase(token.charAt(0)) && !token.contains(".")) {
+                if (!isBuiltinType(token)) {
+                    continue;
+                }
+            }
+            results.add(token);
+        }
+        return results;
+    }
+
+    static boolean isBuiltinType(final String token) {
+        return Set.of(
+                "string", "int", "long", "short", "byte", "bool", "double", "float",
+                "decimal", "char", "object", "void"
+        ).contains(token);
+    }
+
+    private static String firstIdentifier(final SyntaxNode node) {
+        return firstDirectChildText(node, "cs:id-role");
+    }
+
+    private static String namespaceName(final SyntaxNode node) {
+        final SyntaxNode header = firstChild(node, "cs:namespace-header-node-statement");
+        final List<String> ids;
+        if (header == null) {
+            ids = directChildTexts(node, "cs:id-role");
+        } else {
+            ids = directChildTexts(header, "cs:id-role");
+        }
+        if (ids.isEmpty()) {
+            return "";
+        }
+        return String.join(".", ids);
+    }
+
+    private static String firstDirectChildText(final SyntaxNode node, final String type) {
+        final SyntaxNode child = firstChild(node, type);
+        if (child == null) {
+            return null;
+        }
+        return normalizeWhitespace(child.text);
+    }
+
+    private static SyntaxNode firstChild(final SyntaxNode node, final String type) {
+        for (final SyntaxNode child : node.children) {
+            if (type.equals(child.type)) {
+                return child;
+            }
+        }
+        return null;
+    }
+
+    private static SyntaxNode firstDescendant(final SyntaxNode node, final String type) {
+        for (final SyntaxNode descendant : descendants(node)) {
+            if (type.equals(descendant.type)) {
+                return descendant;
+            }
+        }
+        return null;
+    }
+
+    private static List<String> directChildTexts(final SyntaxNode node, final String type) {
+        final List<String> texts = new ArrayList<>();
+        for (final SyntaxNode child : node.children) {
+            if (type.equals(child.type)) {
+                texts.add(normalizeWhitespace(child.text));
+            }
+        }
+        return texts;
+    }
+
+    private static List<SyntaxNode> descendants(final SyntaxNode node) {
+        final List<SyntaxNode> descendants = new ArrayList<>();
+        final Deque<SyntaxNode> stack = new ArrayDeque<>(node.children);
+        while (!stack.isEmpty()) {
+            final SyntaxNode child = stack.pop();
+            descendants.add(child);
+            for (int i = child.children.size() - 1; i >= 0; i -= 1) {
+                stack.push(child.children.get(i));
+            }
+        }
+        return descendants;
+    }
+
+    private static String safeSubstring(final String text, final int start, final int end) {
+        int safeStart = Math.max(0, Math.min(start, text.length()));
+        int safeEnd = Math.max(safeStart, Math.min(end, text.length()));
+        return text.substring(safeStart, safeEnd);
+    }
+
+    private static final class SyntaxNode {
+        private final String type;
+        private final int startOffset;
+        private final int endOffset;
+        private final List<SyntaxNode> children = new ArrayList<>();
+        private SyntaxNode parent;
+        private String text = "";
+
+        private SyntaxNode(final String type, final int startOffset, final int endOffset) {
+            this.type = type;
+            this.startOffset = startOffset;
+            this.endOffset = endOffset;
+        }
+
+        private boolean sameRange(final SyntaxNode other) {
+            return other != null
+                    && this.startOffset == other.startOffset
+                    && this.endOffset == other.endOffset
+                    && this.type.equals(other.type);
+        }
+    }
+}

--- a/src/main/java/com/hadi/clarpse/compiler/csharp/CSharpFileParser.java
+++ b/src/main/java/com/hadi/clarpse/compiler/csharp/CSharpFileParser.java
@@ -866,7 +866,10 @@ final class CSharpFileParser {
 
     private static String combineNamespace(final String currentNamespace, final String declaredNamespace) {
         if (currentNamespace == null || currentNamespace.isEmpty()) {
-            return declaredNamespace == null ? "" : declaredNamespace;
+            if (declaredNamespace == null) {
+                return "";
+            }
+            return declaredNamespace;
         }
         if (declaredNamespace == null || declaredNamespace.isEmpty()) {
             return currentNamespace;

--- a/src/main/java/com/hadi/clarpse/compiler/csharp/CSharpModel.java
+++ b/src/main/java/com/hadi/clarpse/compiler/csharp/CSharpModel.java
@@ -1,0 +1,130 @@
+package com.hadi.clarpse.compiler.csharp;
+
+import com.hadi.clarpse.compiler.ProjectFile;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+final class CSharpModel {
+
+    private CSharpModel() {
+    }
+
+    static final class ParseOutcome {
+        private final int index;
+        private final CSharpFileModel fileModel;
+        private final com.hadi.clarpse.compiler.CompileFailure failure;
+
+        ParseOutcome(final int index,
+                     final CSharpFileModel fileModel,
+                     final com.hadi.clarpse.compiler.CompileFailure failure) {
+            this.index = index;
+            this.fileModel = fileModel;
+            this.failure = failure;
+        }
+
+        int index() {
+            return index;
+        }
+
+        CSharpFileModel fileModel() {
+            return fileModel;
+        }
+
+        com.hadi.clarpse.compiler.CompileFailure failure() {
+            return failure;
+        }
+    }
+
+    static final class CSharpFileModel {
+        final ProjectFile sourceFile;
+        final String sourceText;
+        final String moduleName;
+        final List<CSharpUsingModel> usings = new ArrayList<>();
+        final List<CSharpTypeModel> types = new ArrayList<>();
+
+        CSharpFileModel(final ProjectFile sourceFile,
+                        final String sourceText,
+                        final String moduleName) {
+            this.sourceFile = sourceFile;
+            this.sourceText = sourceText;
+            this.moduleName = moduleName;
+        }
+    }
+
+    static final class CSharpUsingModel {
+        final String alias;
+        final String target;
+        final boolean aliasImport;
+        final boolean globalImport;
+        final boolean staticImport;
+
+        CSharpUsingModel(final String alias,
+                         final String target,
+                         final boolean aliasImport,
+                         final boolean globalImport,
+                         final boolean staticImport) {
+            this.alias = alias;
+            this.target = target;
+            this.aliasImport = aliasImport;
+            this.globalImport = globalImport;
+            this.staticImport = staticImport;
+        }
+    }
+
+    static final class CSharpTypeModel {
+        String kind;
+        String name;
+        String namespaceName;
+        String moduleName;
+        String sourcePath;
+        String sourceText;
+        String componentName;
+        String uniqueName;
+        String comment = "";
+        String codeFragment;
+        boolean partial;
+        int startOffset;
+        int endOffset;
+        List<String> modifiers = new ArrayList<>();
+        List<String> baseTypes = new ArrayList<>();
+        List<CSharpMemberModel> members = new ArrayList<>();
+        List<CSharpTypeModel> nestedTypes = new ArrayList<>();
+        Set<String> imports = new LinkedHashSet<>();
+        Map<String, String> usingAliases = new LinkedHashMap<>();
+    }
+
+    static final class CSharpMemberModel {
+        String kind;
+        String name;
+        String declaredType;
+        String returnType;
+        String codeFragment;
+        String comment = "";
+        String sourcePath;
+        String sourceText;
+        String moduleName;
+        String ownerTypeUniqueName;
+        int startOffset;
+        int endOffset;
+        int cyclo;
+        List<String> modifiers = new ArrayList<>();
+        List<CSharpParameterModel> parameters = new ArrayList<>();
+        List<CSharpMemberModel> locals = new ArrayList<>();
+        List<String> simpleTypeUsages = new ArrayList<>();
+        List<String> memberUsages = new ArrayList<>();
+        Set<String> imports = new LinkedHashSet<>();
+        boolean inferredType;
+    }
+
+    static final class CSharpParameterModel {
+        String name;
+        String declaredType;
+        String comment = "";
+        List<String> modifiers = new ArrayList<>();
+    }
+}

--- a/src/main/java/com/hadi/clarpse/compiler/csharp/CSharpModel.java
+++ b/src/main/java/com/hadi/clarpse/compiler/csharp/CSharpModel.java
@@ -9,6 +9,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+/**
+ * Internal data-transfer models shared between the C# parse phase and the
+ * assembler phase. These types intentionally keep syntax extraction separate
+ * from final component creation so parsing can remain lightweight and parallel.
+ */
 final class CSharpModel {
 
     private CSharpModel() {

--- a/src/main/java/com/hadi/clarpse/compiler/csharp/CSharpModelAssembler.java
+++ b/src/main/java/com/hadi/clarpse/compiler/csharp/CSharpModelAssembler.java
@@ -1,0 +1,658 @@
+package com.hadi.clarpse.compiler.csharp;
+
+import com.hadi.clarpse.listener.ParseUtil;
+import com.hadi.clarpse.reference.ComponentReference;
+import com.hadi.clarpse.reference.SimpleTypeReference;
+import com.hadi.clarpse.reference.TypeExtensionReference;
+import com.hadi.clarpse.reference.TypeImplementationReference;
+import com.hadi.clarpse.sourcemodel.Component;
+import com.hadi.clarpse.sourcemodel.OOPSourceCodeModel;
+import com.hadi.clarpse.sourcemodel.OOPSourceModelConstants;
+import com.hadi.clarpse.sourcemodel.Package;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.Stack;
+
+final class CSharpModelAssembler {
+
+    private static final Map<String, String> BUILTIN_TYPES = Map.ofEntries(
+            Map.entry("string", "System.String"),
+            Map.entry("int", "System.Int32"),
+            Map.entry("long", "System.Int64"),
+            Map.entry("short", "System.Int16"),
+            Map.entry("byte", "System.Byte"),
+            Map.entry("bool", "System.Boolean"),
+            Map.entry("double", "System.Double"),
+            Map.entry("float", "System.Single"),
+            Map.entry("decimal", "System.Decimal"),
+            Map.entry("char", "System.Char"),
+            Map.entry("object", "System.Object"),
+            Map.entry("void", "System.Void")
+    );
+
+    private CSharpModelAssembler() {
+    }
+
+    static OOPSourceCodeModel buildModel(final Collection<CSharpModel.CSharpFileModel> fileModels) {
+        applyGlobalUsings(fileModels);
+        final List<CSharpModel.CSharpTypeModel> mergedTypes = mergePartials(fileModels);
+        final TypeIndex typeIndex = new TypeIndex(mergedTypes);
+        final OOPSourceCodeModel model = new OOPSourceCodeModel();
+        final Stack<Component> stack = new Stack<>();
+        mergedTypes.sort(Comparator.comparing(type -> type.uniqueName));
+        for (final CSharpModel.CSharpTypeModel typeModel : mergedTypes) {
+            if (!typeModel.componentName.contains(".")) {
+                insertType(typeModel, typeIndex, model, stack);
+            }
+        }
+        return model;
+    }
+
+    private static List<CSharpModel.CSharpTypeModel> mergePartials(final Collection<CSharpModel.CSharpFileModel> fileModels) {
+        final List<CSharpModel.CSharpTypeModel> flattened = new ArrayList<>();
+        for (final CSharpModel.CSharpFileModel fileModel : fileModels) {
+            for (final CSharpModel.CSharpTypeModel typeModel : fileModel.types) {
+                assignIdentity(typeModel, "");
+                flattened.add(typeModel);
+                flattened.addAll(flattenNested(typeModel));
+            }
+        }
+        final Map<String, CSharpModel.CSharpTypeModel> merged = new LinkedHashMap<>();
+        for (final CSharpModel.CSharpTypeModel typeModel : flattened) {
+            final String key = typeKey(typeModel);
+            final CSharpModel.CSharpTypeModel existing = merged.get(key);
+            if (existing == null) {
+                merged.put(key, typeModel);
+                continue;
+            }
+            existing.partial = existing.partial || typeModel.partial;
+            existing.baseTypes.addAll(typeModel.baseTypes);
+            existing.members.addAll(typeModel.members);
+            existing.nestedTypes.addAll(typeModel.nestedTypes);
+            existing.modifiers = mergeStrings(existing.modifiers, typeModel.modifiers);
+            existing.imports.addAll(typeModel.imports);
+            if ((existing.comment == null || existing.comment.isEmpty()) && typeModel.comment != null) {
+                existing.comment = typeModel.comment;
+            }
+        }
+        return new ArrayList<>(merged.values());
+    }
+
+    private static void applyGlobalUsings(final Collection<CSharpModel.CSharpFileModel> fileModels) {
+        final Set<String> globalImports = new LinkedHashSet<>();
+        final Map<String, String> globalAliases = new LinkedHashMap<>();
+        for (final CSharpModel.CSharpFileModel fileModel : fileModels) {
+            for (final CSharpModel.CSharpUsingModel usingModel : fileModel.usings) {
+                if (!usingModel.globalImport || usingModel.target == null || usingModel.target.isEmpty()) {
+                    continue;
+                }
+                globalImports.add(usingModel.target);
+                if (usingModel.aliasImport && usingModel.alias != null && !usingModel.alias.isEmpty()) {
+                    globalAliases.put(usingModel.alias, usingModel.target);
+                }
+            }
+        }
+        if (globalImports.isEmpty() && globalAliases.isEmpty()) {
+            return;
+        }
+        for (final CSharpModel.CSharpFileModel fileModel : fileModels) {
+            for (final CSharpModel.CSharpTypeModel typeModel : fileModel.types) {
+                applyGlobalUsings(typeModel, globalImports, globalAliases);
+            }
+        }
+    }
+
+    private static void applyGlobalUsings(final CSharpModel.CSharpTypeModel typeModel,
+                                          final Set<String> globalImports,
+                                          final Map<String, String> globalAliases) {
+        typeModel.imports.addAll(globalImports);
+        globalAliases.forEach(typeModel.usingAliases::putIfAbsent);
+        for (final CSharpModel.CSharpMemberModel member : typeModel.members) {
+            member.imports.addAll(globalImports);
+        }
+        for (final CSharpModel.CSharpTypeModel nested : typeModel.nestedTypes) {
+            applyGlobalUsings(nested, globalImports, globalAliases);
+        }
+    }
+
+    private static List<CSharpModel.CSharpTypeModel> flattenNested(final CSharpModel.CSharpTypeModel typeModel) {
+        final List<CSharpModel.CSharpTypeModel> result = new ArrayList<>();
+        for (final CSharpModel.CSharpTypeModel nested : typeModel.nestedTypes) {
+            assignIdentity(nested, typeModel.componentName);
+            result.add(nested);
+            result.addAll(flattenNested(nested));
+        }
+        return result;
+    }
+
+    private static void assignIdentity(final CSharpModel.CSharpTypeModel typeModel, final String parentComponentName) {
+        if (parentComponentName == null || parentComponentName.isEmpty()) {
+            typeModel.componentName = typeModel.name;
+        } else {
+            typeModel.componentName = parentComponentName + "." + typeModel.name;
+        }
+        if (typeModel.namespaceName == null || typeModel.namespaceName.isEmpty()) {
+            typeModel.uniqueName = typeModel.componentName;
+        } else {
+            typeModel.uniqueName = typeModel.namespaceName + "." + typeModel.componentName;
+        }
+        for (final CSharpModel.CSharpTypeModel nested : typeModel.nestedTypes) {
+            assignIdentity(nested, typeModel.componentName);
+        }
+    }
+
+    private static String typeKey(final CSharpModel.CSharpTypeModel typeModel) {
+        return typeModel.kind + "|" + typeModel.uniqueName;
+    }
+
+    private static void insertType(final CSharpModel.CSharpTypeModel typeModel,
+                                   final TypeIndex typeIndex,
+                                   final OOPSourceCodeModel model,
+                                   final Stack<Component> stack) {
+        final Component typeComponent = buildTypeComponent(typeModel);
+        ParseUtil.pointParentsToGivenChild(typeComponent, stack);
+        stack.push(typeComponent);
+        for (final String baseType : typeModel.baseTypes) {
+            for (final String rawToken : CSharpFileParser.extractTypeTokens(baseType)) {
+                final String resolved = typeIndex.resolveType(rawToken, typeModel, null);
+                if (resolved == null || resolved.equals(typeComponent.uniqueName())) {
+                    continue;
+                }
+                if ("interface".equals(typeModel.kind) || "class".equals(typeModel.kind)
+                        || "record".equals(typeModel.kind) || "recordStruct".equals(typeModel.kind)
+                        || "struct".equals(typeModel.kind)) {
+                    final ComponentReference ref;
+                    if (isInterfaceTarget(rawToken, resolved, typeIndex)) {
+                        ref = new TypeImplementationReference(resolved);
+                    } else {
+                        ref = new TypeExtensionReference(resolved);
+                    }
+                    typeComponent.insertCmpRef(ref);
+                }
+            }
+        }
+        final List<CSharpModel.CSharpTypeModel> nestedTypes = new ArrayList<>(typeModel.nestedTypes);
+        nestedTypes.sort(Comparator.comparing(type -> type.uniqueName));
+        for (final CSharpModel.CSharpTypeModel nested : nestedTypes) {
+            insertType(nested, typeIndex, model, stack);
+        }
+        final List<CSharpModel.CSharpMemberModel> members = new ArrayList<>(typeModel.members);
+        members.sort(Comparator.comparingInt(member -> member.startOffset));
+        for (final CSharpModel.CSharpMemberModel member : members) {
+            insertMember(member, typeModel, typeIndex, model, stack);
+        }
+        if (typeComponent.componentType().isMethodComponent() && typeModel.codeFragment != null) {
+            typeComponent.setCodeHash(typeModel.codeFragment.hashCode());
+        }
+        model.insertComponent(typeComponent);
+        stack.pop();
+        ParseUtil.copyRefsToParents(typeComponent, stack);
+    }
+
+    private static Component buildTypeComponent(final CSharpModel.CSharpTypeModel typeModel) {
+        final Component component = new Component();
+        component.setPkg(resolvePackage(typeModel.namespaceName));
+        component.setComponentName(typeModel.componentName);
+        component.setComponentType(mapTypeComponent(typeModel.kind));
+        component.setModule(typeModel.moduleName);
+        component.setName(typeModel.name);
+        component.setSourceFilePath(typeModel.sourcePath);
+        if (typeModel.comment == null) {
+            component.setComment("");
+        } else {
+            component.setComment(typeModel.comment);
+        }
+        component.setImports(typeModel.imports);
+        component.setAccessModifiers(typeModel.modifiers);
+        if (typeModel.codeFragment != null && !typeModel.codeFragment.isEmpty()) {
+            component.setCodeFragment(typeModel.codeFragment);
+            component.setCodeHash(typeModel.codeFragment.hashCode());
+        }
+        return component;
+    }
+
+    private static void insertMember(final CSharpModel.CSharpMemberModel memberModel,
+                                     final CSharpModel.CSharpTypeModel ownerType,
+                                     final TypeIndex typeIndex,
+                                     final OOPSourceCodeModel model,
+                                     final Stack<Component> stack) {
+        final Component component = buildMemberComponent(memberModel, ownerType);
+        if (component == null) {
+            return;
+        }
+        ParseUtil.pointParentsToGivenChild(component, stack);
+        stack.push(component);
+        if (component.componentType().isMethodComponent()) {
+            for (final CSharpModel.CSharpParameterModel parameter : memberModel.parameters) {
+                final Component paramComponent = buildParameterComponent(parameter, memberModel, ownerType, component);
+                ParseUtil.pointParentsToGivenChild(paramComponent, stack);
+                attachTypeReferences(paramComponent, singletonType(parameter.declaredType),
+                        typeIndex, ownerType, memberModel, false);
+                model.insertComponent(paramComponent);
+                ParseUtil.copyRefsToParents(paramComponent, stack);
+            }
+            for (final CSharpModel.CSharpMemberModel localModel : memberModel.locals) {
+                final Component localComponent = buildLocalComponent(localModel, ownerType, component);
+                ParseUtil.pointParentsToGivenChild(localComponent, stack);
+                attachTypeReferences(localComponent, singletonType(localModel.declaredType),
+                        typeIndex, ownerType, memberModel, false);
+                model.insertComponent(localComponent);
+                ParseUtil.copyRefsToParents(localComponent, stack);
+            }
+        }
+        attachTypeReferences(component, memberModel.simpleTypeUsages, typeIndex, ownerType, memberModel,
+                "method".equals(memberModel.kind) || "constructor".equals(memberModel.kind));
+        attachMemberReferences(component, memberModel.memberUsages, typeIndex, ownerType);
+        if (component.componentType().isMethodComponent()) {
+            component.setCyclo(memberModel.cyclo);
+        }
+        model.insertComponent(component);
+        stack.pop();
+        ParseUtil.copyRefsToParents(component, stack);
+    }
+
+    private static Component buildMemberComponent(final CSharpModel.CSharpMemberModel memberModel,
+                                                  final CSharpModel.CSharpTypeModel ownerType) {
+        final OOPSourceModelConstants.ComponentType componentType = mapMemberComponent(memberModel.kind);
+        if (componentType == null || memberModel.name == null || memberModel.name.isEmpty()) {
+            return null;
+        }
+        final Component component = new Component();
+        component.setPkg(resolvePackage(ownerType.namespaceName));
+        component.setModule(memberModel.moduleName);
+        component.setComponentType(componentType);
+        component.setName(memberModel.name);
+        component.setSourceFilePath(memberModel.sourcePath);
+        if (memberModel.comment == null) {
+            component.setComment("");
+        } else {
+            component.setComment(memberModel.comment);
+        }
+        component.setImports(memberModel.imports);
+        component.setAccessModifiers(memberModel.modifiers);
+        component.setComponentName(ownerType.componentName + "." + memberComponentIdentifier(memberModel, ownerType));
+        if (memberModel.codeFragment != null && !memberModel.codeFragment.isEmpty()) {
+            component.setCodeFragment(memberModel.codeFragment);
+            component.setCodeHash(memberModel.codeFragment.hashCode());
+        }
+        return component;
+    }
+
+    private static Component buildParameterComponent(final CSharpModel.CSharpParameterModel parameter,
+                                                     final CSharpModel.CSharpMemberModel memberModel,
+                                                     final CSharpModel.CSharpTypeModel ownerType,
+                                                     final Component ownerComponent) {
+        final Component component = new Component();
+        component.setPkg(resolvePackage(ownerType.namespaceName));
+        component.setModule(memberModel.moduleName);
+        if ("constructor".equals(memberModel.kind)) {
+            component.setComponentType(OOPSourceModelConstants.ComponentType.CONSTRUCTOR_PARAMETER_COMPONENT);
+        } else {
+            component.setComponentType(OOPSourceModelConstants.ComponentType.METHOD_PARAMETER_COMPONENT);
+        }
+        component.setName(parameter.name);
+        component.setSourceFilePath(memberModel.sourcePath);
+        component.setImports(memberModel.imports);
+        component.setAccessModifiers(parameter.modifiers);
+        component.setComponentName(ownerComponent.componentName() + "." + parameter.name);
+        if (parameter.declaredType != null && !parameter.declaredType.isEmpty()) {
+            component.setCodeFragment(parameter.declaredType);
+        }
+        return component;
+    }
+
+    private static Component buildLocalComponent(final CSharpModel.CSharpMemberModel localModel,
+                                                 final CSharpModel.CSharpTypeModel ownerType,
+                                                 final Component ownerComponent) {
+        final Component component = new Component();
+        component.setPkg(resolvePackage(ownerType.namespaceName));
+        component.setModule(localModel.moduleName);
+        component.setComponentType(OOPSourceModelConstants.ComponentType.LOCAL);
+        component.setName(localModel.name);
+        component.setSourceFilePath(localModel.sourcePath);
+        component.setImports(localModel.imports);
+        component.setAccessModifiers(localModel.modifiers);
+        component.setComponentName(ownerComponent.componentName() + "." + localModel.name);
+        if (localModel.codeFragment != null && !localModel.codeFragment.isEmpty()) {
+            component.setCodeFragment(localModel.codeFragment);
+        }
+        return component;
+    }
+
+    private static void attachTypeReferences(final Component component,
+                                             final Collection<String> rawTypes,
+                                             final TypeIndex typeIndex,
+                                             final CSharpModel.CSharpTypeModel ownerType,
+                                             final CSharpModel.CSharpMemberModel memberModel,
+                                             final boolean applyMemberAccessFilter) {
+        if (rawTypes == null) {
+            return;
+        }
+        final Set<String> seen = new LinkedHashSet<>();
+        for (final String rawType : rawTypes) {
+            if (applyMemberAccessFilter && isLikelyMemberAccess(rawType, ownerType, memberModel)) {
+                continue;
+            }
+            for (final String token : CSharpFileParser.extractTypeTokens(rawType)) {
+                final String resolved = typeIndex.resolveType(token, ownerType, memberModel);
+                if (resolved == null || resolved.equals(component.uniqueName()) || !seen.add(resolved)) {
+                    continue;
+                }
+                component.insertCmpRef(new SimpleTypeReference(resolved));
+            }
+        }
+    }
+
+    private static void attachMemberReferences(final Component component,
+                                               final Collection<String> memberUsages,
+                                               final TypeIndex typeIndex,
+                                               final CSharpModel.CSharpTypeModel ownerType) {
+        if (memberUsages == null) {
+            return;
+        }
+        final Set<String> seen = new LinkedHashSet<>();
+        for (final String usage : memberUsages) {
+            final String resolved = typeIndex.resolveMember(ownerType.uniqueName, usage);
+            if (resolved == null || resolved.equals(component.uniqueName()) || !seen.add(resolved)) {
+                continue;
+            }
+            component.insertCmpRef(new SimpleTypeReference(resolved));
+        }
+    }
+
+    private static boolean isLikelyMemberAccess(final String rawType,
+                                                final CSharpModel.CSharpTypeModel ownerType,
+                                                final CSharpModel.CSharpMemberModel memberModel) {
+        if (rawType == null || rawType.isBlank()) {
+            return false;
+        }
+        if (memberModel == null || (!"method".equals(memberModel.kind) && !"constructor".equals(memberModel.kind))) {
+            return false;
+        }
+        final String trimmed = rawType.trim();
+        final String root;
+        if (trimmed.contains(".")) {
+            root = trimmed.substring(0, trimmed.indexOf('.'));
+        } else {
+            root = trimmed;
+        }
+        if (memberModel != null) {
+            for (final CSharpModel.CSharpParameterModel parameter : memberModel.parameters) {
+                if (root.equals(parameter.name)) {
+                    return true;
+                }
+            }
+            for (final CSharpModel.CSharpMemberModel local : memberModel.locals) {
+                if (root.equals(local.name)) {
+                    return true;
+                }
+            }
+        }
+        if (ownerType != null) {
+            for (final CSharpModel.CSharpMemberModel ownerMember : ownerType.members) {
+                if (root.equals(ownerMember.name)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static List<String> singletonType(final String declaredType) {
+        if (declaredType == null || declaredType.isBlank()) {
+            return List.of();
+        }
+        return List.of(declaredType);
+    }
+
+    private static boolean isInterfaceTarget(final String rawToken,
+                                             final String resolved,
+                                             final TypeIndex typeIndex) {
+        final String simpleName;
+        if (rawToken == null) {
+            simpleName = "";
+        } else {
+            simpleName = rawToken.substring(rawToken.lastIndexOf('.') + 1);
+        }
+        if (simpleName.startsWith("I") && simpleName.length() > 1
+                && Character.isUpperCase(simpleName.charAt(1))) {
+            return true;
+        }
+        return typeIndex.interfaceTypes.contains(resolved);
+    }
+
+    private static Package resolvePackage(final String namespaceName) {
+        if (namespaceName == null || namespaceName.isEmpty()) {
+            return new Package("", "");
+        }
+        return new Package(namespaceName, namespaceName);
+    }
+
+    private static OOPSourceModelConstants.ComponentType mapTypeComponent(final String kind) {
+        switch (kind) {
+            case "class":
+            case "record":
+                return OOPSourceModelConstants.ComponentType.CLASS;
+            case "interface":
+                return OOPSourceModelConstants.ComponentType.INTERFACE;
+            case "recordStruct":
+            case "struct":
+                return OOPSourceModelConstants.ComponentType.STRUCT;
+            case "enum":
+                return OOPSourceModelConstants.ComponentType.ENUM;
+            case "delegate":
+                return OOPSourceModelConstants.ComponentType.FUNCTION;
+            default:
+                return OOPSourceModelConstants.ComponentType.CLASS;
+        }
+    }
+
+    private static OOPSourceModelConstants.ComponentType mapMemberComponent(final String kind) {
+        switch (kind) {
+            case "field":
+            case "property":
+            case "event":
+            case "recordField":
+                return OOPSourceModelConstants.ComponentType.FIELD;
+            case "method":
+                return OOPSourceModelConstants.ComponentType.METHOD;
+            case "constructor":
+                return OOPSourceModelConstants.ComponentType.CONSTRUCTOR;
+            case "enumMember":
+                return OOPSourceModelConstants.ComponentType.ENUM_CONSTANT;
+            case "local":
+                return OOPSourceModelConstants.ComponentType.LOCAL;
+            case "parameter":
+                return OOPSourceModelConstants.ComponentType.METHOD_PARAMETER_COMPONENT;
+            default:
+                return null;
+        }
+    }
+
+    private static String memberComponentIdentifier(final CSharpModel.CSharpMemberModel memberModel,
+                                                    final CSharpModel.CSharpTypeModel ownerType) {
+        switch (memberModel.kind) {
+            case "method":
+                return memberModel.name + signatureSuffix(memberModel.parameters);
+            case "constructor":
+                return ownerType.name + signatureSuffix(memberModel.parameters);
+            default:
+                return memberModel.name;
+        }
+    }
+
+    private static String signatureSuffix(final List<CSharpModel.CSharpParameterModel> parameters) {
+        if (parameters == null || parameters.isEmpty()) {
+            return "()";
+        }
+        final List<String> types = new ArrayList<>();
+        for (final CSharpModel.CSharpParameterModel parameter : parameters) {
+            types.add(displayType(parameter.declaredType));
+        }
+        return "(" + String.join(", ", types) + ")";
+    }
+
+    private static String displayType(final String rawType) {
+        if (rawType == null || rawType.isBlank()) {
+            return "object";
+        }
+        final String normalized = rawType.trim();
+        final int lastDot = normalized.lastIndexOf('.');
+        if (lastDot >= 0) {
+            return normalized.substring(lastDot + 1);
+        }
+        return normalized;
+    }
+
+    private static List<String> mergeStrings(final List<String> left, final List<String> right) {
+        final LinkedHashSet<String> merged = new LinkedHashSet<>();
+        if (left != null) {
+            merged.addAll(left);
+        }
+        if (right != null) {
+            merged.addAll(right);
+        }
+        return new ArrayList<>(merged);
+    }
+
+    private static final class TypeIndex {
+        private final Map<String, CSharpModel.CSharpTypeModel> typesByUniqueName = new LinkedHashMap<>();
+        private final Map<String, List<String>> typesBySimpleName = new HashMap<>();
+        private final Map<String, String> memberByTypeAndName = new HashMap<>();
+        private final Set<String> interfaceTypes = new LinkedHashSet<>();
+
+        private TypeIndex(final List<CSharpModel.CSharpTypeModel> types) {
+            for (final CSharpModel.CSharpTypeModel type : types) {
+                typesByUniqueName.put(type.uniqueName, type);
+                typesBySimpleName.computeIfAbsent(type.name, ignored -> new ArrayList<>()).add(type.uniqueName);
+                if ("interface".equals(type.kind)) {
+                    interfaceTypes.add(type.uniqueName);
+                }
+                for (final CSharpModel.CSharpMemberModel member : type.members) {
+                    if (member.name != null && !member.name.isEmpty()) {
+                        memberByTypeAndName.put(type.uniqueName + "#" + member.name,
+                                type.uniqueName + "." + memberComponentIdentifier(member, type));
+                    }
+                }
+            }
+        }
+
+        private String resolveType(final String rawToken,
+                                   final CSharpModel.CSharpTypeModel ownerType,
+                                   final CSharpModel.CSharpMemberModel memberModel) {
+            if (rawToken == null || rawToken.isBlank()) {
+                return null;
+            }
+            final String cleaned = rawToken.replace("?", "").trim();
+            final String builtin = BUILTIN_TYPES.get(cleaned.toLowerCase(Locale.ROOT));
+            if (builtin != null) {
+                return builtin;
+            }
+            final String aliasTarget = ownerType.usingAliases.get(cleaned);
+            if (aliasTarget != null && !aliasTarget.isEmpty()) {
+                return aliasTarget;
+            }
+            if (typesByUniqueName.containsKey(cleaned)) {
+                return cleaned;
+            }
+            final String nestedCandidate = resolveNested(cleaned, ownerType);
+            if (nestedCandidate != null) {
+                return nestedCandidate;
+            }
+            final String namespaceCandidate = resolveNamespace(cleaned, ownerType.namespaceName);
+            if (namespaceCandidate != null) {
+                return namespaceCandidate;
+            }
+            final String usingCandidate = resolveUsing(cleaned, ownerType.imports);
+            if (usingCandidate != null) {
+                return usingCandidate;
+            }
+            return cleaned;
+        }
+
+        private String resolveMember(final String ownerTypeUniqueName, final String memberName) {
+            if (ownerTypeUniqueName == null || memberName == null || memberName.isEmpty()) {
+                return null;
+            }
+            String current = ownerTypeUniqueName;
+            while (current != null && !current.isEmpty()) {
+                final String resolved = memberByTypeAndName.get(current + "#" + memberName);
+                if (resolved != null) {
+                    return resolved;
+                }
+                final int lastDot = current.lastIndexOf('.');
+                if (lastDot < 0) {
+                    return null;
+                }
+                current = current.substring(0, lastDot);
+            }
+            return null;
+        }
+
+        private String resolveNested(final String simpleName, final CSharpModel.CSharpTypeModel ownerType) {
+            if (ownerType == null) {
+                return null;
+            }
+            String current = ownerType.uniqueName;
+            while (current != null && !current.isEmpty()) {
+                final String candidate = current + "." + simpleName;
+                if (typesByUniqueName.containsKey(candidate)) {
+                    return candidate;
+                }
+                final int lastDot = current.lastIndexOf('.');
+                if (lastDot < 0) {
+                    return null;
+                }
+                current = current.substring(0, lastDot);
+            }
+            return null;
+        }
+
+        private String resolveNamespace(final String simpleName, final String namespaceName) {
+            if (namespaceName == null || namespaceName.isEmpty()) {
+                return simpleLookup(simpleName);
+            }
+            final String candidate = namespaceName + "." + simpleName;
+            if (typesByUniqueName.containsKey(candidate)) {
+                return candidate;
+            }
+            return simpleLookup(simpleName);
+        }
+
+        private String resolveUsing(final String simpleName, final Set<String> imports) {
+            if (imports == null) {
+                return null;
+            }
+            for (final String importTarget : imports) {
+                if (importTarget == null || importTarget.isBlank()) {
+                    continue;
+                }
+                if (typesByUniqueName.containsKey(importTarget) && importTarget.endsWith("." + simpleName)) {
+                    return importTarget;
+                }
+                final String candidate = importTarget + "." + simpleName;
+                if (typesByUniqueName.containsKey(candidate)) {
+                    return candidate;
+                }
+            }
+            return null;
+        }
+
+        private String simpleLookup(final String simpleName) {
+            final List<String> matches = typesBySimpleName.get(simpleName);
+            if (matches == null || matches.isEmpty()) {
+                return null;
+            }
+            return matches.get(0);
+        }
+    }
+}

--- a/src/main/java/com/hadi/clarpse/compiler/csharp/CSharpModelAssembler.java
+++ b/src/main/java/com/hadi/clarpse/compiler/csharp/CSharpModelAssembler.java
@@ -22,6 +22,12 @@ import java.util.Map;
 import java.util.Set;
 import java.util.Stack;
 
+/**
+ * Builds the final {@link OOPSourceCodeModel} from parsed C# file models.
+ * This stage merges partial declarations, applies global imports, constructs
+ * components, and performs fast repo-local type/member resolution using a
+ * precomputed index rather than repeated tree scans.
+ */
 final class CSharpModelAssembler {
 
     private static final Map<String, String> BUILTIN_TYPES = Map.ofEntries(

--- a/src/main/java/com/hadi/clarpse/compiler/csharp/CSharpSyntaxNode.java
+++ b/src/main/java/com/hadi/clarpse/compiler/csharp/CSharpSyntaxNode.java
@@ -1,0 +1,27 @@
+package com.hadi.clarpse.compiler.csharp;
+
+import java.util.ArrayList;
+import java.util.List;
+
+final class CSharpSyntaxNode {
+
+    final String type;
+    final int startOffset;
+    final int endOffset;
+    final List<CSharpSyntaxNode> children = new ArrayList<>();
+    CSharpSyntaxNode parent;
+    String text = "";
+
+    CSharpSyntaxNode(final String type, final int startOffset, final int endOffset) {
+        this.type = type;
+        this.startOffset = startOffset;
+        this.endOffset = endOffset;
+    }
+
+    boolean sameRange(final CSharpSyntaxNode other) {
+        return other != null
+                && this.startOffset == other.startOffset
+                && this.endOffset == other.endOffset
+                && this.type.equals(other.type);
+    }
+}

--- a/src/main/java/com/hadi/clarpse/compiler/csharp/CSharpSyntaxNode.java
+++ b/src/main/java/com/hadi/clarpse/compiler/csharp/CSharpSyntaxNode.java
@@ -3,6 +3,11 @@ package com.hadi.clarpse.compiler.csharp;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Lightweight syntax node used while rebuilding a navigable tree from the
+ * flat JetBrains production stream. It keeps only the offsets, type, parent,
+ * children, and recovered source slice needed by the C# extractor.
+ */
 final class CSharpSyntaxNode {
 
     final String type;

--- a/src/main/java/com/hadi/clarpse/compiler/csharp/ClarpseCSharpCompiler.java
+++ b/src/main/java/com/hadi/clarpse/compiler/csharp/ClarpseCSharpCompiler.java
@@ -24,7 +24,10 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 /**
- * C# compiler backed by the JetBrains JVM parser and Clarpse-owned resolution.
+ * Entry point for C# compilation in Clarpse. It parallelizes per-file parsing,
+ * collects parse failures without aborting the full language pass, and then
+ * delegates to the assembler for partial merging, resolution, and final source
+ * model construction.
  */
 public final class ClarpseCSharpCompiler implements ClarpseCompiler {
 

--- a/src/main/java/com/hadi/clarpse/compiler/csharp/ClarpseCSharpCompiler.java
+++ b/src/main/java/com/hadi/clarpse/compiler/csharp/ClarpseCSharpCompiler.java
@@ -1,0 +1,90 @@
+package com.hadi.clarpse.compiler.csharp;
+
+import com.hadi.clarpse.compiler.ClarpseCompiler;
+import com.hadi.clarpse.compiler.CompileException;
+import com.hadi.clarpse.compiler.CompileFailure;
+import com.hadi.clarpse.compiler.CompileResult;
+import com.hadi.clarpse.compiler.CompilerParallelismSupport;
+import com.hadi.clarpse.compiler.CompilerSupport;
+import com.hadi.clarpse.compiler.Lang;
+import com.hadi.clarpse.compiler.ProjectFile;
+import com.hadi.clarpse.compiler.ProjectFiles;
+import com.hadi.clarpse.sourcemodel.OOPSourceCodeModel;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+/**
+ * C# compiler backed by the JetBrains JVM parser and Clarpse-owned resolution.
+ */
+public final class ClarpseCSharpCompiler implements ClarpseCompiler {
+
+    private static final Logger LOGGER = LogManager.getLogger(ClarpseCSharpCompiler.class);
+
+    @Override
+    public CompileResult compile(final ProjectFiles projectFiles,
+                                 final Collection<String> analyzedFilePaths) throws CompileException {
+        final List<ProjectFile> csharpFiles = ClarpseCompiler.analyzedFiles(projectFiles, Lang.CSHARP, analyzedFilePaths);
+        if (csharpFiles.isEmpty()) {
+            return new CompileResult(new OOPSourceCodeModel(), Set.of());
+        }
+        final List<CSharpModel.ParseOutcome> parseOutcomes = parseFiles(csharpFiles);
+        final List<CSharpModel.CSharpFileModel> successfulFiles = new ArrayList<>();
+        final Set<CompileFailure> failures = new HashSet<>();
+        for (final CSharpModel.ParseOutcome outcome : parseOutcomes) {
+            if (outcome.failure() != null) {
+                failures.add(outcome.failure());
+            } else if (outcome.fileModel() != null) {
+                successfulFiles.add(outcome.fileModel());
+            }
+        }
+        final OOPSourceCodeModel model = CSharpModelAssembler.buildModel(successfulFiles);
+        CompilerSupport.classifyClassCyclo(model, Set.of(
+                com.hadi.clarpse.sourcemodel.OOPSourceModelConstants.ComponentType.CLASS,
+                com.hadi.clarpse.sourcemodel.OOPSourceModelConstants.ComponentType.STRUCT,
+                com.hadi.clarpse.sourcemodel.OOPSourceModelConstants.ComponentType.ENUM
+        ));
+        CompilerSupport.classifyReferences(model);
+        return new CompileResult(model, failures);
+    }
+
+    private List<CSharpModel.ParseOutcome> parseFiles(final List<ProjectFile> files) throws CompileException {
+        final int parallelism = CompilerParallelismSupport.resolveParallelism(files.size());
+        if (parallelism > 1) {
+            LOGGER.info("Parsing C# files in parallel using " + parallelism + " threads.");
+        }
+        final ExecutorService executor = Executors.newFixedThreadPool(parallelism);
+        try {
+            final List<Future<CSharpModel.ParseOutcome>> futures = new ArrayList<>();
+            for (int i = 0; i < files.size(); i += 1) {
+                final ProjectFile file = files.get(i);
+                final int index = i;
+                futures.add(executor.submit(() -> CSharpFileParser.parseFile(file, index)));
+            }
+            final List<CSharpModel.ParseOutcome> outcomes = new ArrayList<>();
+            for (final Future<CSharpModel.ParseOutcome> future : futures) {
+                try {
+                    outcomes.add(future.get());
+                } catch (final InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new CompileException("Interrupted while parsing C# files.", e);
+                } catch (final ExecutionException e) {
+                    throw new CompileException("Failed while parsing C# files.", e);
+                }
+            }
+            outcomes.sort((left, right) -> Integer.compare(left.index(), right.index()));
+            return outcomes;
+        } finally {
+            CompilerParallelismSupport.shutdownExecutor(executor);
+        }
+    }
+}

--- a/src/main/java/com/hadi/clarpse/compiler/csharp/ClarpseCSharpCompiler.java
+++ b/src/main/java/com/hadi/clarpse/compiler/csharp/ClarpseCSharpCompiler.java
@@ -65,7 +65,7 @@ public final class ClarpseCSharpCompiler implements ClarpseCompiler {
         if (parallelism > 1) {
             LOGGER.info("Parsing C# files in parallel using " + parallelism + " threads.");
         }
-        final ExecutorService executor = Executors.newFixedThreadPool(parallelism);
+        final ExecutorService executor = Executors.newFixedThreadPool(parallelism); // NOPMD CloseResource - closed in finally
         try {
             final List<Future<CSharpModel.ParseOutcome>> futures = new ArrayList<>();
             for (int i = 0; i < files.size(); i += 1) {

--- a/src/main/resources/typescript/daemon.js
+++ b/src/main/resources/typescript/daemon.js
@@ -1081,11 +1081,12 @@ async function handleGetFileModel(params) {
     declarations = collectTopLevelDeclarations(ts, entryInfo.source, checker);
   } catch (err) {
     if (err instanceof RangeError || (err.message && err.message.includes("Maximum call stack size exceeded"))) {
-      console.warn(`[clarpse] Stack overflow during type resolution for ${filePath}. Returning partial model.`);
-      declarations = [];
+      console.warn(`[clarpse] Stack overflow during type resolution for ${filePath}.`);
+      err.code = ERROR_CODES.RESOLUTION_FAILED;
     } else {
       throw err;
     }
+    throw err;
   }
   return {
     filePath: normalized,

--- a/src/test/java/com/hadi/test/FailureCodeContractTest.java
+++ b/src/test/java/com/hadi/test/FailureCodeContractTest.java
@@ -45,4 +45,15 @@ public class FailureCodeContractTest {
         CompileFailure failure = result.failures().iterator().next();
         assertEquals(Integer.valueOf(FailureCode.PARSE_FAILED), failure.errorCode());
     }
+
+    @Test
+    public void csharpParseFailureUsesLanguageAgnosticCode() throws Exception {
+        ProjectFiles projectFiles = new ProjectFiles();
+        projectFiles.insertFile(new ProjectFile("/src/Broken.cs", "namespace Demo; public class Broken {"));
+
+        CompileResult result = new ClarpseProject(projectFiles, Lang.CSHARP).result();
+        assertEquals(1, result.failures().size());
+        CompileFailure failure = result.failures().iterator().next();
+        assertEquals(Integer.valueOf(FailureCode.PARSE_FAILED), failure.errorCode());
+    }
 }

--- a/src/test/java/com/hadi/test/csharp/CSharpAccessModifiersTest.java
+++ b/src/test/java/com/hadi/test/csharp/CSharpAccessModifiersTest.java
@@ -1,0 +1,52 @@
+package com.hadi.test.csharp;
+
+import com.hadi.clarpse.compiler.ProjectFile;
+import com.hadi.clarpse.sourcemodel.OOPSourceCodeModel;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class CSharpAccessModifiersTest {
+
+    private static OOPSourceCodeModel model;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        model = CSharpTestUtil.compileInline(
+                new ProjectFile("/Access.cs", """
+                        namespace Demo;
+                        public partial class User {
+                          public string Name { get; set; }
+                          private readonly Repo repo;
+                          internal User(Repo repo) { this.repo = repo; }
+                          protected static void Save(string message) {}
+                        }
+                        public class Repo {}
+                        """)
+        ).model();
+    }
+
+    @Test
+    public void classModifiersAreCaptured() {
+        assertTrue(model.getComponent("Demo.User").get().modifiers().contains("public"));
+        assertTrue(model.getComponent("Demo.User").get().modifiers().contains("partial"));
+    }
+
+    @Test
+    public void fieldModifiersAreCaptured() {
+        assertTrue(model.getComponent("Demo.User.repo").get().modifiers().contains("private"));
+        assertTrue(model.getComponent("Demo.User.repo").get().modifiers().contains("readonly"));
+    }
+
+    @Test
+    public void constructorModifiersAreCaptured() {
+        assertTrue(model.getComponent("Demo.User.User(Repo)").get().modifiers().contains("internal"));
+    }
+
+    @Test
+    public void methodModifiersAreCaptured() {
+        assertTrue(model.getComponent("Demo.User.Save(string)").get().modifiers().contains("protected"));
+        assertTrue(model.getComponent("Demo.User.Save(string)").get().modifiers().contains("static"));
+    }
+}

--- a/src/test/java/com/hadi/test/csharp/CSharpChildComponentsTest.java
+++ b/src/test/java/com/hadi/test/csharp/CSharpChildComponentsTest.java
@@ -1,0 +1,66 @@
+package com.hadi.test.csharp;
+
+import com.hadi.clarpse.compiler.ProjectFile;
+import com.hadi.clarpse.sourcemodel.OOPSourceCodeModel;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class CSharpChildComponentsTest {
+
+    private static OOPSourceCodeModel model;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        model = CSharpTestUtil.compileInline(
+                new ProjectFile("/Children.cs", """
+                        namespace Demo;
+                        public class User {
+                          public string Name { get; set; }
+                          public void Save(string message) { string local = message; }
+                          public interface IRunner { void Run(string item); }
+                          public enum Status { Ready, Done }
+                        }
+                        """)
+        ).model();
+    }
+
+    @Test
+    public void classHasMethodChild() {
+        assertTrue(model.getComponent("Demo.User").get().children().contains("Demo.User.Save(string)"));
+    }
+
+    @Test
+    public void classHasFieldChild() {
+        assertTrue(model.getComponent("Demo.User").get().children().contains("Demo.User.Name"));
+    }
+
+    @Test
+    public void classHasNestedInterfaceChild() {
+        assertTrue(model.getComponent("Demo.User").get().children().contains("Demo.User.IRunner"));
+    }
+
+    @Test
+    public void classHasNestedEnumChild() {
+        assertTrue(model.getComponent("Demo.User").get().children().contains("Demo.User.Status"));
+    }
+
+    @Test
+    public void methodHasParameterChild() {
+        assertTrue(model.getComponent("Demo.User.Save(string)").get().children()
+                .contains("Demo.User.Save(string).message"));
+    }
+
+    @Test
+    public void methodHasLocalChild() {
+        assertTrue(model.getComponent("Demo.User.Save(string)").get().children()
+                .contains("Demo.User.Save(string).local"));
+    }
+
+    @Test
+    public void enumHasConstantChildren() {
+        assertTrue(model.getComponent("Demo.User.Status").get().children().contains("Demo.User.Status.Ready"));
+        assertTrue(model.getComponent("Demo.User.Status").get().children().contains("Demo.User.Status.Done"));
+    }
+}

--- a/src/test/java/com/hadi/test/csharp/CSharpCodeFragmentTest.java
+++ b/src/test/java/com/hadi/test/csharp/CSharpCodeFragmentTest.java
@@ -1,0 +1,59 @@
+package com.hadi.test.csharp;
+
+import com.hadi.clarpse.compiler.ProjectFile;
+import com.hadi.clarpse.sourcemodel.OOPSourceCodeModel;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class CSharpCodeFragmentTest {
+
+    private static OOPSourceCodeModel model;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        model = CSharpTestUtil.compileInline(
+                new ProjectFile("/Fragments.cs", """
+                        namespace Demo;
+                        public class User {
+                          public System.Collections.Generic.List<string> Names { get; set; }
+                          public void Save(string message) {}
+                          public User(Repo repo) {}
+                          public delegate void LogHandler(string value);
+                          public record Audit(string Id);
+                        }
+                        public class Repo {}
+                        """)
+        ).model();
+    }
+
+    @Test
+    public void classCodeFragmentIsCaptured() {
+        assertEquals("public class User", model.getComponent("Demo.User").get().codeFragment());
+    }
+
+    @Test
+    public void propertyCodeFragmentIsCaptured() {
+        assertEquals("Names : System.Collections.Generic.List<string>",
+                model.getComponent("Demo.User.Names").get().codeFragment());
+    }
+
+    @Test
+    public void methodCodeFragmentIsCaptured() {
+        assertEquals("public void Save(string message)",
+                model.getComponent("Demo.User.Save(string)").get().codeFragment());
+    }
+
+    @Test
+    public void constructorCodeFragmentIsCaptured() {
+        assertEquals("public User(Repo repo)",
+                model.getComponent("Demo.User.User(Repo)").get().codeFragment());
+    }
+
+    @Test
+    public void delegateCodeFragmentIsCaptured() {
+        assertEquals("public delegate void LogHandler(string value)",
+                model.getComponent("Demo.User.LogHandler").get().codeFragment());
+    }
+}

--- a/src/test/java/com/hadi/test/csharp/CSharpCommentsCycloTest.java
+++ b/src/test/java/com/hadi/test/csharp/CSharpCommentsCycloTest.java
@@ -1,0 +1,48 @@
+package com.hadi.test.csharp;
+
+import com.hadi.clarpse.compiler.ProjectFile;
+import com.hadi.clarpse.sourcemodel.OOPSourceCodeModel;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class CSharpCommentsCycloTest {
+
+    private static OOPSourceCodeModel model;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        model = CSharpTestUtil.compileInline(
+                new ProjectFile("/Flow.cs", """
+                        namespace Demo;
+                        /// <summary>User aggregate.</summary>
+                        public class User {
+                          /// <summary>Saves a user.</summary>
+                          public void Save() {
+                            if (true && true) {
+                              for (var i = 0; i < 1; i++) {}
+                            }
+                          }
+                        }
+                        """)
+        ).model();
+    }
+
+    @Test
+    public void commentsAreAttached() {
+        assertTrue(model.getComponent("Demo.User").get().comment().contains("summary"));
+        assertTrue(model.getComponent("Demo.User.Save()").get().comment().contains("Saves a user"));
+    }
+
+    @Test
+    public void codeFragmentsAreCaptured() {
+        assertEquals("public void Save()", model.getComponent("Demo.User.Save()").get().codeFragment());
+    }
+
+    @Test
+    public void methodCycloIsComputed() {
+        assertEquals(4, model.getComponent("Demo.User.Save()").get().cyclo());
+    }
+}

--- a/src/test/java/com/hadi/test/csharp/CSharpComponentExistTest.java
+++ b/src/test/java/com/hadi/test/csharp/CSharpComponentExistTest.java
@@ -1,0 +1,81 @@
+package com.hadi.test.csharp;
+
+import com.hadi.clarpse.compiler.ProjectFile;
+import com.hadi.clarpse.sourcemodel.OOPSourceCodeModel;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class CSharpComponentExistTest {
+
+    private static OOPSourceCodeModel model;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        model = CSharpTestUtil.compileInline(
+                new ProjectFile("/Exist.cs", """
+                        namespace Demo;
+                        public class User {
+                          private Repo repo;
+                          public void Save(string message) { string local = message; }
+                          public interface IRunner { void Run(string item); }
+                          public enum Status { Ready }
+                          public record Audit(string Id);
+                        }
+                        public class Repo {}
+                        """)
+        ).model();
+    }
+
+    @Test
+    public void noCSharpFilesParsedMeansEmptyModel() throws Exception {
+        assertEquals(0, CSharpTestUtil.compileInline().model().size());
+    }
+
+    @Test
+    public void classExists() {
+        assertTrue(model.containsComponent("Demo.User"));
+    }
+
+    @Test
+    public void fieldExists() {
+        assertTrue(model.containsComponent("Demo.User.repo"));
+    }
+
+    @Test
+    public void methodExists() {
+        assertTrue(model.containsComponent("Demo.User.Save(string)"));
+    }
+
+    @Test
+    public void methodParamExists() {
+        assertTrue(model.containsComponent("Demo.User.Save(string).message"));
+    }
+
+    @Test
+    public void localExists() {
+        assertTrue(model.containsComponent("Demo.User.Save(string).local"));
+    }
+
+    @Test
+    public void nestedInterfaceExists() {
+        assertTrue(model.containsComponent("Demo.User.IRunner"));
+    }
+
+    @Test
+    public void nestedInterfaceMethodExists() {
+        assertTrue(model.containsComponent("Demo.User.IRunner.Run(string)"));
+    }
+
+    @Test
+    public void enumExists() {
+        assertTrue(model.containsComponent("Demo.User.Status"));
+    }
+
+    @Test
+    public void recordExists() {
+        assertTrue(model.containsComponent("Demo.User.Audit"));
+    }
+}

--- a/src/test/java/com/hadi/test/csharp/CSharpComponentProjectFilePathTest.java
+++ b/src/test/java/com/hadi/test/csharp/CSharpComponentProjectFilePathTest.java
@@ -1,0 +1,65 @@
+package com.hadi.test.csharp;
+
+import com.hadi.clarpse.compiler.ProjectFile;
+import com.hadi.clarpse.sourcemodel.Component;
+import com.hadi.clarpse.sourcemodel.OOPSourceCodeModel;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class CSharpComponentProjectFilePathTest {
+
+    private static OOPSourceCodeModel model;
+    private static final String FILE_A = "/src/demo/User.cs";
+    private static final String FILE_B = "/src/demo/admin/Admin.cs";
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        model = CSharpTestUtil.compileInline(
+                new ProjectFile(FILE_A, """
+                        namespace Demo;
+                        public class User {
+                          public string Name { get; set; }
+                          public void Save(string message) {}
+                        }
+                        """),
+                new ProjectFile(FILE_B, """
+                        namespace Demo.Admin;
+                        public class Admin {
+                          public void Run() {}
+                        }
+                        """)
+        ).model();
+    }
+
+    @Test
+    public void classHasCorrectSourcePath() {
+        final Component component = model.getComponent("Demo.User").get();
+        assertEquals(FILE_A, component.sourceFile());
+    }
+
+    @Test
+    public void fieldHasCorrectSourcePath() {
+        final Component component = model.getComponent("Demo.User.Name").get();
+        assertEquals(FILE_A, component.sourceFile());
+    }
+
+    @Test
+    public void methodHasCorrectSourcePath() {
+        final Component component = model.getComponent("Demo.User.Save(string)").get();
+        assertEquals(FILE_A, component.sourceFile());
+    }
+
+    @Test
+    public void nestedNamespaceClassHasCorrectSourcePath() {
+        final Component component = model.getComponent("Demo.Admin.Admin").get();
+        assertEquals(FILE_B, component.sourceFile());
+    }
+
+    @Test
+    public void nestedNamespaceMethodHasCorrectSourcePath() {
+        final Component component = model.getComponent("Demo.Admin.Admin.Run()").get();
+        assertEquals(FILE_B, component.sourceFile());
+    }
+}

--- a/src/test/java/com/hadi/test/csharp/CSharpComponentTypeTest.java
+++ b/src/test/java/com/hadi/test/csharp/CSharpComponentTypeTest.java
@@ -1,0 +1,83 @@
+package com.hadi.test.csharp;
+
+import com.hadi.clarpse.compiler.ProjectFile;
+import com.hadi.clarpse.sourcemodel.OOPSourceCodeModel;
+import com.hadi.clarpse.sourcemodel.OOPSourceModelConstants;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class CSharpComponentTypeTest {
+
+    private static OOPSourceCodeModel model;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        model = CSharpTestUtil.compileInline(
+                new ProjectFile("/Sample.cs", """
+                        namespace Demo;
+                        public class User {
+                          public string Name { get; set; }
+                          public User(Repo repo) { this.repo = repo; }
+                          public void Save(string message) { var helper = new Helper(); }
+                          public delegate void LogHandler(string value);
+                          public record Audit(string Id);
+                          public interface IRunner { void Run(string item); }
+                          public enum Status { Ready }
+                          private Repo repo;
+                        }
+                        public class Repo {}
+                        public class Helper {}
+                        """)
+        ).model();
+    }
+
+    @Test
+    public void classIsMapped() {
+        assertEquals(OOPSourceModelConstants.ComponentType.CLASS,
+                model.getComponent("Demo.User").get().componentType());
+    }
+
+    @Test
+    public void propertyIsMappedAsField() {
+        assertEquals(OOPSourceModelConstants.ComponentType.FIELD,
+                model.getComponent("Demo.User.Name").get().componentType());
+    }
+
+    @Test
+    public void constructorIsMapped() {
+        assertEquals(OOPSourceModelConstants.ComponentType.CONSTRUCTOR,
+                model.getComponent("Demo.User.User(Repo)").get().componentType());
+    }
+
+    @Test
+    public void methodIsMapped() {
+        assertEquals(OOPSourceModelConstants.ComponentType.METHOD,
+                model.getComponent("Demo.User.Save(string)").get().componentType());
+    }
+
+    @Test
+    public void delegateIsMappedAsFunction() {
+        assertEquals(OOPSourceModelConstants.ComponentType.FUNCTION,
+                model.getComponent("Demo.User.LogHandler").get().componentType());
+    }
+
+    @Test
+    public void recordIsMappedAsClass() {
+        assertEquals(OOPSourceModelConstants.ComponentType.CLASS,
+                model.getComponent("Demo.User.Audit").get().componentType());
+    }
+
+    @Test
+    public void interfaceIsMapped() {
+        assertEquals(OOPSourceModelConstants.ComponentType.INTERFACE,
+                model.getComponent("Demo.User.IRunner").get().componentType());
+    }
+
+    @Test
+    public void enumIsMapped() {
+        assertEquals(OOPSourceModelConstants.ComponentType.ENUM,
+                model.getComponent("Demo.User.Status").get().componentType());
+    }
+}

--- a/src/test/java/com/hadi/test/csharp/CSharpImportExternalAndRecordVariantsTest.java
+++ b/src/test/java/com/hadi/test/csharp/CSharpImportExternalAndRecordVariantsTest.java
@@ -1,0 +1,171 @@
+package com.hadi.test.csharp;
+
+import com.hadi.clarpse.compiler.ProjectFile;
+import com.hadi.clarpse.sourcemodel.Component;
+import com.hadi.clarpse.sourcemodel.OOPSourceCodeModel;
+import com.hadi.clarpse.sourcemodel.OOPSourceModelConstants;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class CSharpImportExternalAndRecordVariantsTest {
+
+    private static OOPSourceCodeModel model;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        model = CSharpTestUtil.compileInline(
+                new ProjectFile("/src/shared/Usings.cs", """
+                        global using Demo.Shared;
+                        global using GlobalRepo = Demo.Shared.Repo;
+                        global using static System.Math;
+                        """),
+                new ProjectFile("/src/shared/Types.cs", """
+                        namespace Demo.Shared;
+                        public class Repo {}
+                        public class SharedThing {}
+                        """),
+                new ProjectFile("/src/app/Imports.cs", """
+                        namespace Demo.App;
+                        using System.Collections.Generic;
+                        using System.Text;
+                        using static System.String;
+                        public class ImportConsumer {
+                          public SharedThing Thing { get; set; }
+                          public GlobalRepo Repo { get; set; }
+                          public List<string> Names { get; set; }
+                          public StringBuilder Builder { get; set; }
+                          public double Measure() { return Math.Sqrt(4); }
+                        }
+                        """),
+                new ProjectFile("/src/app/Records.cs", """
+                        namespace Demo.App;
+                        public record class AuditRecord(string Id, int Version);
+                        public record struct AuditPoint(int X, int Y);
+                        """)
+        ).model();
+    }
+
+    @Test
+    public void globalUsingResolvesCrossFileType() {
+        assertEquals("Demo.Shared.SharedThing", model.getComponent("Demo.App.ImportConsumer.Thing").get()
+                .references(OOPSourceModelConstants.TypeReferences.SIMPLE).get(0).invokedComponent());
+    }
+
+    @Test
+    public void globalAliasUsingResolvesCrossFileType() {
+        assertEquals("Demo.Shared.Repo", model.getComponent("Demo.App.ImportConsumer.Repo").get()
+                .references(OOPSourceModelConstants.TypeReferences.SIMPLE).get(0).invokedComponent());
+    }
+
+    @Test
+    public void normalUsingNamespaceImportIsRecorded() {
+        assertTrue(model.getComponent("Demo.App.ImportConsumer").get().imports().contains("System.Collections.Generic"));
+    }
+
+    @Test
+    public void normalUsingTypeImportIsRecorded() {
+        assertTrue(model.getComponent("Demo.App.ImportConsumer").get().imports().contains("System.Text"));
+    }
+
+    @Test
+    public void staticUsingImportIsRecorded() {
+        assertTrue(model.getComponent("Demo.App.ImportConsumer").get().imports().contains("System.String"));
+    }
+
+    @Test
+    public void globalStaticUsingImportIsRecorded() {
+        assertTrue(model.getComponent("Demo.App.ImportConsumer").get().imports().contains("System.Math"));
+    }
+
+    @Test
+    public void importedGenericCollectionTypeIsExternal() {
+        final Component component = model.getComponent("Demo.App.ImportConsumer.Names").get();
+        assertTrue(component.externalDependencies().stream()
+                .anyMatch(ref -> ref.invokedComponent().equals("List")));
+    }
+
+    @Test
+    public void importedFrameworkBuilderTypeIsExternal() {
+        final Component component = model.getComponent("Demo.App.ImportConsumer.Builder").get();
+        assertTrue(component.externalDependencies().stream()
+                .anyMatch(ref -> ref.invokedComponent().equals("StringBuilder")));
+    }
+
+    @Test
+    public void builtinStringTypeIsExternal() {
+        final Component component = model.getComponent("Demo.App.ImportConsumer.Names").get();
+        assertTrue(component.externalDependencies().stream()
+                .anyMatch(ref -> ref.invokedComponent().equals("System.String")));
+    }
+
+    @Test
+    public void externalStaticMathTypeReferenceIsCaptured() {
+        final Component component = model.getComponent("Demo.App.ImportConsumer.Measure()").get();
+        assertTrue(component.externalDependencies().stream()
+                .anyMatch(ref -> ref.invokedComponent().equals("Math")));
+    }
+
+    @Test
+    public void externalDoubleReturnTypeIsCaptured() {
+        final Component component = model.getComponent("Demo.App.ImportConsumer.Measure()").get();
+        assertTrue(component.externalDependencies().stream()
+                .anyMatch(ref -> ref.invokedComponent().equals("System.Double")));
+    }
+
+    @Test
+    public void externalReferencesAreNotClassifiedInternal() {
+        final Component component = model.getComponent("Demo.App.ImportConsumer.Builder").get();
+        assertTrue(component.internalDependencies().stream()
+                .noneMatch(ref -> ref.invokedComponent().equals("StringBuilder")));
+    }
+
+    @Test
+    public void recordClassMapsToClass() {
+        assertEquals(OOPSourceModelConstants.ComponentType.CLASS,
+                model.getComponent("Demo.App.AuditRecord").get().componentType());
+    }
+
+    @Test
+    public void recordStructMapsToStruct() {
+        assertEquals(OOPSourceModelConstants.ComponentType.STRUCT,
+                model.getComponent("Demo.App.AuditPoint").get().componentType());
+    }
+
+    @Test
+    public void recordClassPositionalMembersExist() {
+        assertTrue(model.containsComponent("Demo.App.AuditRecord.Id"));
+        assertTrue(model.containsComponent("Demo.App.AuditRecord.Version"));
+    }
+
+    @Test
+    public void recordStructPositionalMembersExist() {
+        assertTrue(model.containsComponent("Demo.App.AuditPoint.X"));
+        assertTrue(model.containsComponent("Demo.App.AuditPoint.Y"));
+    }
+
+    @Test
+    public void recordStructChildrenContainPositionalMembers() {
+        assertTrue(model.getComponent("Demo.App.AuditPoint").get().children().contains("Demo.App.AuditPoint.X"));
+        assertTrue(model.getComponent("Demo.App.AuditPoint").get().children().contains("Demo.App.AuditPoint.Y"));
+    }
+
+    @Test
+    public void delegateLikeChildrenRemainParentedCorrectly() {
+        assertTrue(model.getComponent("Demo.App.ImportConsumer").get().children().contains("Demo.App.ImportConsumer.Measure()"));
+    }
+
+    @Test
+    public void propertyChildrenRemainParentedCorrectly() {
+        assertTrue(model.getComponent("Demo.App.ImportConsumer").get().children().contains("Demo.App.ImportConsumer.Repo"));
+        assertTrue(model.getComponent("Demo.App.ImportConsumer").get().children().contains("Demo.App.ImportConsumer.Thing"));
+    }
+
+    @Test
+    public void recordClassComponentNamesAreStable() {
+        assertEquals("AuditRecord", model.getComponent("Demo.App.AuditRecord").get().name());
+        assertEquals("AuditPoint", model.getComponent("Demo.App.AuditPoint").get().name());
+    }
+}

--- a/src/test/java/com/hadi/test/csharp/CSharpMultiVariableDeclarationTest.java
+++ b/src/test/java/com/hadi/test/csharp/CSharpMultiVariableDeclarationTest.java
@@ -1,0 +1,46 @@
+package com.hadi.test.csharp;
+
+import com.hadi.clarpse.compiler.ProjectFile;
+import com.hadi.clarpse.sourcemodel.OOPSourceCodeModel;
+import com.hadi.clarpse.sourcemodel.OOPSourceModelConstants;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class CSharpMultiVariableDeclarationTest {
+
+    @Test
+    public void fieldMultiVariableDeclarationCreatesMultipleComponents() throws Exception {
+        final OOPSourceCodeModel model = CSharpTestUtil.compileInline(
+                new ProjectFile("/Fields.cs", """
+                        namespace Demo;
+                        public class User {
+                          private Repo first, second;
+                        }
+                        public class Repo {}
+                        """)
+        ).model();
+
+        assertTrue(model.containsComponent("Demo.User.first"));
+        assertTrue(model.containsComponent("Demo.User.second"));
+    }
+
+    @Test
+    public void fieldMultiVariableDeclarationRetainsTypeReference() throws Exception {
+        final OOPSourceCodeModel model = CSharpTestUtil.compileInline(
+                new ProjectFile("/Fields.cs", """
+                        namespace Demo;
+                        public class User {
+                          private Repo first, second;
+                        }
+                        public class Repo {}
+                        """)
+        ).model();
+
+        assertEquals("Demo.Repo", model.getComponent("Demo.User.first").get()
+                .references(OOPSourceModelConstants.TypeReferences.SIMPLE).get(0).invokedComponent());
+        assertEquals("Demo.Repo", model.getComponent("Demo.User.second").get()
+                .references(OOPSourceModelConstants.TypeReferences.SIMPLE).get(0).invokedComponent());
+    }
+}

--- a/src/test/java/com/hadi/test/csharp/CSharpNamespaceAndModuleTest.java
+++ b/src/test/java/com/hadi/test/csharp/CSharpNamespaceAndModuleTest.java
@@ -7,6 +7,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class CSharpNamespaceAndModuleTest {
 
@@ -35,5 +36,20 @@ public class CSharpNamespaceAndModuleTest {
     public void fileNameBecomesModule() {
         final Component component = model.getComponent("Demo.Feature.User").get();
         assertEquals("User", component.module());
+    }
+
+    @Test
+    public void nestedNamespaceBlocksPreserveParentNamespace() throws Exception {
+        final OOPSourceCodeModel nestedNamespaceModel = CSharpTestUtil.compileInline(
+                new ProjectFile("/src/App/Nested.cs", """
+                        namespace Demo {
+                          namespace Feature {
+                            public class NestedUser {}
+                          }
+                        }
+                        """)
+        ).model();
+
+        assertTrue(nestedNamespaceModel.getComponent("Demo.Feature.NestedUser").isPresent());
     }
 }

--- a/src/test/java/com/hadi/test/csharp/CSharpNamespaceAndModuleTest.java
+++ b/src/test/java/com/hadi/test/csharp/CSharpNamespaceAndModuleTest.java
@@ -1,0 +1,39 @@
+package com.hadi.test.csharp;
+
+import com.hadi.clarpse.compiler.ProjectFile;
+import com.hadi.clarpse.sourcemodel.Component;
+import com.hadi.clarpse.sourcemodel.OOPSourceCodeModel;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class CSharpNamespaceAndModuleTest {
+
+    private static OOPSourceCodeModel model;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        model = CSharpTestUtil.compileInline(
+                new ProjectFile("/src/App/User.cs", """
+                        namespace Demo.Feature;
+                        public class User {
+                          public string Name { get; set; }
+                        }
+                        """)
+        ).model();
+    }
+
+    @Test
+    public void namespaceBecomesPackage() {
+        final Component component = model.getComponent("Demo.Feature.User").get();
+        assertEquals("Demo.Feature", component.pkg().name());
+        assertEquals("Demo.Feature", component.pkg().path());
+    }
+
+    @Test
+    public void fileNameBecomesModule() {
+        final Component component = model.getComponent("Demo.Feature.User").get();
+        assertEquals("User", component.module());
+    }
+}

--- a/src/test/java/com/hadi/test/csharp/CSharpPartialAndFailureTest.java
+++ b/src/test/java/com/hadi/test/csharp/CSharpPartialAndFailureTest.java
@@ -1,0 +1,100 @@
+package com.hadi.test.csharp;
+
+import com.hadi.clarpse.compiler.ClarpseProject;
+import com.hadi.clarpse.compiler.CompileResult;
+import com.hadi.clarpse.compiler.FailureCode;
+import com.hadi.clarpse.compiler.Lang;
+import com.hadi.clarpse.compiler.ProjectFile;
+import com.hadi.clarpse.compiler.ProjectFiles;
+import com.hadi.clarpse.sourcemodel.OOPSourceCodeModel;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class CSharpPartialAndFailureTest {
+
+    @Test
+    public void partialClassesMergeMembersAcrossFiles() throws Exception {
+        final OOPSourceCodeModel model = CSharpTestUtil.compileInline(
+                new ProjectFile("/User.Part1.cs", """
+                        namespace Demo;
+                        public partial class User {
+                          public string Name { get; set; }
+                        }
+                        """),
+                new ProjectFile("/User.Part2.cs", """
+                        namespace Demo;
+                        public partial class User {
+                          public void Save() {}
+                        }
+                        """)
+        ).model();
+
+        assertTrue(model.containsComponent("Demo.User.Name"));
+        assertTrue(model.containsComponent("Demo.User.Save()"));
+    }
+
+    @Test
+    public void parseFailureUsesLanguageAgnosticCode() throws Exception {
+        final ProjectFiles projectFiles = new ProjectFiles();
+        projectFiles.insertFile(new ProjectFile("/Broken.cs", "namespace Demo; public class User {"));
+
+        final CompileResult result = new ClarpseProject(projectFiles, Lang.CSHARP).result();
+        assertEquals(1, result.failures().size());
+        assertEquals(Integer.valueOf(FailureCode.PARSE_FAILED), result.failures().iterator().next().errorCode());
+    }
+
+    @Test
+    public void interpolatedStringsDoNotTriggerFalseParseFailure() throws Exception {
+        final CompileResult result = CSharpTestUtil.compileInline(
+                new ProjectFile("/Interpolated.cs", """
+                        namespace Demo;
+                        public class User {
+                          public string FileFor(string id) {
+                            return $"{id}.json";
+                          }
+                        }
+                        """)
+        );
+
+        assertTrue(result.failures().isEmpty());
+        assertTrue(result.model().containsComponent("Demo.User"));
+        assertTrue(result.model().containsComponent("Demo.User.FileFor(string)"));
+    }
+
+    @Test
+    public void verbatimStringsAndCommentsDoNotTriggerFalseParseFailure() throws Exception {
+        final CompileResult result = CSharpTestUtil.compileInline(
+                new ProjectFile("/Verbatim.cs",
+                        "namespace Demo;\n"
+                                + "public class User {\n"
+                                + "  public string Query() {\n"
+                                + "    // braces here should not matter: {}\n"
+                                + "    var sql = @\"select * from Users where Name = \"\"{demo}\"\"\";\n"
+                                + "    return sql;\n"
+                                + "  }\n"
+                                + "}\n")
+        );
+
+        assertTrue(result.failures().isEmpty());
+        assertTrue(result.model().containsComponent("Demo.User.Query()"));
+    }
+
+    @Test
+    public void stringsEndingWithEscapedBackslashDoNotTriggerFalseParseFailure() throws Exception {
+        final CompileResult result = CSharpTestUtil.compileInline(
+                new ProjectFile("/Paths.cs",
+                        "namespace Demo;\n"
+                                + "public class User {\n"
+                                + "  public string Build(string company) {\n"
+                                + "    var part = $\"{company}\\\\\";\n"
+                                + "    return part;\n"
+                                + "  }\n"
+                                + "}\n")
+        );
+
+        assertTrue(result.failures().isEmpty());
+        assertTrue(result.model().containsComponent("Demo.User.Build(string)"));
+    }
+}

--- a/src/test/java/com/hadi/test/csharp/CSharpReferenceTest.java
+++ b/src/test/java/com/hadi/test/csharp/CSharpReferenceTest.java
@@ -1,0 +1,101 @@
+package com.hadi.test.csharp;
+
+import com.hadi.clarpse.compiler.ProjectFile;
+import com.hadi.clarpse.reference.TypeExtensionReference;
+import com.hadi.clarpse.reference.TypeImplementationReference;
+import com.hadi.clarpse.sourcemodel.OOPSourceCodeModel;
+import com.hadi.clarpse.sourcemodel.OOPSourceModelConstants;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class CSharpReferenceTest {
+
+    private static OOPSourceCodeModel model;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        model = CSharpTestUtil.compileInline(
+                new ProjectFile("/Refs.cs", """
+                        namespace Demo;
+                        using Demo.Tools;
+                        using AliasRepo = Demo.Tools.Repo;
+                        public interface IRunner {}
+                        public class BaseUser {}
+                        public class User : BaseUser, IRunner {
+                          public Repo Repo { get; set; }
+                          public AliasRepo AliasRepo { get; set; }
+                          public User(Repo repo) { this.Repo = repo; }
+                          public void Save(string message) { var helper = new Helper(); }
+                        }
+                        namespace Demo.Tools;
+                        public class Repo {}
+                        public class Helper {}
+                        """)
+        ).model();
+    }
+
+    @Test
+    public void extensionReferenceIsResolved() {
+        assertTrue(model.getComponent("Demo.User").get()
+                .references(OOPSourceModelConstants.TypeReferences.EXTENSION)
+                .contains(new TypeExtensionReference("Demo.BaseUser")));
+    }
+
+    @Test
+    public void implementationReferenceIsResolved() {
+        assertTrue(model.getComponent("Demo.User").get()
+                .references(OOPSourceModelConstants.TypeReferences.IMPLEMENTATION)
+                .contains(new TypeImplementationReference("Demo.IRunner")));
+    }
+
+    @Test
+    public void propertyTypeReferenceIsResolved() {
+        assertEquals("Demo.Tools.Repo",
+                model.getComponent("Demo.User.Repo").get()
+                        .references(OOPSourceModelConstants.TypeReferences.SIMPLE)
+                        .get(0).invokedComponent());
+    }
+
+    @Test
+    public void aliasUsingTypeReferenceIsResolved() {
+        assertEquals("Demo.Tools.Repo",
+                model.getComponent("Demo.User.AliasRepo").get()
+                        .references(OOPSourceModelConstants.TypeReferences.SIMPLE)
+                        .get(0).invokedComponent());
+    }
+
+    @Test
+    public void objectCreationReferenceIsResolved() {
+        assertTrue(model.getComponent("Demo.User.Save(string)").get()
+                .references(OOPSourceModelConstants.TypeReferences.SIMPLE)
+                .stream()
+                .anyMatch(ref -> ref.invokedComponent().equals("Demo.Tools.Helper")));
+    }
+
+    @Test
+    public void capitalizedMemberReceiverIsNotMisclassifiedAsStaticType() throws Exception {
+        final OOPSourceCodeModel memberAccessModel = CSharpTestUtil.compileInline(
+                new ProjectFile("/Store.cs", """
+                        namespace Demo;
+                        public interface IStore { void Clear(); }
+                        public class Store : IStore { public void Clear() {} }
+                        public class Tracker {
+                          public IStore Store { get; set; }
+                          public void Reset() { Store.Clear(); }
+                        }
+                        """)
+        ).model();
+
+        assertTrue(memberAccessModel.getComponent("Demo.Tracker.Reset()").get()
+                .references(OOPSourceModelConstants.TypeReferences.SIMPLE)
+                .stream()
+                .noneMatch(ref -> ref.invokedComponent().equals("Store")));
+        assertTrue(memberAccessModel.getComponent("Demo.Tracker.Reset()").get()
+                .references(OOPSourceModelConstants.TypeReferences.SIMPLE)
+                .stream()
+                .noneMatch(ref -> ref.invokedComponent().equals("Demo.Tracker.Store")));
+    }
+}

--- a/src/test/java/com/hadi/test/csharp/CSharpSimpleTypeReferenceTest.java
+++ b/src/test/java/com/hadi/test/csharp/CSharpSimpleTypeReferenceTest.java
@@ -1,0 +1,85 @@
+package com.hadi.test.csharp;
+
+import com.hadi.clarpse.compiler.ProjectFile;
+import com.hadi.clarpse.sourcemodel.OOPSourceCodeModel;
+import com.hadi.clarpse.sourcemodel.OOPSourceModelConstants;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class CSharpSimpleTypeReferenceTest {
+
+    private static OOPSourceCodeModel model;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        model = CSharpTestUtil.compileInline(
+                new ProjectFile("/Refs.cs", """
+                        namespace Demo;
+                        using Demo.Tools;
+                        public class User {
+                          public Repo Repo { get; set; }
+                          public event LogHandler Saved;
+                          public User(Repo repo) { this.Repo = repo; }
+                          public void Save(string message) { Helper helper = new Helper(); }
+                          public delegate void LogHandler(string value);
+                        }
+                        namespace Demo.Tools;
+                        public class Repo {}
+                        public class Helper {}
+                        """)
+        ).model();
+    }
+
+    @Test
+    public void fieldLikePropertyTypeResolves() {
+        assertEquals("Demo.Tools.Repo", model.getComponent("Demo.User.Repo").get()
+                .references(OOPSourceModelConstants.TypeReferences.SIMPLE).get(0).invokedComponent());
+    }
+
+    @Test
+    public void eventTypeResolves() {
+        assertEquals("Demo.User.LogHandler", model.getComponent("Demo.User.Saved").get()
+                .references(OOPSourceModelConstants.TypeReferences.SIMPLE).get(0).invokedComponent());
+    }
+
+    @Test
+    public void constructorParamTypeResolves() {
+        assertEquals("Demo.Tools.Repo", model.getComponent("Demo.User.User(Repo).repo").get()
+                .references(OOPSourceModelConstants.TypeReferences.SIMPLE).get(0).invokedComponent());
+    }
+
+    @Test
+    public void methodParamBuiltinTypeResolves() {
+        assertEquals("System.String", model.getComponent("Demo.User.Save(string).message").get()
+                .references(OOPSourceModelConstants.TypeReferences.SIMPLE).get(0).invokedComponent());
+    }
+
+    @Test
+    public void localTypedReferenceResolves() {
+        assertEquals("Demo.Tools.Helper", model.getComponent("Demo.User.Save(string).helper").get()
+                .references(OOPSourceModelConstants.TypeReferences.SIMPLE).get(0).invokedComponent());
+    }
+
+    @Test
+    public void methodCapturesObjectCreationReference() {
+        assertTrue(model.getComponent("Demo.User.Save(string)").get()
+                .references(OOPSourceModelConstants.TypeReferences.SIMPLE).stream()
+                .anyMatch(ref -> ref.invokedComponent().equals("Demo.Tools.Helper")));
+    }
+
+    @Test
+    public void delegateParamBuiltinTypeResolves() {
+        assertEquals("System.String", model.getComponent("Demo.User.LogHandler.value").get()
+                .references(OOPSourceModelConstants.TypeReferences.SIMPLE).get(0).invokedComponent());
+    }
+
+    @Test
+    public void constructorCapturesFieldAssignmentReference() {
+        assertTrue(model.getComponent("Demo.User.User(Repo)").get()
+                .references(OOPSourceModelConstants.TypeReferences.SIMPLE).stream()
+                .anyMatch(ref -> ref.invokedComponent().equals("Demo.User.Repo")));
+    }
+}

--- a/src/test/java/com/hadi/test/csharp/CSharpSpotCheckComponentsTest.java
+++ b/src/test/java/com/hadi/test/csharp/CSharpSpotCheckComponentsTest.java
@@ -1,0 +1,128 @@
+package com.hadi.test.csharp;
+
+import com.hadi.clarpse.compiler.ProjectFile;
+import com.hadi.clarpse.sourcemodel.OOPSourceCodeModel;
+import com.hadi.clarpse.sourcemodel.OOPSourceModelConstants;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class CSharpSpotCheckComponentsTest {
+
+    private static OOPSourceCodeModel model;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        model = CSharpTestUtil.compileInline(
+                new ProjectFile("/src/spot/Shapes.cs", """
+                        namespace Demo.Shapes;
+                        /// <summary>Represents a shape registry.</summary>
+                        public abstract class ShapeRegistry : BaseRegistry, ITrackable {
+                          private readonly Repo _repo;
+                          public string Name { get; set; }
+                          public event ChangedHandler Changed;
+                          public delegate void ChangedHandler(string value);
+                          public struct Point { public int X; }
+                          public interface IWorker { void Run(); }
+                          public enum Status { Ready, Done }
+                          public record Audit(string Id);
+                          protected ShapeRegistry(Repo repo) { _repo = repo; }
+                          public Helper Build(string id) { Helper helper = new Helper(); return helper; }
+                        }
+                        public class Repo {}
+                        public class Helper {}
+                        public abstract class BaseRegistry {}
+                        public interface ITrackable {}
+                        """)
+        ).model();
+    }
+
+    @Test
+    public void abstractClassIsMappedAsClass() {
+        assertEquals(OOPSourceModelConstants.ComponentType.CLASS,
+                model.getComponent("Demo.Shapes.ShapeRegistry").get().componentType());
+    }
+
+    @Test
+    public void abstractModifierIsCaptured() {
+        assertTrue(model.getComponent("Demo.Shapes.ShapeRegistry").get().modifiers().contains("abstract"));
+    }
+
+    @Test
+    public void readonlyFieldModifierIsCaptured() {
+        assertTrue(model.getComponent("Demo.Shapes.ShapeRegistry._repo").get().modifiers().contains("readonly"));
+    }
+
+    @Test
+    public void privateFieldModifierIsCaptured() {
+        assertTrue(model.getComponent("Demo.Shapes.ShapeRegistry._repo").get().modifiers().contains("private"));
+    }
+
+    @Test
+    public void propertyIsMappedAsField() {
+        assertEquals(OOPSourceModelConstants.ComponentType.FIELD,
+                model.getComponent("Demo.Shapes.ShapeRegistry.Name").get().componentType());
+    }
+
+    @Test
+    public void eventIsMappedAsField() {
+        assertEquals(OOPSourceModelConstants.ComponentType.FIELD,
+                model.getComponent("Demo.Shapes.ShapeRegistry.Changed").get().componentType());
+    }
+
+    @Test
+    public void delegateIsMappedAsFunction() {
+        assertEquals(OOPSourceModelConstants.ComponentType.FUNCTION,
+                model.getComponent("Demo.Shapes.ShapeRegistry.ChangedHandler").get().componentType());
+    }
+
+    @Test
+    public void nestedStructIsMapped() {
+        assertEquals(OOPSourceModelConstants.ComponentType.STRUCT,
+                model.getComponent("Demo.Shapes.ShapeRegistry.Point").get().componentType());
+    }
+
+    @Test
+    public void nestedInterfaceIsMapped() {
+        assertEquals(OOPSourceModelConstants.ComponentType.INTERFACE,
+                model.getComponent("Demo.Shapes.ShapeRegistry.IWorker").get().componentType());
+    }
+
+    @Test
+    public void nestedEnumIsMapped() {
+        assertEquals(OOPSourceModelConstants.ComponentType.ENUM,
+                model.getComponent("Demo.Shapes.ShapeRegistry.Status").get().componentType());
+    }
+
+    @Test
+    public void recordIsMappedAsClass() {
+        assertEquals(OOPSourceModelConstants.ComponentType.CLASS,
+                model.getComponent("Demo.Shapes.ShapeRegistry.Audit").get().componentType());
+    }
+
+    @Test
+    public void enumMemberIsMapped() {
+        assertEquals(OOPSourceModelConstants.ComponentType.ENUM_CONSTANT,
+                model.getComponent("Demo.Shapes.ShapeRegistry.Status.Ready").get().componentType());
+    }
+
+    @Test
+    public void constructorIsMapped() {
+        assertEquals(OOPSourceModelConstants.ComponentType.CONSTRUCTOR,
+                model.getComponent("Demo.Shapes.ShapeRegistry.ShapeRegistry(Repo)").get().componentType());
+    }
+
+    @Test
+    public void protectedConstructorModifierIsCaptured() {
+        assertTrue(model.getComponent("Demo.Shapes.ShapeRegistry.ShapeRegistry(Repo)").get()
+                .modifiers().contains("protected"));
+    }
+
+    @Test
+    public void methodIsMapped() {
+        assertEquals(OOPSourceModelConstants.ComponentType.METHOD,
+                model.getComponent("Demo.Shapes.ShapeRegistry.Build(string)").get().componentType());
+    }
+}

--- a/src/test/java/com/hadi/test/csharp/CSharpSpotCheckIdentityAndPathsTest.java
+++ b/src/test/java/com/hadi/test/csharp/CSharpSpotCheckIdentityAndPathsTest.java
@@ -1,0 +1,138 @@
+package com.hadi.test.csharp;
+
+import com.hadi.clarpse.compiler.ProjectFile;
+import com.hadi.clarpse.sourcemodel.Component;
+import com.hadi.clarpse.sourcemodel.OOPSourceCodeModel;
+import com.hadi.clarpse.sourcemodel.OOPSourceModelConstants;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class CSharpSpotCheckIdentityAndPathsTest {
+
+    private static final String ORDER_PART1 = "/src/orders/Order.Part1.cs";
+    private static final String ORDER_PART2 = "/src/orders/Order.Part2.cs";
+    private static final String LINE_ITEM = "/src/orders/LineItem.cs";
+    private static final String CONFIG = "/src/fs/Config.cs";
+    private static OOPSourceCodeModel model;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        model = CSharpTestUtil.compileInline(
+                new ProjectFile(ORDER_PART1, """
+                        namespace Demo.Orders;
+                        public partial class Order {
+                          public string Id { get; set; }
+                          public void Add(LineItem item) { LineItem local = item; }
+                          public class Metadata { public int Version; }
+                        }
+                        """),
+                new ProjectFile(ORDER_PART2, """
+                        namespace Demo.Orders;
+                        public partial class Order {
+                          public event OrderSaved Saved;
+                          public delegate void OrderSaved(string value);
+                        }
+                        """),
+                new ProjectFile(LINE_ITEM, """
+                        namespace Demo.Orders;
+                        public class LineItem {}
+                        """),
+                new ProjectFile(CONFIG, """
+                        namespace Demo.FileScoped;
+                        public class Config { public string Key { get; set; } }
+                        """)
+        ).model();
+    }
+
+    @Test
+    public void partialTypeHasPropertyFromFirstPart() {
+        assertTrue(model.containsComponent("Demo.Orders.Order.Id"));
+    }
+
+    @Test
+    public void partialTypeHasEventFromSecondPart() {
+        assertTrue(model.containsComponent("Demo.Orders.Order.Saved"));
+    }
+
+    @Test
+    public void partialTypeHasDelegateFromSecondPart() {
+        assertTrue(model.containsComponent("Demo.Orders.Order.OrderSaved"));
+    }
+
+    @Test
+    public void propertySourceFilePathComesFromFirstPart() {
+        final Component component = model.getComponent("Demo.Orders.Order.Id").get();
+        assertEquals(ORDER_PART1, component.sourceFile());
+    }
+
+    @Test
+    public void eventSourceFilePathComesFromSecondPart() {
+        final Component component = model.getComponent("Demo.Orders.Order.Saved").get();
+        assertEquals(ORDER_PART2, component.sourceFile());
+    }
+
+    @Test
+    public void delegateSourceFilePathComesFromSecondPart() {
+        final Component component = model.getComponent("Demo.Orders.Order.OrderSaved").get();
+        assertEquals(ORDER_PART2, component.sourceFile());
+    }
+
+    @Test
+    public void fileScopedNamespaceBecomesPackage() {
+        final Component component = model.getComponent("Demo.FileScoped.Config").get();
+        assertEquals("Demo.FileScoped", component.pkg().name());
+    }
+
+    @Test
+    public void fileScopedModuleUsesFilename() {
+        final Component component = model.getComponent("Demo.FileScoped.Config").get();
+        assertEquals("Config", component.module());
+    }
+
+    @Test
+    public void orderModuleUsesFilenameWithoutExtension() {
+        final Component component = model.getComponent("Demo.Orders.Order").get();
+        assertEquals("Order.Part1", component.module());
+    }
+
+    @Test
+    public void partialTypeChildrenIncludeNestedClass() {
+        assertTrue(model.getComponent("Demo.Orders.Order").get().children()
+                .contains("Demo.Orders.Order.Metadata"));
+    }
+
+    @Test
+    public void partialTypeChildrenIncludeMethod() {
+        assertTrue(model.getComponent("Demo.Orders.Order").get().children()
+                .contains("Demo.Orders.Order.Add(LineItem)"));
+    }
+
+    @Test
+    public void nestedClassFieldTypeIsCaptured() {
+        assertEquals(OOPSourceModelConstants.ComponentType.FIELD,
+                model.getComponent("Demo.Orders.Order.Metadata.Version").get().componentType());
+    }
+
+    @Test
+    public void methodParamSourceFilePathComesFromFirstPart() {
+        final Component component = model.getComponent("Demo.Orders.Order.Add(LineItem).item").get();
+        assertEquals(ORDER_PART1, component.sourceFile());
+    }
+
+    @Test
+    public void methodLocalSourceFilePathComesFromFirstPart() {
+        final Component component = model.getComponent("Demo.Orders.Order.Add(LineItem).local").get();
+        assertEquals(ORDER_PART1, component.sourceFile());
+    }
+
+    @Test
+    public void methodParamAndLocalTypeReferencesResolve() {
+        assertEquals("Demo.Orders.LineItem", model.getComponent("Demo.Orders.Order.Add(LineItem).item").get()
+                .references(OOPSourceModelConstants.TypeReferences.SIMPLE).get(0).invokedComponent());
+        assertEquals("Demo.Orders.LineItem", model.getComponent("Demo.Orders.Order.Add(LineItem).local").get()
+                .references(OOPSourceModelConstants.TypeReferences.SIMPLE).get(0).invokedComponent());
+    }
+}

--- a/src/test/java/com/hadi/test/csharp/CSharpSpotCheckReferencesAndCommentsTest.java
+++ b/src/test/java/com/hadi/test/csharp/CSharpSpotCheckReferencesAndCommentsTest.java
@@ -1,0 +1,143 @@
+package com.hadi.test.csharp;
+
+import com.hadi.clarpse.compiler.ProjectFile;
+import com.hadi.clarpse.reference.TypeExtensionReference;
+import com.hadi.clarpse.reference.TypeImplementationReference;
+import com.hadi.clarpse.sourcemodel.OOPSourceCodeModel;
+import com.hadi.clarpse.sourcemodel.OOPSourceModelConstants;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class CSharpSpotCheckReferencesAndCommentsTest {
+
+    private static OOPSourceCodeModel model;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        model = CSharpTestUtil.compileInline(
+                new ProjectFile("/src/app/User.cs", """
+                        namespace Demo.App;
+                        using Demo.Common;
+                        using AliasRepo = Demo.Common.Repo;
+                        /// <summary>Main user aggregate.</summary>
+                        public partial class User : Entity, IRunner {
+                          /// <summary>Persists data.</summary>
+                          public AliasRepo Repo { get; set; }
+                          public event SavedHandler Saved;
+                          public delegate void SavedHandler(string value);
+                          public User(Repo repo) { this.Repo = repo; }
+                          public Helper Save(string message) {
+                            // Build helper from repo {}
+                            Helper helper = new Helper();
+                            if (message != null && message.Length > 0) {
+                              for (var i = 0; i < 1; i++) {}
+                            }
+                            return helper;
+                          }
+                        }
+                        public abstract class Entity {}
+                        public interface IRunner {}
+                        """),
+                new ProjectFile("/src/common/Common.cs", """
+                        namespace Demo.Common;
+                        public class Repo {}
+                        public class Helper {}
+                        """)
+        ).model();
+    }
+
+    @Test
+    public void classCommentIsCaptured() {
+        assertTrue(model.getComponent("Demo.App.User").get().comment().contains("Main user aggregate"));
+    }
+
+    @Test
+    public void methodCommentIsCaptured() {
+        assertTrue(model.getComponent("Demo.App.User.Repo").get().comment().contains("Persists data"));
+    }
+
+    @Test
+    public void propertyTypeReferenceResolvesThroughAliasUsing() {
+        assertEquals("Demo.Common.Repo", model.getComponent("Demo.App.User.Repo").get()
+                .references(OOPSourceModelConstants.TypeReferences.SIMPLE).get(0).invokedComponent());
+    }
+
+    @Test
+    public void eventTypeReferenceResolvesToNestedDelegate() {
+        assertEquals("Demo.App.User.SavedHandler", model.getComponent("Demo.App.User.Saved").get()
+                .references(OOPSourceModelConstants.TypeReferences.SIMPLE).get(0).invokedComponent());
+    }
+
+    @Test
+    public void constructorParamTypeReferenceResolves() {
+        assertEquals("Demo.Common.Repo", model.getComponent("Demo.App.User.User(Repo).repo").get()
+                .references(OOPSourceModelConstants.TypeReferences.SIMPLE).get(0).invokedComponent());
+    }
+
+    @Test
+    public void methodParamBuiltinTypeReferenceResolves() {
+        assertEquals("System.String", model.getComponent("Demo.App.User.Save(string).message").get()
+                .references(OOPSourceModelConstants.TypeReferences.SIMPLE).get(0).invokedComponent());
+    }
+
+    @Test
+    public void localTypeReferenceResolves() {
+        assertEquals("Demo.Common.Helper", model.getComponent("Demo.App.User.Save(string).helper").get()
+                .references(OOPSourceModelConstants.TypeReferences.SIMPLE).get(0).invokedComponent());
+    }
+
+    @Test
+    public void methodCapturesObjectCreationReference() {
+        assertTrue(model.getComponent("Demo.App.User.Save(string)").get()
+                .references(OOPSourceModelConstants.TypeReferences.SIMPLE).stream()
+                .anyMatch(ref -> ref.invokedComponent().equals("Demo.Common.Helper")));
+    }
+
+    @Test
+    public void delegateParamBuiltinTypeResolves() {
+        assertEquals("System.String", model.getComponent("Demo.App.User.SavedHandler.value").get()
+                .references(OOPSourceModelConstants.TypeReferences.SIMPLE).get(0).invokedComponent());
+    }
+
+    @Test
+    public void constructorCapturesAssignedPropertyReference() {
+        assertTrue(model.getComponent("Demo.App.User.User(Repo)").get()
+                .references(OOPSourceModelConstants.TypeReferences.SIMPLE).stream()
+                .anyMatch(ref -> ref.invokedComponent().equals("Demo.App.User.Repo")));
+    }
+
+    @Test
+    public void extensionReferenceResolves() {
+        assertTrue(model.getComponent("Demo.App.User").get()
+                .references(OOPSourceModelConstants.TypeReferences.EXTENSION)
+                .contains(new TypeExtensionReference("Demo.App.Entity")));
+    }
+
+    @Test
+    public void implementationReferenceResolves() {
+        assertTrue(model.getComponent("Demo.App.User").get()
+                .references(OOPSourceModelConstants.TypeReferences.IMPLEMENTATION)
+                .contains(new TypeImplementationReference("Demo.App.IRunner")));
+    }
+
+    @Test
+    public void methodCycloIncludesIfAndLoop() {
+        assertEquals(4, model.getComponent("Demo.App.User.Save(string)").get().cyclo());
+    }
+
+    @Test
+    public void methodCodeFragmentIsCaptured() {
+        assertEquals("public Helper Save(string message)",
+                model.getComponent("Demo.App.User.Save(string)").get().codeFragment());
+    }
+
+    @Test
+    public void capitalizedPropertyReceiverIsNotTreatedAsTypeReference() {
+        assertTrue(model.getComponent("Demo.App.User.User(Repo)").get()
+                .references(OOPSourceModelConstants.TypeReferences.SIMPLE).stream()
+                .noneMatch(ref -> ref.invokedComponent().equals("Repo")));
+    }
+}

--- a/src/test/java/com/hadi/test/csharp/CSharpTestUtil.java
+++ b/src/test/java/com/hadi/test/csharp/CSharpTestUtil.java
@@ -1,0 +1,21 @@
+package com.hadi.test.csharp;
+
+import com.hadi.clarpse.compiler.ClarpseProject;
+import com.hadi.clarpse.compiler.CompileResult;
+import com.hadi.clarpse.compiler.Lang;
+import com.hadi.clarpse.compiler.ProjectFile;
+import com.hadi.clarpse.compiler.ProjectFiles;
+
+public final class CSharpTestUtil {
+
+    private CSharpTestUtil() {
+    }
+
+    public static CompileResult compileInline(final ProjectFile... files) throws Exception {
+        final ProjectFiles projectFiles = new ProjectFiles();
+        for (final ProjectFile file : files) {
+            projectFiles.insertFile(file);
+        }
+        return new ClarpseProject(projectFiles, Lang.CSHARP).result();
+    }
+}

--- a/src/test/java/com/hadi/test/csharp/CSharpTypeExtensionReferenceTest.java
+++ b/src/test/java/com/hadi/test/csharp/CSharpTypeExtensionReferenceTest.java
@@ -1,0 +1,48 @@
+package com.hadi.test.csharp;
+
+import com.hadi.clarpse.compiler.ProjectFile;
+import com.hadi.clarpse.reference.TypeExtensionReference;
+import com.hadi.clarpse.sourcemodel.OOPSourceCodeModel;
+import com.hadi.clarpse.sourcemodel.OOPSourceModelConstants;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class CSharpTypeExtensionReferenceTest {
+
+    @Test
+    public void accurateExtendedType() throws Exception {
+        final OOPSourceCodeModel model = CSharpTestUtil.compileInline(
+                new ProjectFile("/Base.cs", "namespace Demo; public class BaseUser {}"),
+                new ProjectFile("/User.cs", "namespace Demo; public class User : BaseUser {}")
+        ).model();
+
+        assertTrue(model.getComponent("Demo.User").get()
+                .references(OOPSourceModelConstants.TypeReferences.EXTENSION)
+                .contains(new TypeExtensionReference("Demo.BaseUser")));
+    }
+
+    @Test
+    public void extendedTypeReferenceCount() throws Exception {
+        final OOPSourceCodeModel model = CSharpTestUtil.compileInline(
+                new ProjectFile("/Base.cs", "namespace Demo; public class BaseUser {}"),
+                new ProjectFile("/User.cs", "namespace Demo; public class User : BaseUser {}")
+        ).model();
+
+        assertEquals(1, model.getComponent("Demo.User").get()
+                .references(OOPSourceModelConstants.TypeReferences.EXTENSION).size());
+    }
+
+    @Test
+    public void nestedClassExtensionIsResolved() throws Exception {
+        final OOPSourceCodeModel model = CSharpTestUtil.compileInline(
+                new ProjectFile("/Base.cs", "namespace Demo; public class BaseUser {}"),
+                new ProjectFile("/User.cs", "namespace Demo; public class User { public class Admin : BaseUser {} }")
+        ).model();
+
+        assertTrue(model.getComponent("Demo.User.Admin").get()
+                .references(OOPSourceModelConstants.TypeReferences.EXTENSION)
+                .contains(new TypeExtensionReference("Demo.BaseUser")));
+    }
+}

--- a/src/test/java/com/hadi/test/csharp/CSharpTypeImplementationReferenceTest.java
+++ b/src/test/java/com/hadi/test/csharp/CSharpTypeImplementationReferenceTest.java
@@ -1,0 +1,65 @@
+package com.hadi.test.csharp;
+
+import com.hadi.clarpse.compiler.ProjectFile;
+import com.hadi.clarpse.reference.TypeImplementationReference;
+import com.hadi.clarpse.sourcemodel.OOPSourceCodeModel;
+import com.hadi.clarpse.sourcemodel.OOPSourceModelConstants;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class CSharpTypeImplementationReferenceTest {
+
+    @Test
+    public void accurateImplementedType() throws Exception {
+        final OOPSourceCodeModel model = CSharpTestUtil.compileInline(
+                new ProjectFile("/Runner.cs", "namespace Demo; public interface IRunner {}"),
+                new ProjectFile("/User.cs", "namespace Demo; public class User : IRunner {}")
+        ).model();
+
+        assertTrue(model.getComponent("Demo.User").get()
+                .references(OOPSourceModelConstants.TypeReferences.IMPLEMENTATION)
+                .contains(new TypeImplementationReference("Demo.IRunner")));
+    }
+
+    @Test
+    public void multipleImplementedTypes() throws Exception {
+        final OOPSourceCodeModel model = CSharpTestUtil.compileInline(
+                new ProjectFile("/Runner.cs", "namespace Demo; public interface IRunner {}"),
+                new ProjectFile("/Persist.cs", "namespace Demo; public interface IPersisted {}"),
+                new ProjectFile("/User.cs", "namespace Demo; public class User : IRunner, IPersisted {}")
+        ).model();
+
+        assertTrue(model.getComponent("Demo.User").get()
+                .references(OOPSourceModelConstants.TypeReferences.IMPLEMENTATION)
+                .contains(new TypeImplementationReference("Demo.IRunner")));
+        assertTrue(model.getComponent("Demo.User").get()
+                .references(OOPSourceModelConstants.TypeReferences.IMPLEMENTATION)
+                .contains(new TypeImplementationReference("Demo.IPersisted")));
+    }
+
+    @Test
+    public void implementedTypeReferenceCount() throws Exception {
+        final OOPSourceCodeModel model = CSharpTestUtil.compileInline(
+                new ProjectFile("/Runner.cs", "namespace Demo; public interface IRunner {}"),
+                new ProjectFile("/Persist.cs", "namespace Demo; public interface IPersisted {}"),
+                new ProjectFile("/User.cs", "namespace Demo; public class User : IRunner, IPersisted {}")
+        ).model();
+
+        assertEquals(2, model.getComponent("Demo.User").get()
+                .references(OOPSourceModelConstants.TypeReferences.IMPLEMENTATION).size());
+    }
+
+    @Test
+    public void nestedClassImplementationIsResolved() throws Exception {
+        final OOPSourceCodeModel model = CSharpTestUtil.compileInline(
+                new ProjectFile("/Runner.cs", "namespace Demo; public interface IRunner {}"),
+                new ProjectFile("/User.cs", "namespace Demo; public class User { public class Admin : IRunner {} }")
+        ).model();
+
+        assertTrue(model.getComponent("Demo.User.Admin").get()
+                .references(OOPSourceModelConstants.TypeReferences.IMPLEMENTATION)
+                .contains(new TypeImplementationReference("Demo.IRunner")));
+    }
+}

--- a/src/test/java/com/hadi/test/typescript/TypeScriptRecursiveTypeTest.java
+++ b/src/test/java/com/hadi/test/typescript/TypeScriptRecursiveTypeTest.java
@@ -2,11 +2,13 @@ package com.hadi.test.typescript;
 
 import com.hadi.clarpse.compiler.CompileResult;
 import com.hadi.clarpse.compiler.typescript.NodeRuntime;
+import com.hadi.clarpse.compiler.typescript.TypeScriptDaemonException;
 import com.hadi.clarpse.sourcemodel.Component;
 import org.junit.Assume;
 import org.junit.Test;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -64,8 +66,9 @@ public class TypeScriptRecursiveTypeTest {
         CompileResult result = TypeScriptTestUtil.compileFixture("recursive-types");
 
         assertNotNull(result);
-        // If there are failures, the compilation should still produce results
-        // rather than throwing an exception
         assertTrue(result.model().components().count() > 0);
+        result.failures().forEach(failure ->
+                assertEquals(TypeScriptDaemonException.CODE_RESOLUTION_FAILED,
+                        failure.errorCode().intValue()));
     }
 }


### PR DESCRIPTION
## Summary

This PR adds first-class C# support to `clarpse` on the JVM.

It introduces a new C# compiler pipeline based on JetBrains' parser artifacts, maps C# constructs into the existing language-agnostic OOP model, and adds a broad C# parity suite aimed at the same behavioral surface the Java tests cover. It also wires `Lang.CSHARP` through the compiler factory and project flow, and adds shared parallelism support so the C# path uses the same `CLARPSE_PARALLELISM` environment variable behavior as Java.

## What Changed

- Added `Lang.CSHARP` and `.cs` support through the compiler selection flow.
- Added a JVM-side C# compiler:
  - syntax parsing
  - namespace / using extraction
  - class / interface / enum / struct / record / delegate handling
  - field / property / event / method / constructor / local / parameter extraction
  - partial type merging
  - repo-local type resolution
- Added shared compiler parallelism utilities so Java and C# use the same env var and shutdown behavior.
- Added extensive C# tests, including:
  - component existence and types
  - modifiers
  - child component relationships
  - type references
  - inheritance / implementation references
  - comments
  - code fragments
  - cyclomatic complexity
  - namespace / module behavior
  - parse failure behavior
  - import variants
  - record class / record struct
  - external/internal reference spot checks

## Behavior / Mapping

Current C# model mapping is:

- `class`, `record` -> `CLASS`
- `struct`, `record struct` -> `STRUCT`
- `interface` -> `INTERFACE`
- `enum` -> `ENUM`
- `delegate` -> `FUNCTION`
- `property`, `event`, `field`, record positional field -> `FIELD`

Resolution is intentionally fast and repo-local:
- builtins
- same-namespace lookup
- nested types
- `using` imports
- `using` aliases
- `global using`
- partial merged members
- simple constructor / member reference cases

It is not Roslyn-grade semantic resolution.

## Threading / Performance

- C# parsing runs in parallel per file using a fixed thread pool.
- It now shares `CLARPSE_PARALLELISM` behavior with Java.
- Resolution is index-based rather than repeated full scans.

## Validation

Verified with:
- `mvn -q -DskipTests compile`
- `mvn -q -Dtest='CSharp*' test`
- `mvn -DskipTests install`

I also installed the jar locally and validated downstream in `striff-lib`:
- targeted new C# tests passed
- full `striff-lib` test suite passed

## Known Limits

- external framework/library resolution is still heuristic
- parser / assembler internals are still denser than ideal and can be split further in a follow-up
- no `.csproj` / assembly-level semantic loading
- no overload-resolution / extension-method / full generic inference support
