### PR TITLE
fix: register C# generic type declarations under their erased name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>io.github.hadi-technology</groupId>
 	<artifactId>clarpse</artifactId>
-	<version>9.8.1</version>
+	<version>9.8.2</version>
 	<packaging>jar</packaging>
 
 	<name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/java/com/hadi/clarpse/compiler/csharp/CSharpFileParser.java
+++ b/src/main/java/com/hadi/clarpse/compiler/csharp/CSharpFileParser.java
@@ -856,7 +856,10 @@ final class CSharpFileParser {
             return "";
         }
         final int typeParamStart = identifier.indexOf('<');
-        return typeParamStart < 0 ? identifier : identifier.substring(0, typeParamStart).trim();
+        if (typeParamStart < 0) {
+            return identifier;
+        }
+        return identifier.substring(0, typeParamStart).trim();
     }
 
     private static String namespaceName(final SyntaxNode node) {

--- a/src/main/java/com/hadi/clarpse/compiler/csharp/CSharpFileParser.java
+++ b/src/main/java/com/hadi/clarpse/compiler/csharp/CSharpFileParser.java
@@ -335,7 +335,7 @@ final class CSharpFileParser {
                 typeModel.kind = "recordStruct";
             }
         }
-        typeModel.name = firstIdentifier(node);
+        typeModel.name = eraseTypeParameterList(firstIdentifier(node));
         if (namespaceName == null) {
             typeModel.namespaceName = "";
         } else {
@@ -840,6 +840,23 @@ final class CSharpFileParser {
 
     private static String firstIdentifier(final SyntaxNode node) {
         return firstDirectChildText(node, "cs:id-role");
+    }
+
+    /**
+     * Generic type declarations carry their type-parameter list in the identifier text
+     * ("Repo&lt;T&gt;"), but references are resolved against the erased name ("Repo").
+     * Register declarations under the erased name so generic types are reachable as
+     * reference targets; without this every generic class or interface is an orphan
+     * component with zero afferent coupling. C#'s arity-overloaded types (IFoo and
+     * IFoo&lt;T&gt;) collapse onto one component, which matches how references, which
+     * carry no arity, are resolved anyway.
+     */
+    private static String eraseTypeParameterList(final String identifier) {
+        if (identifier == null) {
+            return "";
+        }
+        final int typeParamStart = identifier.indexOf('<');
+        return typeParamStart < 0 ? identifier : identifier.substring(0, typeParamStart).trim();
     }
 
     private static String namespaceName(final SyntaxNode node) {

--- a/src/test/java/com/hadi/test/csharp/CSharpCrossFileResolutionTest.java
+++ b/src/test/java/com/hadi/test/csharp/CSharpCrossFileResolutionTest.java
@@ -1,0 +1,65 @@
+package com.hadi.test.csharp;
+
+import com.hadi.clarpse.compiler.ProjectFile;
+import com.hadi.clarpse.sourcemodel.OOPSourceCodeModel;
+import com.hadi.clarpse.sourcemodel.OOPSourceModelConstants;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Cross-FILE reference resolution: the dominant shape in real repositories, where a class
+ * references types declared in other files, both in the same namespace (no using directive
+ * needed in C#) and in a different namespace (via a using directive).
+ */
+public class CSharpCrossFileResolutionTest {
+
+    private static OOPSourceCodeModel model;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        model = CSharpTestUtil.compileInline(
+                new ProjectFile("/Services/OrderService.cs", """
+                        namespace Acme.Services;
+                        using Acme.Data;
+                        public class OrderService {
+                          private readonly Validator validator = new Validator();
+                          public OrderRepo Repo { get; set; }
+                          public void Submit() { validator.Check(); Repo.Persist(); }
+                        }
+                        """),
+                new ProjectFile("/Services/Validator.cs", """
+                        namespace Acme.Services;
+                        public class Validator {
+                          public void Check() {}
+                        }
+                        """),
+                new ProjectFile("/Data/OrderRepo.cs", """
+                        namespace Acme.Data;
+                        public class OrderRepo {
+                          public void Persist() {}
+                        }
+                        """)
+        ).model();
+    }
+
+    private static boolean componentReferences(final String component, final String target) {
+        return model.getComponent(component).get().references().stream()
+                .anyMatch(ref -> ref.invokedComponent().equals(target));
+    }
+
+    @Test
+    public void sameNamespaceCrossFileReferenceIsResolved() {
+        // Validator lives in another file but the same namespace: no using directive exists
+        // or is required, which is the single most common reference shape in C# codebases.
+        assertTrue("OrderService should reference Acme.Services.Validator",
+                componentReferences("Acme.Services.OrderService", "Acme.Services.Validator"));
+    }
+
+    @Test
+    public void crossNamespaceCrossFileReferenceIsResolved() {
+        assertTrue("OrderService should reference Acme.Data.OrderRepo",
+                componentReferences("Acme.Services.OrderService", "Acme.Data.OrderRepo"));
+    }
+}

--- a/src/test/java/com/hadi/test/csharp/CSharpModernPatternsResolutionTest.java
+++ b/src/test/java/com/hadi/test/csharp/CSharpModernPatternsResolutionTest.java
@@ -1,0 +1,144 @@
+package com.hadi.test.csharp;
+
+import com.hadi.clarpse.compiler.ProjectFile;
+import com.hadi.clarpse.reference.TypeExtensionReference;
+import com.hadi.clarpse.reference.TypeImplementationReference;
+import com.hadi.clarpse.sourcemodel.OOPSourceCodeModel;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Resolution coverage for the reference shapes that dominate modern C# codebases: constructor
+ * injection, generic inheritance, nested generic type arguments, fully-qualified references,
+ * global usings, and C# 12 primary constructors. Each shape must produce a resolved edge to
+ * the declared component, since striff's coupling and boundary detectors are starved when any
+ * of them silently fail.
+ */
+public class CSharpModernPatternsResolutionTest {
+
+    private static OOPSourceCodeModel model;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        model = CSharpTestUtil.compileInline(
+                new ProjectFile("/GlobalUsings.cs", """
+                        global using Acme.Contracts;
+                        """),
+                new ProjectFile("/Contracts/IHandler.cs", """
+                        namespace Acme.Contracts;
+                        public interface IHandler<TCommand> {
+                          void Handle(TCommand command);
+                        }
+                        """),
+                new ProjectFile("/Contracts/ServiceBase.cs", """
+                        namespace Acme.Contracts;
+                        public abstract class ServiceBase<T> {
+                        }
+                        """),
+                new ProjectFile("/Domain/Order.cs", """
+                        namespace Acme.Domain;
+                        public class Order {
+                        }
+                        """),
+                new ProjectFile("/Services/OrderHandler.cs", """
+                        using System.Collections.Generic;
+                        using Acme.Domain;
+
+                        namespace Acme.Services;
+
+                        public class OrderHandler : ServiceBase<Order>, IHandler<Order> {
+                          private readonly IDictionary<string, List<Order>> cache;
+                          private readonly Acme.Domain.Order template = new Acme.Domain.Order();
+                          public OrderHandler(IHandler<Order> inner) { }
+                          public void Handle(Order command) { }
+                        }
+                        """),
+                new ProjectFile("/Services/AuditService.cs", """
+                        using Acme.Domain;
+
+                        namespace Acme.Services;
+
+                        public class AuditService(Order lastOrder) {
+                          public Order LastOrder => lastOrder;
+                        }
+                        """)
+        ).model();
+    }
+
+    private static boolean anyRefTo(final String component, final String target) {
+        return model.getComponent(component)
+                .map(c -> c.references().stream().anyMatch(r -> r.invokedComponent().equals(target)))
+                .orElse(false);
+    }
+
+    @Test
+    public void genericBaseClassProducesExtensionReference() {
+        assertTrue("OrderHandler should extend Acme.Contracts.ServiceBase",
+                model.getComponent("Acme.Services.OrderHandler").get()
+                        .references(com.hadi.clarpse.sourcemodel.OOPSourceModelConstants.TypeReferences.EXTENSION)
+                        .contains(new TypeExtensionReference("Acme.Contracts.ServiceBase")));
+    }
+
+    @Test
+    public void genericInterfaceProducesImplementationReference() {
+        assertTrue("OrderHandler should implement Acme.Contracts.IHandler",
+                model.getComponent("Acme.Services.OrderHandler").get()
+                        .references(com.hadi.clarpse.sourcemodel.OOPSourceModelConstants.TypeReferences.IMPLEMENTATION)
+                        .contains(new TypeImplementationReference("Acme.Contracts.IHandler")));
+    }
+
+    @Test
+    public void constructorInjectionParameterResolves() {
+        assertTrue("ctor injection should reference Acme.Contracts.IHandler",
+                anyRefTo("Acme.Services.OrderHandler", "Acme.Contracts.IHandler"));
+    }
+
+    @Test
+    public void nestedGenericTypeArgumentResolves() {
+        assertTrue("IDictionary<string, List<Order>> should reference Acme.Domain.Order",
+                anyRefTo("Acme.Services.OrderHandler.cache", "Acme.Domain.Order"));
+    }
+
+    @Test
+    public void fullyQualifiedReferenceResolves() {
+        assertTrue("Acme.Domain.Order inline qualified ref should resolve",
+                anyRefTo("Acme.Services.OrderHandler.template", "Acme.Domain.Order"));
+    }
+
+    @Test
+    public void globalUsingFromAnotherFileResolvesContracts() {
+        // ServiceBase/IHandler are visible in OrderHandler.cs only through GlobalUsings.cs.
+        assertTrue("global using should make Acme.Contracts resolvable without a local using",
+                anyRefTo("Acme.Services.OrderHandler", "Acme.Contracts.ServiceBase"));
+    }
+
+    @Test
+    public void primaryConstructorParameterResolves() {
+        assertTrue("C# 12 primary ctor parameter should reference Acme.Domain.Order",
+                anyRefTo("Acme.Services.AuditService", "Acme.Domain.Order"));
+    }
+
+    @Test
+    public void arityOverloadedTypesDoNotBreakTheModel() throws Exception {
+        // IFoo and IFoo<T> legally coexist; after erasure they collapse onto one component.
+        // The model must stay consistent and keep the type reachable as a reference target.
+        OOPSourceCodeModel arity = CSharpTestUtil.compileInline(
+                new ProjectFile("/A.cs", """
+                        namespace Demo;
+                        public interface IFoo { }
+                        public interface IFoo<T> { }
+                        public class User {
+                          public IFoo Plain { get; set; }
+                          public IFoo<int> Generic { get; set; }
+                        }
+                        """)
+        ).model();
+        assertTrue(arity.getComponent("Demo.IFoo").isPresent());
+        assertTrue(arity.getComponent("Demo.User.Plain").get().references().stream()
+                .anyMatch(r -> r.invokedComponent().equals("Demo.IFoo")));
+        assertTrue(arity.getComponent("Demo.User.Generic").get().references().stream()
+                .anyMatch(r -> r.invokedComponent().equals("Demo.IFoo")));
+    }
+}

--- a/src/test/java/com/hadi/test/csharp/CSharpRealisticLayoutResolutionTest.java
+++ b/src/test/java/com/hadi/test/csharp/CSharpRealisticLayoutResolutionTest.java
@@ -1,0 +1,81 @@
+package com.hadi.test.csharp;
+
+import com.hadi.clarpse.compiler.ProjectFile;
+import com.hadi.clarpse.sourcemodel.OOPSourceCodeModel;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Same cross-file scenarios as {@link CSharpCrossFileResolutionTest}, but written the way
+ * real C# files are laid out: using directives at the top of the file BEFORE the namespace
+ * declaration (both file-scoped and block-scoped forms), plus a generic type reference.
+ */
+public class CSharpRealisticLayoutResolutionTest {
+
+    private static OOPSourceCodeModel model;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        model = CSharpTestUtil.compileInline(
+                new ProjectFile("/Services/OrderService.cs", """
+                        using Acme.Data;
+                        using Acme.Logging;
+
+                        namespace Acme.Services;
+
+                        public class OrderService {
+                          private readonly ILog<OrderService> log;
+                          public OrderRepo Repo { get; set; }
+                          public void Submit() { Repo.Persist(); }
+                        }
+                        """),
+                new ProjectFile("/Legacy/ReportService.cs", """
+                        using Acme.Data;
+
+                        namespace Acme.Legacy
+                        {
+                            public class ReportService
+                            {
+                                public OrderRepo Source { get; set; }
+                            }
+                        }
+                        """),
+                new ProjectFile("/Data/OrderRepo.cs", """
+                        namespace Acme.Data;
+                        public class OrderRepo {
+                          public void Persist() {}
+                        }
+                        """),
+                new ProjectFile("/Logging/ILog.cs", """
+                        namespace Acme.Logging;
+                        public interface ILog<T> {
+                        }
+                        """)
+        ).model();
+    }
+
+    private static boolean componentReferences(final String component, final String target) {
+        return model.getComponent(component).get().references().stream()
+                .anyMatch(ref -> ref.invokedComponent().equals(target));
+    }
+
+    @Test
+    public void usingsBeforeFileScopedNamespaceResolveCrossNamespaceReferences() {
+        assertTrue("OrderService should reference Acme.Data.OrderRepo",
+                componentReferences("Acme.Services.OrderService", "Acme.Data.OrderRepo"));
+    }
+
+    @Test
+    public void usingsBeforeBlockScopedNamespaceResolveCrossNamespaceReferences() {
+        assertTrue("ReportService should reference Acme.Data.OrderRepo",
+                componentReferences("Acme.Legacy.ReportService", "Acme.Data.OrderRepo"));
+    }
+
+    @Test
+    public void genericInterfaceReferenceResolvesToItsDeclaration() {
+        assertTrue("OrderService should reference Acme.Logging.ILog",
+                componentReferences("Acme.Services.OrderService", "Acme.Logging.ILog"));
+    }
+}


### PR DESCRIPTION
## Problem

Generic C# type declarations registered their component name with the type-parameter list included (`Repo<T>`), while the reference-resolution side resolves against the erased name (`Repo`). Every generic class and interface was therefore an **orphan node**: unreachable as a reference target, afferent coupling stuck at zero.

Real-world impact: DI-heavy codebases (Bitwarden, Semantic Kernel, Orleans, MassTransit), where the load-bearing contracts are all generic (`ILogger<T>`, `IRepository<T>`, `IHandler<TCommand>`), produced near-empty relationship graphs downstream in Striff, which starved its coupling and boundary detectors of findings. Verified against real `dotnet/orleans` sources: before the fix `IGrainFactory`-style interfaces received zero incoming references; after, cross-file and cross-namespace edges resolve normally.

## Fix

`CSharpFileParser.parseType` now erases the type-parameter list from the declared name (`eraseTypeParameterList`). Arity-overloaded types (`IFoo` and `IFoo<T>`) collapse onto one component, which mirrors the arity-less reference side.

## Coverage added

- `CSharpCrossFileResolutionTest`: cross-file resolution in the same namespace (no `using` needed) and across namespaces — previously all reference tests were single-file.
- `CSharpRealisticLayoutResolutionTest`: usings-before-namespace layout (file-scoped and block forms) plus the failing generic-reference case that exposed the bug.
- `CSharpModernPatternsResolutionTest`: generic inheritance, generic interface implementation, constructor injection, nested generic type arguments, fully-qualified references, cross-file `global using`, C# 12 primary constructors, and arity-overload model consistency.

Full suite: 644 tests green. Version bumped to 9.8.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X9W3whWjXLxAQFHY61Gk61