### PR TITLE
fix: auto-clean persisted ProjectFiles temp dirs via JVM-shutdown hook (9.8.1)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>io.github.hadi-technology</groupId>
 	<artifactId>clarpse</artifactId>
-	<version>9.8.0</version>
+	<version>9.8.1</version>
 	<packaging>jar</packaging>
 
 	<name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/java/com/hadi/clarpse/compiler/ProjectFiles.java
+++ b/src/main/java/com/hadi/clarpse/compiler/ProjectFiles.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
@@ -57,6 +58,24 @@ import java.util.zip.ZipInputStream;
 public class ProjectFiles implements AutoCloseable {
 
     private static final Logger LOGGER = LogManager.getLogger(ProjectFiles.class);
+
+    /**
+     * Temp dirs created by {@link #persistDir()} that have not yet been cleaned up. A single
+     * JVM-shutdown hook deletes whatever remains, so an interrupted or crashed process can no longer
+     * leak extracted-source temp dirs. Normal cleanup is still {@link #close()} (and the in-place
+     * cleanup in {@link #shiftSubDirsLeft()}), which also deregister here — so in steady state this
+     * set only holds currently-open projects and does not grow.
+     */
+    private static final Set<String> PENDING_TEMP_DIRS = ConcurrentHashMap.newKeySet();
+
+    static {
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            for (final String dir : PENDING_TEMP_DIRS) {
+                FileUtils.deleteQuietly(new File(dir));
+            }
+        }, "clarpse-projectfiles-tempdir-cleanup"));
+    }
+
     private static final int MAX_ZIP_ENTRIES = ClarpseProperties.getInt("clarpse.zip.maxEntries", 100000);
     private static final long MAX_TOTAL_UNCOMPRESSED_BYTES =
             ClarpseProperties.getLong("clarpse.zip.maxTotalUncompressedBytes", 200L * 1024 * 1024);
@@ -162,6 +181,7 @@ public class ProjectFiles implements AutoCloseable {
         this.configFiles.putAll(shiftedConfigFiles);
         if (this.tempProjectDir && this.projectDir != null && !this.projectDir.isEmpty()) {
             FileUtils.deleteQuietly(new File(this.projectDir));
+            PENDING_TEMP_DIRS.remove(this.projectDir);
             this.tempProjectDir = false;
             this.projectDir = null;
         }
@@ -397,6 +417,7 @@ public class ProjectFiles implements AutoCloseable {
     public void close() {
         if (this.tempProjectDir && this.projectDir != null && !this.projectDir.isEmpty()) {
             FileUtils.deleteQuietly(new File(this.projectDir));
+            PENDING_TEMP_DIRS.remove(this.projectDir);
             this.tempProjectDir = false;
         }
     }
@@ -444,6 +465,7 @@ public class ProjectFiles implements AutoCloseable {
         LOGGER.info(this.size() + " files were persisted in " + elapsedTime + " ms");
         this.projectDir = rootDir;
         this.tempProjectDir = true;
+        PENDING_TEMP_DIRS.add(rootDir);   // shutdown-hook backstop if close() never runs
     }
 
     private String resolvePersistedRelativePath(final String projectPath) {

--- a/src/test/java/com/hadi/test/ProjectFilesTest.java
+++ b/src/test/java/com/hadi/test/ProjectFilesTest.java
@@ -549,4 +549,31 @@ public class ProjectFilesTest {
         }
         return tmp;
     }
+
+    /**
+     * A persisted temp dir whose owner never calls {@link ProjectFiles#close()} must still be removed
+     * by the JVM-shutdown hook, so an interrupted or crashed process cannot leak extracted-source
+     * temp dirs. Runs a child JVM that persists and exits without closing, then asserts the dir is gone.
+     */
+    @Test
+    public void leakedTempDirIsDeletedByJvmShutdownHook() throws Exception {
+        String javaBin = System.getProperty("java.home") + File.separator + "bin" + File.separator + "java";
+        String classpath = System.getProperty("java.class.path");
+        Process proc = new ProcessBuilder(javaBin, "-cp", classpath, "com.hadi.test.TempDirLeakHelper")
+                .redirectErrorStream(true)
+                .start();
+        String output = new String(proc.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        proc.waitFor();
+
+        String tempDir = null;
+        for (String line : output.split("\\R")) {
+            if (line.startsWith("TEMPDIR:")) {
+                tempDir = line.substring("TEMPDIR:".length()).trim();
+            }
+        }
+        assertTrue("helper did not report a temp dir; child output:\n" + output,
+                tempDir != null && !tempDir.isEmpty());
+        assertFalse("temp dir leaked despite the shutdown hook: " + tempDir,
+                Files.exists(Paths.get(tempDir)));
+    }
 }

--- a/src/test/java/com/hadi/test/TempDirLeakHelper.java
+++ b/src/test/java/com/hadi/test/TempDirLeakHelper.java
@@ -1,0 +1,23 @@
+package com.hadi.test;
+
+import com.hadi.clarpse.compiler.ProjectFile;
+import com.hadi.clarpse.compiler.ProjectFiles;
+
+/**
+ * Test fixture run in a child JVM by {@code ProjectFilesTest}: it persists a {@link ProjectFiles}
+ * temp dir and then exits WITHOUT calling {@link ProjectFiles#close()}, so the parent test can assert
+ * that clarpse's JVM-shutdown hook deleted the otherwise-leaked temp dir. The persisted dir path is
+ * printed prefixed with {@code TEMPDIR:} for the parent to read back.
+ */
+public final class TempDirLeakHelper {
+
+    private TempDirLeakHelper() {
+    }
+
+    public static void main(final String[] args) {
+        final ProjectFiles projectFiles = new ProjectFiles();
+        projectFiles.insertFile(new ProjectFile("/leak/A.java", "package leak; class A {}"));
+        System.out.println("TEMPDIR:" + projectFiles.projectDir());
+        // Intentionally NOT closed: the shutdown hook must clean the temp dir on JVM exit.
+    }
+}


### PR DESCRIPTION
## Problem

`ProjectFiles.persistDir()` extracts source into a temp dir under `java.io.tmpdir` but registers **no exit-time safety net**. Normal cleanup is `close()` (called by the consumer), but if a process is interrupted or crashes before `close()` runs, the temp dir leaks **permanently**. Observed while batch-processing many repos: an interrupted/killed run left ~180 orphaned `tmp/<16-char>` dirs per PR piling up.

This is the one temp-dir creator in clarpse *without* a backstop — `DaemonResourceExtractor` and `ClarpseServer` already use `deleteOnExit`/shutdown hooks.

## Fix

- A bounded static registry of persisted temp dirs plus a **single JVM-shutdown hook** that deletes whatever is still open at exit.
- `persistDir()` registers; `close()` and the `shiftSubDirsLeft()` cleanup path deregister — so in steady state the registry only holds currently-open projects and does not grow. Normal `close()` cleanup is unchanged.

## Test

`ProjectFilesTest#leakedTempDirIsDeletedByJvmShutdownHook` runs a **child JVM** that persists and exits *without* closing, then asserts the temp dir was deleted by the hook. Full `ProjectFilesTest` green (36/36); Checkstyle 0, PMD clean.

Bumps `9.8.0 → 9.8.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)