### PR TITLE
Bound concurrent Node compiler daemons (default 1 per JVM)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>io.github.hadi-technology</groupId>
 	<artifactId>clarpse</artifactId>
-	<version>9.7.0</version>
+	<version>9.8.0</version>
 	<packaging>jar</packaging>
 
 	<name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/java/com/hadi/clarpse/compiler/NodeDaemonGate.java
+++ b/src/main/java/com/hadi/clarpse/compiler/NodeDaemonGate.java
@@ -1,0 +1,78 @@
+package com.hadi.clarpse.compiler;
+
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Bounds how many Node.js compiler daemons (TypeScript, Python) may run concurrently in
+ * this JVM.
+ *
+ * <p>Each daemon is spawned with {@code --max-old-space-size=clarpse.node.heapSize}
+ * (4 GiB by default) — a heap size the daemon genuinely needs for large repositories, so
+ * it cannot simply be lowered. What a memory-constrained host <em>can</em> control is how
+ * many such processes exist at once: with the default permit count of 1, the worst-case
+ * native footprint of node compilers is one daemon's heap instead of one per concurrent
+ * parse. Inside a container whose cgroup also hosts the JVM heap, that difference is what
+ * keeps the container under its memory limit.
+ *
+ * <p>Configure via system property or environment variable
+ * {@code clarpse.node.maxConcurrentDaemons} / {@code CLARPSE_NODE_MAX_CONCURRENT_DAEMONS}
+ * (falls back to the bundled clarpse.properties, default 1). Acquisition waits up to
+ * {@code clarpse.node.daemonPermitTimeoutSeconds} (default 600) so a leaked daemon fails
+ * loudly instead of stalling every future parse.
+ */
+public final class NodeDaemonGate {
+
+    private static final String MAX_CONCURRENT_PROP = "clarpse.node.maxConcurrentDaemons";
+    private static final String MAX_CONCURRENT_ENV = "CLARPSE_NODE_MAX_CONCURRENT_DAEMONS";
+    private static final String PERMIT_TIMEOUT_PROP = "clarpse.node.daemonPermitTimeoutSeconds";
+
+    private static final Semaphore PERMITS = new Semaphore(resolveMaxConcurrent(), true);
+
+    private NodeDaemonGate() {
+    }
+
+    private static int resolveMaxConcurrent() {
+        final String systemProp = System.getProperty(MAX_CONCURRENT_PROP);
+        if (systemProp != null && !systemProp.trim().isEmpty()) {
+            return Math.max(1, Integer.parseInt(systemProp.trim()));
+        }
+        final String envVar = System.getenv(MAX_CONCURRENT_ENV);
+        if (envVar != null && !envVar.trim().isEmpty()) {
+            return Math.max(1, Integer.parseInt(envVar.trim()));
+        }
+        return Math.max(1, ClarpseProperties.getInt(MAX_CONCURRENT_PROP, 1));
+    }
+
+    private static long permitTimeoutSeconds() {
+        final String systemProp = System.getProperty(PERMIT_TIMEOUT_PROP);
+        if (systemProp != null && !systemProp.trim().isEmpty()) {
+            return Long.parseLong(systemProp.trim());
+        }
+        return ClarpseProperties.getInt(PERMIT_TIMEOUT_PROP, 600);
+    }
+
+    /**
+     * Blocks until a daemon slot is free. Throws {@link IllegalStateException} if none
+     * frees up within the configured timeout — a symptom of a leaked daemon, which should
+     * fail loudly rather than silently serialize every parse behind it forever.
+     */
+    public static void acquire() {
+        final long timeout = permitTimeoutSeconds();
+        try {
+            if (!PERMITS.tryAcquire(timeout, TimeUnit.SECONDS)) {
+                throw new IllegalStateException(
+                        "Timed out after " + timeout + "s waiting for a node daemon slot ("
+                                + MAX_CONCURRENT_PROP + "=" + PERMITS.availablePermits()
+                                + " available). A previous daemon may have leaked without close().");
+            }
+        } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted while waiting for a node daemon slot.", e);
+        }
+    }
+
+    public static void release() {
+        PERMITS.release();
+    }
+}

--- a/src/main/java/com/hadi/clarpse/compiler/python/PythonDaemon.java
+++ b/src/main/java/com/hadi/clarpse/compiler/python/PythonDaemon.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.hadi.clarpse.compiler.ClarpseProperties;
 import com.hadi.clarpse.compiler.DaemonResourceExtractor;
+import com.hadi.clarpse.compiler.NodeDaemonGate;
 import com.hadi.clarpse.compiler.python.model.PythonFileModel;
 import com.hadi.clarpse.compiler.typescript.NodeRuntime;
 import org.apache.commons.io.FileUtils;
@@ -53,6 +54,7 @@ public final class PythonDaemon implements AutoCloseable {
     private BufferedReader reader;
     private int nextId = 1;
     private Path tempDir;
+    private boolean permitHeld;
 
     public void start() throws PythonDaemonException {
         if (process != null && process.isAlive()) {
@@ -67,13 +69,30 @@ public final class PythonDaemon implements AutoCloseable {
         final List<String> command = List.of(nodeCommand, "--max-old-space-size=" + resolveNodeHeapSize(), daemonScript.toString());
         final ProcessBuilder builder = new ProcessBuilder(command);
         builder.redirectError(ProcessBuilder.Redirect.INHERIT);
+        // The daemon's heap allowance is large by necessity; what keeps a constrained
+        // host alive is bounding how many daemons exist at once (see NodeDaemonGate).
+        try {
+            NodeDaemonGate.acquire();
+        } catch (final IllegalStateException e) {
+            throw new PythonDaemonException(e.getMessage(),
+                    PythonDaemonException.CODE_RESOLVER_START_FAILED, e);
+        }
+        permitHeld = true;
         try {
             process = builder.start();
             writer = new BufferedWriter(new OutputStreamWriter(process.getOutputStream(), StandardCharsets.UTF_8));
             reader = new BufferedReader(new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8));
         } catch (final IOException e) {
+            releasePermit();
             throw new PythonDaemonException("Failed to start Python daemon.",
                     PythonDaemonException.CODE_RESOLVER_START_FAILED, e);
+        }
+    }
+
+    private void releasePermit() {
+        if (permitHeld) {
+            permitHeld = false;
+            NodeDaemonGate.release();
         }
     }
 
@@ -202,6 +221,7 @@ public final class PythonDaemon implements AutoCloseable {
             FileUtils.deleteQuietly(tempDir.toFile());
             tempDir = null;
         }
+        releasePermit();
     }
 
     public static final class InitResult {

--- a/src/main/java/com/hadi/clarpse/compiler/typescript/TypeScriptDaemon.java
+++ b/src/main/java/com/hadi/clarpse/compiler/typescript/TypeScriptDaemon.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.hadi.clarpse.compiler.ClarpseProperties;
 import com.hadi.clarpse.compiler.DaemonResourceExtractor;
+import com.hadi.clarpse.compiler.NodeDaemonGate;
 import com.hadi.clarpse.compiler.typescript.model.TypeScriptFileModel;
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
@@ -56,6 +57,7 @@ public final class TypeScriptDaemon implements AutoCloseable {
     private BufferedReader reader;
     private int nextId = 1;
     private Path tempDir;
+    private boolean permitHeld;
 
     public void start() throws TypeScriptDaemonException {
         if (process != null && process.isAlive()) {
@@ -70,13 +72,30 @@ public final class TypeScriptDaemon implements AutoCloseable {
         final List<String> command = List.of(nodeCommand, "--max-old-space-size=" + resolveNodeHeapSize(), daemonScript.toString());
         final ProcessBuilder builder = new ProcessBuilder(command);
         builder.redirectError(ProcessBuilder.Redirect.INHERIT);
+        // The daemon's heap allowance is large by necessity; what keeps a constrained
+        // host alive is bounding how many daemons exist at once (see NodeDaemonGate).
+        try {
+            NodeDaemonGate.acquire();
+        } catch (final IllegalStateException e) {
+            throw new TypeScriptDaemonException(e.getMessage(),
+                    TypeScriptDaemonException.CODE_DAEMON_ERROR, e);
+        }
+        permitHeld = true;
         try {
             process = builder.start();
             writer = new BufferedWriter(new OutputStreamWriter(process.getOutputStream(), StandardCharsets.UTF_8));
             reader = new BufferedReader(new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8));
         } catch (final IOException e) {
+            releasePermit();
             throw new TypeScriptDaemonException("Failed to start TypeScript daemon.",
                     TypeScriptDaemonException.CODE_DAEMON_ERROR, e);
+        }
+    }
+
+    private void releasePermit() {
+        if (permitHeld) {
+            permitHeld = false;
+            NodeDaemonGate.release();
         }
     }
 
@@ -203,6 +222,7 @@ public final class TypeScriptDaemon implements AutoCloseable {
             FileUtils.deleteQuietly(tempDir.toFile());
             tempDir = null;
         }
+        releasePermit();
     }
 
     public static final class InitResult {

--- a/src/main/resources/clarpse.properties
+++ b/src/main/resources/clarpse.properties
@@ -4,3 +4,8 @@ clarpse.zip.maxEntryUncompressedBytes=10485760
 # Node.js heap size in MB for TypeScript and Python daemons (default: 4096)
 # Increase for large projects to avoid "JavaScript heap out of memory" errors
 clarpse.node.heapSize=4096
+# Max Node compiler daemons (TS/Python) running concurrently in this JVM. The per-daemon
+# heap (clarpse.node.heapSize) is large by necessity; bounding daemon COUNT is what keeps
+# a memory-constrained container under its cgroup limit.
+clarpse.node.maxConcurrentDaemons=1
+clarpse.node.daemonPermitTimeoutSeconds=600


### PR DESCRIPTION
## Why

Each TypeScript/Python daemon runs `node --max-old-space-size=4096` — heap it genuinely needs to parse large repos, so the size can't be reduced without breaking those parses. What was unbounded is the daemon **count**: old/new versions parse concurrently, and multiple analyses can run at once, so several 4GiB node processes could coexist inside one container cgroup next to the JVM heap.

## What

- `NodeDaemonGate`: JVM-wide fair semaphore, acquired when a daemon process is spawned, released on `close()` (including the spawn-failure path).
- Default **1 concurrent daemon per JVM**, configurable via `clarpse.node.maxConcurrentDaemons` (property/env/clarpse.properties).
- Acquisition waits up to `clarpse.node.daemonPermitTimeoutSeconds` (default 600) then fails loudly — a leaked daemon should be an error, not an invisible global serializer.
- Version 9.7.0 → 9.8.0.

## Effect on memory budgeting

Worst-case native node footprint per JVM drops from `N_concurrent_parses × 2 × 4GiB` to `1 × 4GiB`, which is what makes a 10Gi container limit honorable. TS/Python analyses serialize their old/new parses as a consequence (Java parsing is unaffected); that latency trade is deliberate.
