### PR TITLE
feat!: model Java records, and make codeHash and modifiers mean the same thing in every language

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Clarpse is a multi-language architectural code analysis library for building bet
 <dependency>
   <groupId>io.github.hadi-technology</groupId>
   <artifactId>clarpse</artifactId>
-<version>9.9.0</version>
+<version>10.0.0</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Clarpse is a multi-language architectural code analysis library for building bet
 <dependency>
   <groupId>io.github.hadi-technology</groupId>
   <artifactId>clarpse</artifactId>
-<version>9.5.1</version>
+<version>9.9.0</version>
 </dependency>
 ```
 
@@ -19,7 +19,7 @@ Clarpse is a multi-language parsing and analysis library that converts source co
 
 # Features
 
- - Supports **Java** with a lightweight, architecture-focused parser.
+ - Supports **Java** with a lightweight, architecture-focused parser, including records.
  - Supports **C#** with JVM-based parsing, partial type merging, namespace-aware indexing, and fast in-repo symbol resolution.
  - Supports **TypeScript** with compiler-accurate, tsconfig-aware parsing and resolution, including constructor parameter property detection and monorepo support.
  - Supports **Python** with Pyright-backed parsing, including nested classes, comment parsing, cyclomatic complexity, code hashing, and visibility inference.

--- a/docs/python-architecture.md
+++ b/docs/python-architecture.md
@@ -22,7 +22,7 @@ class diagrams while treating external libraries as labels only.
 - Extract docstrings and comments for components.
 - Calculate cyclomatic complexity for methods and functions.
 - Generate code hashes for change detection.
-- Infer visibility modifiers for methods (public/private based on name prefix).
+- Infer visibility modifiers for classes and members (public/protected/private based on name prefix).
 
 # Identity and Naming
 Unique names follow the existing Clarpse rule.
@@ -74,8 +74,9 @@ and can be mapped through imports or local class declarations.
 - Nested classes are fully supported with proper unique name chaining.
 - Docstrings are extracted and attached to the component's comment field.
 - Cyclomatic complexity is calculated and stored in the component's cyclo field.
-- Code hashes are generated from implementation hashes or signature hashes for change detection.
-- Method visibility is inferred: methods starting with `_` are marked as private.
+- Every component carries a non-zero code hash, derived from its full declaration, for change detection.
+- Visibility is inferred from naming: `__` is private, `_` is protected, everything else is public.
+- `@staticmethod` and `@classmethod` are reported as `static`.
 
 # JSON Protocol
 Requests use line delimited JSON.
@@ -126,16 +127,22 @@ Python docstrings are extracted and attached to components using the standard do
 Method and function cyclomatic complexity is calculated by the Pyright daemon and stored in the component's cyclo field. This provides a measure of code complexity for architectural analysis.
 
 ## Code Hashing
-Each method and function includes a code hash for change detection:
-- If an implementation hash is provided by the daemon, it is used directly.
-- Otherwise, the signature hash is used as a fallback.
-- This enables downstream tools to detect when method implementations have changed.
+Every component carries a non-zero code hash for change detection:
+- The daemon hashes the whole declaration - a class body, a `def` including its signature and
+  decorators, a field statement, a parameter - so that an implementation edit changes the hash while a
+  reformat or comment edit does not.
+- If the daemon had nothing to hash, the signature hash is used as a fallback, and failing that the
+  component's name.
+- A hash of zero is therefore never emitted, and means "never computed".
+- This enables downstream tools to detect when implementations have changed.
 
 ## Visibility Inference
-Python methods are tagged with visibility modifiers based on naming conventions:
-- Methods starting with `_` (single underscore) are marked as private.
-- Methods starting with `__` (double underscore) are marked as private.
-- All other methods are considered public.
+Python has no visibility keywords, so members are tagged from naming conventions:
+- Names starting with `__` (double underscore, not dunder) are name-mangled, and marked private.
+- Names starting with `_` (single underscore) are marked protected.
+- Everything else - dunder methods included - is importable, and marked public explicitly.
+- This applies to classes, methods, functions, fields and module variables alike.
+- `@staticmethod` and `@classmethod` both add the `static` modifier.
 
 ## Nested Classes
 Python supports nested class definitions, and these are fully modeled:

--- a/docs/typescript-architecture.md
+++ b/docs/typescript-architecture.md
@@ -136,6 +136,18 @@ TypeScript's parameter properties are fully supported:
 ## Code Fragment Support
 Method and function signatures are captured as code fragments for display and analysis purposes.
 
+## Code Hashing
+Every component carries a non-zero code hash for change detection:
+- The daemon hashes the whole declaration - a class body, a method including its signature, a property,
+  a parameter - so an implementation edit changes the hash while a reformat does not.
+- If there was nothing to hash, the code fragment is used as a fallback, then the component's name, so
+  a hash of zero is never emitted and means "never computed".
+
+## Export as Visibility
+`export` puts a declaration on the module's public surface, so an exported declaration reports both
+`export` and `public`. A module-private declaration reports neither, matching the way a package-private
+Java type reports no visibility at all.
+
 # Non-Goals
 - No heuristic or string-based fallback resolution; symbol/type resolution is compiler-backed only.
 - No fallback parsing.

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>io.github.hadi-technology</groupId>
 	<artifactId>clarpse</artifactId>
-	<version>9.9.0</version>
+	<version>10.0.0</version>
 	<packaging>jar</packaging>
 
 	<name>${project.groupId}:${project.artifactId}</name>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>io.github.hadi-technology</groupId>
 	<artifactId>clarpse</artifactId>
-	<version>9.8.2</version>
+	<version>9.9.0</version>
 	<packaging>jar</packaging>
 
 	<name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/java/com/hadi/clarpse/compiler/csharp/CSharpFileParser.java
+++ b/src/main/java/com/hadi/clarpse/compiler/csharp/CSharpFileParser.java
@@ -357,6 +357,7 @@ final class CSharpFileParser {
             typeModel.componentName = parentTypeComponentName + "." + typeModel.name;
         }
         typeModel.codeFragment = buildTypeCodeFragment(node.text);
+        typeModel.implementationHash = implementationHash(node.text);
 
         for (final SyntaxNode child : node.children) {
             if ("cs:type-usage-role".equals(child.type) && isDirectBaseType(child, node)) {
@@ -481,6 +482,7 @@ final class CSharpFileParser {
                     parameter.name = firstIdentifier(child);
                     parameter.declaredType = firstDirectChildText(child, "cs:type-usage-role");
                     parameter.modifiers = parseModifiers(child.text);
+                    parameter.implementationHash = implementationHash(child.text);
                     member.parameters.add(parameter);
                 }
             }
@@ -576,6 +578,7 @@ final class CSharpFileParser {
         member.endOffset = node.endOffset;
         member.imports = new LinkedHashSet<>(ownerType.imports);
         member.codeFragment = buildMemberCodeFragment(kind, name, member.declaredType, member.returnType, node.text);
+        member.implementationHash = implementationHash(node.text);
         if (member.declaredType != null && !member.declaredType.isEmpty()) {
             member.simpleTypeUsages.add(member.declaredType);
         }
@@ -600,6 +603,7 @@ final class CSharpFileParser {
                 member.declaredType = firstDirectChildText(child, "cs:type-usage-role");
                 member.modifiers = parseModifiers(child.text);
                 member.codeFragment = trimTypeText(member.declaredType);
+                member.implementationHash = implementationHash(child.text);
                 if (member.declaredType != null && !member.declaredType.isEmpty()) {
                     member.simpleTypeUsages.add(member.declaredType);
                 }
@@ -636,6 +640,26 @@ final class CSharpFileParser {
         }
         final SyntaxNode block = firstChild(parent, "cs:block-list");
         return block == null || child.endOffset <= block.startOffset;
+    }
+
+    /**
+     * Hashes a declaration's full source text - body included - with all whitespace stripped, so that
+     * reformatting is invisible but any change to the implementation is not. Zero is reserved for "no
+     * text to hash", which lets callers fall back to a signature-derived hash.
+     */
+    static int implementationHash(final String text) {
+        if (text == null) {
+            return 0;
+        }
+        final String stripped = text.replaceAll("\\s+", "");
+        if (stripped.isEmpty()) {
+            return 0;
+        }
+        final int hash = stripped.hashCode();
+        if (hash == 0) {
+            return 1;
+        }
+        return hash;
     }
 
     private static String buildTypeCodeFragment(final String text) {

--- a/src/main/java/com/hadi/clarpse/compiler/csharp/CSharpModel.java
+++ b/src/main/java/com/hadi/clarpse/compiler/csharp/CSharpModel.java
@@ -95,6 +95,8 @@ final class CSharpModel {
         boolean partial;
         int startOffset;
         int endOffset;
+        /** Hash over the whole declaration, body included, so that implementation edits are visible. */
+        int implementationHash;
         List<String> modifiers = new ArrayList<>();
         List<String> baseTypes = new ArrayList<>();
         List<CSharpMemberModel> members = new ArrayList<>();
@@ -117,6 +119,8 @@ final class CSharpModel {
         int startOffset;
         int endOffset;
         int cyclo;
+        /** Hash over the whole declaration, body included, so that implementation edits are visible. */
+        int implementationHash;
         List<String> modifiers = new ArrayList<>();
         List<CSharpParameterModel> parameters = new ArrayList<>();
         List<CSharpMemberModel> locals = new ArrayList<>();
@@ -130,6 +134,8 @@ final class CSharpModel {
         String name;
         String declaredType;
         String comment = "";
+        /** Hash over the whole parameter declaration, its modifiers and default value included. */
+        int implementationHash;
         List<String> modifiers = new ArrayList<>();
     }
 }

--- a/src/main/java/com/hadi/clarpse/compiler/csharp/CSharpModelAssembler.java
+++ b/src/main/java/com/hadi/clarpse/compiler/csharp/CSharpModelAssembler.java
@@ -81,6 +81,9 @@ final class CSharpModelAssembler {
                 continue;
             }
             existing.partial = existing.partial || typeModel.partial;
+            // Summed rather than folded in sequence, so that the merged hash does not depend on the
+            // order the partial declarations happened to be parsed in.
+            existing.implementationHash += typeModel.implementationHash;
             existing.baseTypes.addAll(typeModel.baseTypes);
             existing.members.addAll(typeModel.members);
             existing.nestedTypes.addAll(typeModel.nestedTypes);
@@ -196,9 +199,6 @@ final class CSharpModelAssembler {
         for (final CSharpModel.CSharpMemberModel member : members) {
             insertMember(member, typeModel, typeIndex, model, stack);
         }
-        if (typeComponent.componentType().isMethodComponent() && typeModel.codeFragment != null) {
-            typeComponent.setCodeHash(typeModel.codeFragment.hashCode());
-        }
         model.insertComponent(typeComponent);
         stack.pop();
         ParseUtil.copyRefsToParents(typeComponent, stack);
@@ -221,9 +221,28 @@ final class CSharpModelAssembler {
         component.setAccessModifiers(typeModel.modifiers);
         if (typeModel.codeFragment != null && !typeModel.codeFragment.isEmpty()) {
             component.setCodeFragment(typeModel.codeFragment);
-            component.setCodeHash(typeModel.codeFragment.hashCode());
         }
+        applyCodeHash(component, typeModel.implementationHash, typeModel.codeFragment);
         return component;
+    }
+
+    /**
+     * Sets the component's code hash, preferring the hash over its full declaration so that a body edit
+     * is detectable, and falling back to the component's signature when there was no text to hash. Every
+     * component ends up with a non-zero hash, so a zero unambiguously means "never computed".
+     */
+    private static void applyCodeHash(final Component component, final int implementationHash, final String fallback) {
+        int hash = implementationHash;
+        if (hash == 0 && fallback != null) {
+            hash = fallback.hashCode();
+        }
+        if (hash == 0) {
+            hash = component.componentName().hashCode();
+        }
+        if (hash == 0) {
+            hash = 1;
+        }
+        component.setCodeHash(hash);
     }
 
     private static void insertMember(final CSharpModel.CSharpMemberModel memberModel,
@@ -288,8 +307,8 @@ final class CSharpModelAssembler {
         component.setComponentName(ownerType.componentName + "." + memberComponentIdentifier(memberModel, ownerType));
         if (memberModel.codeFragment != null && !memberModel.codeFragment.isEmpty()) {
             component.setCodeFragment(memberModel.codeFragment);
-            component.setCodeHash(memberModel.codeFragment.hashCode());
         }
+        applyCodeHash(component, memberModel.implementationHash, memberModel.codeFragment);
         return component;
     }
 
@@ -313,6 +332,7 @@ final class CSharpModelAssembler {
         if (parameter.declaredType != null && !parameter.declaredType.isEmpty()) {
             component.setCodeFragment(parameter.declaredType);
         }
+        applyCodeHash(component, parameter.implementationHash, parameter.declaredType);
         return component;
     }
 
@@ -331,6 +351,7 @@ final class CSharpModelAssembler {
         if (localModel.codeFragment != null && !localModel.codeFragment.isEmpty()) {
             component.setCodeFragment(localModel.codeFragment);
         }
+        applyCodeHash(component, localModel.implementationHash, localModel.codeFragment);
         return component;
     }
 

--- a/src/main/java/com/hadi/clarpse/compiler/python/PythonModelAssembler.java
+++ b/src/main/java/com/hadi/clarpse/compiler/python/PythonModelAssembler.java
@@ -173,6 +173,8 @@ final class PythonModelAssembler {
         component.setName(classModel.className);
         component.setComponentName(CompilerSupport.componentNameFromUniqueName(packageName, classModel.uniqueName));
         component.setSourceFilePath(sourcePath);
+        applyVisibility(component, classModel.className);
+        applyCodeHash(component, classModel.implementationHash, classModel.className);
         if (classModel.comment != null && !classModel.comment.isEmpty()) {
             component.setComment(classModel.comment);
         }
@@ -204,9 +206,11 @@ final class PythonModelAssembler {
         final String fieldUniqueName = CompilerSupport.uniqueNameForMember(classModel.uniqueName, field.name);
         component.setComponentName(CompilerSupport.componentNameFromUniqueName(packageName, fieldUniqueName));
         component.setSourceFilePath(sourcePath);
+        applyVisibility(component, field.name);
         if (field.rawType != null && !field.rawType.isEmpty()) {
-            applyCodeFragmentHash(component, field.name + " : " + field.rawType);
+            component.setCodeFragment(field.name + " : " + field.rawType);
         }
+        applyCodeHash(component, field.implementationHash, component.codeFragment());
         final PythonTypeRefModel typeRef = new PythonTypeRefModel();
         typeRef.raw = field.rawType;
         typeRef.targetUniqueName = field.targetUniqueName;
@@ -240,9 +244,11 @@ final class PythonModelAssembler {
         final String fieldUniqueName = CompilerSupport.uniqueNameForMember(base, field.name);
         component.setComponentName(CompilerSupport.componentNameFromUniqueName(packageName, fieldUniqueName));
         component.setSourceFilePath(sourcePath);
+        applyVisibility(component, field.name);
         if (field.rawType != null && !field.rawType.isEmpty()) {
-            applyCodeFragmentHash(component, field.name + " : " + field.rawType);
+            component.setCodeFragment(field.name + " : " + field.rawType);
         }
+        applyCodeHash(component, field.implementationHash, component.codeFragment());
         final PythonTypeRefModel typeRef = new PythonTypeRefModel();
         typeRef.raw = field.rawType;
         typeRef.targetUniqueName = field.targetUniqueName;
@@ -280,18 +286,16 @@ final class PythonModelAssembler {
         if (method.comment != null && !method.comment.isEmpty()) {
             component.setComment(method.comment);
         }
-        final String visibility = inferPythonVisibility(method.name);
-        if (visibility != null) {
-            component.insertAccessModifier(visibility);
+        applyVisibility(component, method.name);
+        // @staticmethod and @classmethod both mean "not bound to an instance", which is what `static`
+        // means everywhere else in the model.
+        if (method.staticMethod || method.classMethod) {
+            component.insertAccessModifier("static");
         }
         if (method.signature != null && !method.signature.isEmpty()) {
             component.setCodeFragment(method.signature);
         }
-        if (method.implementationHash != 0) {
-            component.setCodeHash(method.implementationHash);
-        } else if (method.signature != null && !method.signature.isEmpty()) {
-            component.setCodeHash(method.signature.hashCode());
-        }
+        applyCodeHash(component, method.implementationHash, method.signature);
         if (method.returnType != null) {
             final ComponentReference ref = buildReference(method.returnType, false);
             if (ref != null && !ref.invokedComponent().equals(component.uniqueName())) {
@@ -328,14 +332,11 @@ final class PythonModelAssembler {
         if (function.comment != null && !function.comment.isEmpty()) {
             component.setComment(function.comment);
         }
+        applyVisibility(component, function.name);
         if (function.signature != null && !function.signature.isEmpty()) {
             component.setCodeFragment(function.signature);
         }
-        if (function.implementationHash != 0) {
-            component.setCodeHash(function.implementationHash);
-        } else if (function.signature != null && !function.signature.isEmpty()) {
-            component.setCodeHash(function.signature.hashCode());
-        }
+        applyCodeHash(component, function.implementationHash, function.signature);
         if (function.returnType != null) {
             final ComponentReference ref = buildReference(function.returnType, false);
             if (ref != null && !ref.invokedComponent().equals(component.uniqueName())) {
@@ -378,8 +379,9 @@ final class PythonModelAssembler {
         component.setComponentName(CompilerSupport.componentNameFromUniqueName(packageName, paramUniqueName));
         component.setSourceFilePath(sourcePath);
         if (param.rawType != null && !param.rawType.isEmpty()) {
-            applyCodeFragmentHash(component, param.rawType);
+            component.setCodeFragment(param.rawType);
         }
+        applyCodeHash(component, param.implementationHash, param.rawType);
         final PythonTypeRefModel typeRef = new PythonTypeRefModel();
         typeRef.raw = param.rawType;
         typeRef.targetUniqueName = param.targetUniqueName;
@@ -409,8 +411,9 @@ final class PythonModelAssembler {
         component.setComponentName(CompilerSupport.componentNameFromUniqueName(packageName, paramUniqueName));
         component.setSourceFilePath(sourcePath);
         if (param.rawType != null && !param.rawType.isEmpty()) {
-            applyCodeFragmentHash(component, param.rawType);
+            component.setCodeFragment(param.rawType);
         }
+        applyCodeHash(component, param.implementationHash, param.rawType);
         final PythonTypeRefModel typeRef = new PythonTypeRefModel();
         typeRef.raw = param.rawType;
         typeRef.targetUniqueName = param.targetUniqueName;
@@ -426,14 +429,33 @@ final class PythonModelAssembler {
         return method != null && "__init__".equals(method.name);
     }
 
-    private static void applyCodeFragmentHash(final Component component, final String codeFragment) {
-        if (component == null || codeFragment == null || codeFragment.isEmpty()) {
-            return;
+    /**
+     * Sets the component's code hash, preferring the daemon's hash over the declaration's full source so
+     * that an implementation edit is detectable, and falling back to the signature when the daemon had
+     * nothing to hash. Every component ends up with a non-zero hash, so a zero unambiguously means
+     * "never computed".
+     */
+    private static void applyCodeHash(final Component component, final int implementationHash, final String fallback) {
+        int hash = implementationHash;
+        if (hash == 0 && fallback != null && !fallback.isEmpty()) {
+            hash = fallback.hashCode();
         }
-        component.setCodeFragment(codeFragment);
-        component.setCodeHash(codeFragment.hashCode());
+        if (hash == 0) {
+            hash = component.componentName().hashCode();
+        }
+        if (hash == 0) {
+            hash = 1;
+        }
+        component.setCodeHash(hash);
     }
 
+    /**
+     * Python has no visibility keywords, so visibility is read off the name: a leading double underscore
+     * is name-mangled and therefore private, a single underscore is the convention for internal use, and
+     * anything else - dunder methods included - is importable and therefore public. Spelled out
+     * explicitly rather than left empty, so that {@code modifiers().contains("public")} answers the same
+     * question here as it does for Java, C# or TypeScript.
+     */
     private static String inferPythonVisibility(final String name) {
         if (name == null || name.isEmpty()) {
             return null;
@@ -444,7 +466,14 @@ final class PythonModelAssembler {
         if (name.startsWith("_") && !name.startsWith("__")) {
             return "protected";
         }
-        return null;
+        return "public";
+    }
+
+    private static void applyVisibility(final Component component, final String name) {
+        final String visibility = inferPythonVisibility(name);
+        if (visibility != null) {
+            component.insertAccessModifier(visibility);
+        }
     }
 
     private static ComponentReference buildReference(final PythonTypeRefModel ref,

--- a/src/main/java/com/hadi/clarpse/compiler/python/model/PythonClassModel.java
+++ b/src/main/java/com/hadi/clarpse/compiler/python/model/PythonClassModel.java
@@ -11,6 +11,7 @@ public class PythonClassModel {
     public String className;
     public String uniqueName;
     public String comment;
+    public int implementationHash;
     public List<PythonTypeRefModel> bases = new ArrayList<>();
     public List<PythonMethodModel> methods = new ArrayList<>();
     public List<PythonFieldModel> fields = new ArrayList<>();

--- a/src/main/java/com/hadi/clarpse/compiler/python/model/PythonFieldModel.java
+++ b/src/main/java/com/hadi/clarpse/compiler/python/model/PythonFieldModel.java
@@ -7,6 +7,7 @@ public class PythonFieldModel {
 
     public String name;
     public String rawType;
+    public int implementationHash;
     public String targetUniqueName;
     public String externalLabel;
 }

--- a/src/main/java/com/hadi/clarpse/compiler/python/model/PythonParamModel.java
+++ b/src/main/java/com/hadi/clarpse/compiler/python/model/PythonParamModel.java
@@ -7,6 +7,7 @@ public class PythonParamModel {
 
     public String name;
     public String rawType;
+    public int implementationHash;
     public String targetUniqueName;
     public String externalLabel;
 }

--- a/src/main/java/com/hadi/clarpse/compiler/typescript/TypeScriptModelAssembler.java
+++ b/src/main/java/com/hadi/clarpse/compiler/typescript/TypeScriptModelAssembler.java
@@ -118,11 +118,21 @@ final class TypeScriptModelAssembler {
         if (codeFragment != null && !codeFragment.isEmpty()) {
             component.setCodeFragment(codeFragment);
         }
-        if (declaration != null && declaration.implementationHash != 0) {
-            component.setCodeHash(declaration.implementationHash);
-        } else if (codeFragment != null && !codeFragment.isEmpty()) {
-            component.setCodeHash(codeFragment.hashCode());
+        int hash = 0;
+        if (declaration != null) {
+            hash = declaration.implementationHash;
         }
+        if (hash == 0 && codeFragment != null && !codeFragment.isEmpty()) {
+            hash = codeFragment.hashCode();
+        }
+        if (hash == 0) {
+            // Every component gets a non-zero hash, so that a zero unambiguously means "never computed".
+            hash = component.componentName().hashCode();
+        }
+        if (hash == 0) {
+            hash = 1;
+        }
+        component.setCodeHash(hash);
     }
 
     private static String generateComponentName(final String moduleName,

--- a/src/main/java/com/hadi/clarpse/listener/JavaTreeListener.java
+++ b/src/main/java/com/hadi/clarpse/listener/JavaTreeListener.java
@@ -7,12 +7,14 @@ import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.PackageDeclaration;
 import com.github.javaparser.ast.body.AnnotationDeclaration;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.CompactConstructorDeclaration;
 import com.github.javaparser.ast.body.ConstructorDeclaration;
 import com.github.javaparser.ast.body.EnumConstantDeclaration;
 import com.github.javaparser.ast.body.EnumDeclaration;
 import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.body.Parameter;
+import com.github.javaparser.ast.body.RecordDeclaration;
 import com.github.javaparser.ast.body.VariableDeclarator;
 import com.github.javaparser.ast.expr.ClassExpr;
 import com.github.javaparser.ast.expr.Expression;
@@ -117,16 +119,24 @@ public class JavaTreeListener extends VoidVisitorAdapter<Object> {
         if (node.getComment().isPresent()) {
             newCmp.setComment(node.getComment().get().toString());
         }
-        StringBuilder codeBuffer = new StringBuilder();
+        newCmp.setCodeHash(normalizedCode(node).hashCode());
+        newCmp.setSourceFilePath(file.path());
+        return newCmp;
+    }
+
+    /**
+     * The given node's source text with its comment and all whitespace stripped, so that a
+     * reformatting or a comment edit leaves the derived code hash untouched.
+     */
+    private static String normalizedCode(final Node node) {
+        final StringBuilder codeBuffer = new StringBuilder();
         final Node nodeNoComment = node.removeComment();
         nodeNoComment.getTokenRange().ifPresent(tokenRange -> tokenRange.iterator().forEachRemaining(
                 javaToken -> codeBuffer.append(javaToken.asString().replaceAll("\\s+", ""))));
         if (codeBuffer.length() == 0) {
             codeBuffer.append(nodeNoComment.toString().replaceAll("\\s+", ""));
         }
-        newCmp.setCodeHash(codeBuffer.toString().hashCode());
-        newCmp.setSourceFilePath(file.path());
-        return newCmp;
+        return codeBuffer.toString();
     }
 
     private static String moduleNameForFile(final String filePath) {
@@ -189,15 +199,7 @@ public class JavaTreeListener extends VoidVisitorAdapter<Object> {
                 cmp = createComponent(ctx, ComponentType.CLASS);
             }
             if (ctx.getTypeParameters().isNonEmpty()) {
-                StringBuilder fragment = new StringBuilder("<");
-                for (final Type typeParam : ctx.getTypeParameters()) {
-                    fragment.append(typeParam.asString()).append(", ");
-                }
-                fragment = new StringBuilder(fragment.toString().trim());
-                if (fragment.toString().endsWith(",")) {
-                    fragment = new StringBuilder(fragment.substring(0, fragment.length() - 1));
-                }
-                cmp.setCodeFragment(fragment + ">");
+                cmp.setCodeFragment(typeParametersCodeFragment(ctx.getTypeParameters()));
             }
 
             cmp.setAccessModifiers(resolveJavaParserModifiers(ctx.getModifiers()));
@@ -231,16 +233,199 @@ public class JavaTreeListener extends VoidVisitorAdapter<Object> {
             }
 
             componentStack.push(cmp);
-            for (final Node node : ctx.getChildNodes()) {
-                if (node instanceof FieldDeclaration || node instanceof Statement || node instanceof Expression
-                        || node instanceof MethodDeclaration || node instanceof ConstructorDeclaration
-                        || node instanceof ClassOrInterfaceDeclaration || node instanceof EnumDeclaration
-                        || node instanceof AnnotationDeclaration) {
-                    node.accept(this, arg);
-                }
-            }
+            visitTypeBody(ctx, arg);
             completeComponent();
         }
+    }
+
+    /**
+     * Visits the member declarations of the given type, leaving alone the nodes that make up its own
+     * declaration (its modifiers, type parameters and supertypes).
+     */
+    private void visitTypeBody(final Node ctx, final Object arg) {
+        for (final Node node : ctx.getChildNodes()) {
+            if (node instanceof FieldDeclaration || node instanceof Statement || node instanceof Expression
+                    || node instanceof MethodDeclaration || node instanceof ConstructorDeclaration
+                    || node instanceof ClassOrInterfaceDeclaration || node instanceof EnumDeclaration
+                    || node instanceof AnnotationDeclaration || node instanceof RecordDeclaration) {
+                node.accept(this, arg);
+            }
+        }
+    }
+
+    private static String typeParametersCodeFragment(final NodeList<? extends Type> typeParameters) {
+        final StringBuilder fragment = new StringBuilder("<");
+        for (final Type typeParam : typeParameters) {
+            fragment.append(typeParam.asString()).append(", ");
+        }
+        while (fragment.toString().endsWith(", ") || fragment.toString().endsWith(",")) {
+            fragment.setLength(fragment.length() - 1);
+        }
+        return fragment + ">";
+    }
+
+    /**
+     * Records are modelled as {@link ComponentType#CLASS} components; their record components become
+     * {@code FIELD} children, and the canonical constructor is modelled whether it is declared
+     * explicitly, declared compactly, or left implicit.
+     */
+    @Override
+    public final void visit(final RecordDeclaration ctx, final Object arg) {
+        if (!ParseUtil.componentStackContainsMethod(componentStack)) {
+            final Component cmp = createComponent(ctx, ComponentType.CLASS);
+            if (ctx.getTypeParameters().isNonEmpty()) {
+                cmp.setCodeFragment(typeParametersCodeFragment(ctx.getTypeParameters()));
+            }
+            cmp.setAccessModifiers(resolveJavaParserModifiers(ctx.getModifiers()));
+            // A record is implicitly final, which its modifier list does not spell out.
+            cmp.insertAccessModifier("final");
+            cmp.setComponentName(ParseUtil.generateComponentName(ctx.getNameAsString(), componentStack));
+            cmp.setName(ctx.getNameAsString());
+            cmp.setImports(currentImports);
+            if (ctx.getComment().isPresent()) {
+                cmp.setComment(ctx.getComment().get().toString());
+            }
+            ParseUtil.pointParentsToGivenChild(cmp, componentStack);
+
+            for (final ClassOrInterfaceType implementedType : ctx.getImplementedTypes()) {
+                final String resolvedType = resolveType(implementedType.asString());
+                if (resolvedType != null) {
+                    ParseUtil.insertCmpRef(cmp, new TypeImplementationReference(resolvedType),
+                            this.componentStack);
+                }
+            }
+
+            componentStack.push(cmp);
+            insertRecordComponentFields(ctx, arg);
+            insertRecordCanonicalConstructor(ctx, arg);
+            visitTypeBody(ctx, arg);
+            completeComponent();
+        }
+    }
+
+    /**
+     * Each record component is an implicitly private final field of the record.
+     */
+    private void insertRecordComponentFields(final RecordDeclaration ctx, final Object arg) {
+        for (final Parameter recordComponent : ctx.getParameters()) {
+            final Component fieldCmp = createComponent(recordComponent, ComponentType.FIELD);
+            fieldCmp.setName(recordComponent.getNameAsString());
+            fieldCmp.setCodeFragment(recordComponent.getNameAsString() + " : "
+                    + recordComponent.getType().asString());
+            fieldCmp.setComponentName(ParseUtil.generateComponentName(recordComponent.getNameAsString(),
+                    componentStack));
+            fieldCmp.setAccessModifiers(Arrays.asList("private", "final"));
+            ParseUtil.pointParentsToGivenChild(fieldCmp, componentStack);
+            componentStack.push(fieldCmp);
+            // Walk the declared type the same way a field declaration's type is walked, so that a record
+            // component contributes the same dependency edges an equivalent field would.
+            recordComponent.getType().accept(this, arg);
+            completeComponent();
+        }
+    }
+
+    /**
+     * Models the record's canonical constructor. An explicitly declared one is left to
+     * {@link #visit(ConstructorDeclaration, Object)}; a compact declaration or no declaration at all is
+     * synthesized here from the record components, so that the constructor and its parameters are
+     * present either way.
+     */
+    private void insertRecordCanonicalConstructor(final RecordDeclaration ctx, final Object arg) {
+        if (declaresCanonicalConstructor(ctx)) {
+            return;
+        }
+        final List<CompactConstructorDeclaration> compactCtors = ctx.getCompactConstructors();
+        CompactConstructorDeclaration compactCtor = null;
+        if (!compactCtors.isEmpty()) {
+            compactCtor = compactCtors.get(0);
+        }
+        Node declarationNode = ctx;
+        if (compactCtor != null) {
+            declarationNode = compactCtor;
+        }
+        final Component ctorCmp = createComponent(declarationNode, ComponentType.CONSTRUCTOR);
+        ctorCmp.setName(ctx.getNameAsString());
+        final String signature = ctx.getNameAsString() + "(" + getFormalParameterTypesList(ctx.getParameters()) + ")";
+        String compactBody = "";
+        if (compactCtor != null) {
+            compactBody = normalizedCode(compactCtor);
+        }
+        // Hash the canonical signature rather than the whole record, so that an unrelated member edit
+        // does not read as a change to this constructor.
+        ctorCmp.setCodeHash((signature + compactBody).hashCode());
+        if (compactCtor != null) {
+            ctorCmp.setAccessModifiers(resolveJavaParserModifiers(compactCtor.getModifiers()));
+            for (final ReferenceType thrown : compactCtor.getThrownExceptions()) {
+                final String resolvedType = resolveType(thrown.asString());
+                if (resolvedType != null) {
+                    ParseUtil.insertCmpRef(ctorCmp, new SimpleTypeReference(resolvedType), this.componentStack);
+                }
+            }
+        } else {
+            // An implicit canonical constructor is as visible as the record itself.
+            ctorCmp.setAccessModifiers(visibilityModifiers(ctx.getModifiers()));
+        }
+        ctorCmp.setCodeFragment(signature);
+        ctorCmp.setComponentName(ParseUtil.generateComponentName(signature, componentStack));
+        ParseUtil.pointParentsToGivenChild(ctorCmp, componentStack);
+        componentStack.push(ctorCmp);
+        for (final Parameter recordComponent : ctx.getParameters()) {
+            final Component ctorParamCmp = createComponent(recordComponent,
+                    ComponentType.CONSTRUCTOR_PARAMETER_COMPONENT);
+            ctorParamCmp.setName(recordComponent.getNameAsString());
+            ctorParamCmp.setCodeFragment(recordComponent.getType().asString());
+            ctorParamCmp.setComponentName(ParseUtil.generateComponentName(recordComponent.getNameAsString(),
+                    componentStack));
+            ctorParamCmp.setAccessModifiers(resolveJavaParserModifiers(recordComponent.getModifiers()));
+            final String resolvedType = resolveType(recordComponent.getType().asString());
+            if (resolvedType != null) {
+                ParseUtil.insertCmpRef(ctorParamCmp, new SimpleTypeReference(resolvedType), this.componentStack);
+            }
+            ParseUtil.pointParentsToGivenChild(ctorParamCmp, componentStack);
+            componentStack.push(ctorParamCmp);
+            completeComponent();
+        }
+        currCyclomaticComplexity = 1;
+        if (compactCtor != null) {
+            currCyclomaticComplexity += countLogicalBinaryOperators(compactCtor);
+            compactCtor.getBody().accept(this, arg);
+        }
+        completeComponent();
+    }
+
+    /**
+     * True if the record body declares the canonical constructor in full, in which case the regular
+     * constructor visitor models it.
+     */
+    private static boolean declaresCanonicalConstructor(final RecordDeclaration ctx) {
+        final List<String> recordComponentTypes = new ArrayList<>();
+        for (final Parameter recordComponent : ctx.getParameters()) {
+            recordComponentTypes.add(recordComponent.getType().asString());
+        }
+        for (final Node member : ctx.getMembers()) {
+            if (!(member instanceof ConstructorDeclaration)) {
+                continue;
+            }
+            final List<String> ctorParamTypes = new ArrayList<>();
+            for (final Parameter param : ((ConstructorDeclaration) member).getParameters()) {
+                ctorParamTypes.add(param.getType().asString());
+            }
+            if (ctorParamTypes.equals(recordComponentTypes)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static List<String> visibilityModifiers(final NodeList<Modifier> modifiers) {
+        final List<String> visibility = new ArrayList<>();
+        for (final Modifier modifier : modifiers) {
+            final String keyword = modifier.toString().toLowerCase(Locale.ROOT).trim();
+            if (keyword.equals("public") || keyword.equals("protected") || keyword.equals("private")) {
+                visibility.add(keyword);
+            }
+        }
+        return visibility;
     }
 
     @Override

--- a/src/main/java/com/hadi/clarpse/sourcemodel/Component.java
+++ b/src/main/java/com/hadi/clarpse/sourcemodel/Component.java
@@ -217,7 +217,7 @@ public final class Component implements Serializable {
     }
 
     public void insertAccessModifier(final String modifier) {
-        if (OOPSourceModelConstants.getJavaAccessModifierMap().containsValue(modifier.toLowerCase(Locale.ROOT))) {
+        if (OOPSourceModelConstants.getAccessModifierMap().containsValue(modifier.toLowerCase(Locale.ROOT))) {
             modifiers.add(modifier.toLowerCase(Locale.ROOT));
         } else {
             throw new IllegalArgumentException(modifier + " is an invalid modifier!");
@@ -304,9 +304,17 @@ public final class Component implements Serializable {
         sourceFile = sourceFilePath;
     }
 
+    /**
+     * Inserts every given modifier, enforcing the same vocabulary as
+     * {@link #insertAccessModifier(String)} so that {@code modifiers()} only ever holds tokens the
+     * model can resolve through {@link OOPSourceModelConstants#accessModifier(String)}.
+     *
+     * @param list Modifier tokens, in any case.
+     * @throws IllegalArgumentException If any token is not a supported modifier.
+     */
     public void setAccessModifiers(final List<String> list) {
         for (final String modifier : list) {
-            modifiers.add(modifier.toLowerCase(Locale.ROOT));
+            insertAccessModifier(modifier);
         }
     }
 

--- a/src/main/java/com/hadi/clarpse/sourcemodel/OOPSourceModelConstants.java
+++ b/src/main/java/com/hadi/clarpse/sourcemodel/OOPSourceModelConstants.java
@@ -19,7 +19,6 @@ public final class OOPSourceModelConstants {
     static final Map<String, String> JAVA_COLLECTIONS = new HashMap<String, String>();
 
     static final Map<String, String> JAVA_ANNOTATIONS = new HashMap<String, String>();
-    private static final Map<AccessModifiers, String> JAVA_ACCESS_MODIFIER_MAP = new HashMap<AccessModifiers, String>();
     private static final Map<AccessModifiers, String> ACCESS_MODIFIER_MAP = new HashMap<AccessModifiers, String>();
     private static final Map<ComponentType, String> COMPONENT_TYPES = new HashMap<ComponentType, String>();
     public static final String JAVA_DEFAULT_PKG = "java.lang.";
@@ -193,26 +192,23 @@ public final class OOPSourceModelConstants {
     }
 
     static {
-        getJavaAccessModifierMap().put(AccessModifiers.PRIVATE, "private");
-        getJavaAccessModifierMap().put(AccessModifiers.PROTECTED, "protected");
-        getJavaAccessModifierMap().put(AccessModifiers.PUBLIC, "public");
-        getJavaAccessModifierMap().put(AccessModifiers.VOLATILE, "volatile");
-        getJavaAccessModifierMap().put(AccessModifiers.TRANSIENT, "transient");
-        getJavaAccessModifierMap().put(AccessModifiers.SYNCHRONIZED, "synchronized");
-        getJavaAccessModifierMap().put(AccessModifiers.STRICTFP, "strictfp");
-        getJavaAccessModifierMap().put(AccessModifiers.STATIC, "static");
-        getJavaAccessModifierMap().put(AccessModifiers.NATIVE, "native");
-        getJavaAccessModifierMap().put(AccessModifiers.ABSTRACT, "abstract");
-        getJavaAccessModifierMap().put(AccessModifiers.INTERFACE, "interface");
-        getJavaAccessModifierMap().put(AccessModifiers.FINAL, "final");
-        getJavaAccessModifierMap().put(AccessModifiers.DEFAULT, "default");
-        getJavaAccessModifierMap().put(AccessModifiers.SEALED, "sealed");
-        getJavaAccessModifierMap().put(AccessModifiers.NON_SEALED, "non-sealed");
-        getJavaAccessModifierMap().put(AccessModifiers.TRANSITIVE, "transitive");
-    }
-
-    static {
-        ACCESS_MODIFIER_MAP.putAll(JAVA_ACCESS_MODIFIER_MAP);
+        // Java
+        ACCESS_MODIFIER_MAP.put(AccessModifiers.PRIVATE, "private");
+        ACCESS_MODIFIER_MAP.put(AccessModifiers.PROTECTED, "protected");
+        ACCESS_MODIFIER_MAP.put(AccessModifiers.PUBLIC, "public");
+        ACCESS_MODIFIER_MAP.put(AccessModifiers.VOLATILE, "volatile");
+        ACCESS_MODIFIER_MAP.put(AccessModifiers.TRANSIENT, "transient");
+        ACCESS_MODIFIER_MAP.put(AccessModifiers.SYNCHRONIZED, "synchronized");
+        ACCESS_MODIFIER_MAP.put(AccessModifiers.STRICTFP, "strictfp");
+        ACCESS_MODIFIER_MAP.put(AccessModifiers.STATIC, "static");
+        ACCESS_MODIFIER_MAP.put(AccessModifiers.NATIVE, "native");
+        ACCESS_MODIFIER_MAP.put(AccessModifiers.ABSTRACT, "abstract");
+        ACCESS_MODIFIER_MAP.put(AccessModifiers.INTERFACE, "interface");
+        ACCESS_MODIFIER_MAP.put(AccessModifiers.FINAL, "final");
+        ACCESS_MODIFIER_MAP.put(AccessModifiers.DEFAULT, "default");
+        ACCESS_MODIFIER_MAP.put(AccessModifiers.SEALED, "sealed");
+        ACCESS_MODIFIER_MAP.put(AccessModifiers.NON_SEALED, "non-sealed");
+        ACCESS_MODIFIER_MAP.put(AccessModifiers.TRANSITIVE, "transitive");
         // C#
         ACCESS_MODIFIER_MAP.put(AccessModifiers.INTERNAL, "internal");
         ACCESS_MODIFIER_MAP.put(AccessModifiers.PARTIAL, "partial");
@@ -253,14 +249,10 @@ public final class OOPSourceModelConstants {
         return JAVA_DEFAULT_CLASSES;
     }
 
-    public static Map<AccessModifiers, String> getJavaAccessModifierMap() {
-        return JAVA_ACCESS_MODIFIER_MAP;
-    }
-
     /**
-     * Every modifier token the model accepts, across all supported languages. This is a superset of
-     * {@link #getJavaAccessModifierMap()} and is the vocabulary {@code Component} validates against,
-     * so that a C# {@code partial} or a TypeScript {@code export} is as legal as a Java {@code final}.
+     * Every modifier token the model accepts, across all supported languages, and the vocabulary
+     * {@code Component} validates against - so that a C# {@code partial} or a TypeScript
+     * {@code export} is as legal as a Java {@code final}.
      *
      * @return Mapping of modifier enum to its lower-case source token.
      */

--- a/src/main/java/com/hadi/clarpse/sourcemodel/OOPSourceModelConstants.java
+++ b/src/main/java/com/hadi/clarpse/sourcemodel/OOPSourceModelConstants.java
@@ -7,6 +7,7 @@ import com.hadi.clarpse.reference.TypeImplementationReference;
 
 import java.io.Serializable;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -19,6 +20,7 @@ public final class OOPSourceModelConstants {
 
     static final Map<String, String> JAVA_ANNOTATIONS = new HashMap<String, String>();
     private static final Map<AccessModifiers, String> JAVA_ACCESS_MODIFIER_MAP = new HashMap<AccessModifiers, String>();
+    private static final Map<AccessModifiers, String> ACCESS_MODIFIER_MAP = new HashMap<AccessModifiers, String>();
     private static final Map<ComponentType, String> COMPONENT_TYPES = new HashMap<ComponentType, String>();
     public static final String JAVA_DEFAULT_PKG = "java.lang.";
     static final Map<String, String> JAVA_DEFAULT_CLASSES = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
@@ -203,7 +205,31 @@ public final class OOPSourceModelConstants {
         getJavaAccessModifierMap().put(AccessModifiers.ABSTRACT, "abstract");
         getJavaAccessModifierMap().put(AccessModifiers.INTERFACE, "interface");
         getJavaAccessModifierMap().put(AccessModifiers.FINAL, "final");
+        getJavaAccessModifierMap().put(AccessModifiers.DEFAULT, "default");
+        getJavaAccessModifierMap().put(AccessModifiers.SEALED, "sealed");
+        getJavaAccessModifierMap().put(AccessModifiers.NON_SEALED, "non-sealed");
+        getJavaAccessModifierMap().put(AccessModifiers.TRANSITIVE, "transitive");
+    }
 
+    static {
+        ACCESS_MODIFIER_MAP.putAll(JAVA_ACCESS_MODIFIER_MAP);
+        // C#
+        ACCESS_MODIFIER_MAP.put(AccessModifiers.INTERNAL, "internal");
+        ACCESS_MODIFIER_MAP.put(AccessModifiers.PARTIAL, "partial");
+        ACCESS_MODIFIER_MAP.put(AccessModifiers.READONLY, "readonly");
+        ACCESS_MODIFIER_MAP.put(AccessModifiers.VIRTUAL, "virtual");
+        ACCESS_MODIFIER_MAP.put(AccessModifiers.OVERRIDE, "override");
+        ACCESS_MODIFIER_MAP.put(AccessModifiers.UNSAFE, "unsafe");
+        // C# and TypeScript
+        ACCESS_MODIFIER_MAP.put(AccessModifiers.ASYNC, "async");
+        ACCESS_MODIFIER_MAP.put(AccessModifiers.CONST, "const");
+        // TypeScript
+        ACCESS_MODIFIER_MAP.put(AccessModifiers.EXPORT, "export");
+        ACCESS_MODIFIER_MAP.put(AccessModifiers.DECLARE, "declare");
+        ACCESS_MODIFIER_MAP.put(AccessModifiers.LET, "let");
+        ACCESS_MODIFIER_MAP.put(AccessModifiers.VAR, "var");
+        ACCESS_MODIFIER_MAP.put(AccessModifiers.GET, "get");
+        ACCESS_MODIFIER_MAP.put(AccessModifiers.SET, "set");
     }
 
     static {
@@ -231,6 +257,37 @@ public final class OOPSourceModelConstants {
         return JAVA_ACCESS_MODIFIER_MAP;
     }
 
+    /**
+     * Every modifier token the model accepts, across all supported languages. This is a superset of
+     * {@link #getJavaAccessModifierMap()} and is the vocabulary {@code Component} validates against,
+     * so that a C# {@code partial} or a TypeScript {@code export} is as legal as a Java {@code final}.
+     *
+     * @return Mapping of modifier enum to its lower-case source token.
+     */
+    public static Map<AccessModifiers, String> getAccessModifierMap() {
+        return ACCESS_MODIFIER_MAP;
+    }
+
+    /**
+     * Resolves a modifier token to its enum, so callers can reach
+     * {@link AccessModifiers#getUMLClassDigramSymbol()} without guessing at the enum name.
+     *
+     * @param modifier Modifier token, in any case.
+     * @return The matching enum, or {@code null} if the token is not a supported modifier.
+     */
+    public static AccessModifiers accessModifier(final String modifier) {
+        if (modifier == null) {
+            return null;
+        }
+        final String normalized = modifier.toLowerCase(Locale.ROOT).trim();
+        for (final Map.Entry<AccessModifiers, String> entry : ACCESS_MODIFIER_MAP.entrySet()) {
+            if (entry.getValue().equals(normalized)) {
+                return entry.getKey();
+            }
+        }
+        return null;
+    }
+
     public static Map<ComponentType, String> getJavaComponentTypes() {
         return COMPONENT_TYPES;
     }
@@ -240,7 +297,10 @@ public final class OOPSourceModelConstants {
      */
     public enum AccessModifiers {
         FINAL(""), ABSTRACT(""), INTERFACE(""), NATIVE(""), PRIVATE("-"), PROTECTED("#"), PUBLIC("+"), STATIC(
-                ""), STRICTFP(""), SYNCHRONIZED(""), TRANSIENT(""), NONE("~"), VOLATILE("");
+                ""), STRICTFP(""), SYNCHRONIZED(""), TRANSIENT(""), NONE("~"), VOLATILE(""),
+        DEFAULT(""), SEALED(""), NON_SEALED(""), TRANSITIVE(""),
+        INTERNAL("~"), PARTIAL(""), READONLY(""), VIRTUAL(""), OVERRIDE(""), UNSAFE(""),
+        ASYNC(""), CONST(""), EXPORT(""), DECLARE(""), LET(""), VAR(""), GET(""), SET("");
 
         private String umlClassDigramSymbol = null;
 

--- a/src/main/resources/python/daemon.js
+++ b/src/main/resources/python/daemon.js
@@ -1347,11 +1347,15 @@ function textForNode(node, fileText) {
 
 function stableImplementationHash(text) {
   const normalized = String(text || '').replace(/\r\n/g, '\n').trim();
+  if (!normalized.length) {
+    return 0;
+  }
   let hash = 0;
   for (let i = 0; i < normalized.length; i += 1) {
     hash = ((hash * 31) + normalized.charCodeAt(i)) | 0;
   }
-  return hash;
+  // Zero is reserved for "nothing to hash", so that the Java side can tell a real hash from a missing one.
+  return hash === 0 ? 1 : hash;
 }
 
 function decodeDocStringLiteral(statementText) {
@@ -1676,6 +1680,7 @@ function extractParams(funcNode, ctx, parseNodeType) {
     params.push({
       name: paramName,
       rawType: ref ? ref.raw : rawType,
+      implementationHash: stableImplementationHash(textForNode(param, ctx.fileText)),
       targetUniqueName: ref ? ref.targetUniqueName : null,
       externalLabel: ref ? ref.externalLabel : (rawType || 'Any')
     });
@@ -1766,9 +1771,8 @@ function extractMethod(methodNode, ctx, parseNodeType) {
   const uniqueName = ctx.classUniqueName + '.' + signature;
   const returnRef = resolveTypeRef(returnNode, returnRaw || 'Any', ctx);
   const cyclo = computeCyclo(methodNode, ctx.fileText);
-  const implementationHash = stableImplementationHash(
-    methodNode && methodNode.d && methodNode.d.suite ? textForNode(methodNode.d.suite, ctx.fileText) : ''
-  );
+  // The whole def, not just its suite: a changed signature or decorator is a change too.
+  const implementationHash = stableImplementationHash(textForNode(methodNode, ctx.fileText));
   const bodyReferences = collectBodyReferences(methodNode.d ? methodNode.d.suite : null, ctx, parseNodeType);
   return {
     name,
@@ -1802,9 +1806,8 @@ function extractFunction(functionNode, ctx, parseNodeType) {
   const uniqueName = moduleUniqueName + '.' + signature;
   const returnRef = resolveTypeRef(returnNode, returnRaw || 'Any', ctx);
   const cyclo = computeCyclo(functionNode, ctx.fileText);
-  const implementationHash = stableImplementationHash(
-    functionNode && functionNode.d && functionNode.d.suite ? textForNode(functionNode.d.suite, ctx.fileText) : ''
-  );
+  // The whole def, not just its suite: a changed signature or decorator is a change too.
+  const implementationHash = stableImplementationHash(textForNode(functionNode, ctx.fileText));
   const bodyReferences = collectBodyReferences(functionNode.d ? functionNode.d.suite : null, ctx, parseNodeType);
   return {
     name,
@@ -1843,6 +1846,7 @@ function extractFieldFromStatement(statement, ctx, parseNodeType, options) {
   return {
     name: fieldName,
     rawType: ref ? ref.raw : rawType,
+    implementationHash: stableImplementationHash(textForNode(statement, ctx.fileText)),
     targetUniqueName: ref ? ref.targetUniqueName : null,
     externalLabel: ref ? ref.externalLabel : (rawType || 'Any')
   };
@@ -1889,6 +1893,7 @@ function extractInstanceFieldFromStatement(statement, ctx) {
   return {
     name: fieldName,
     rawType: ref ? ref.raw : rawType,
+    implementationHash: stableImplementationHash(statementText),
     targetUniqueName: ref ? ref.targetUniqueName : null,
     externalLabel: ref ? ref.externalLabel : (rawType || 'Any')
   };
@@ -1987,6 +1992,7 @@ function extractClassesFromStatements(statements, ctx, parseNodeType, parentUniq
       className,
       uniqueName: classUniqueName,
       comment: classComment,
+      implementationHash: stableImplementationHash(textForNode(statement, ctx.fileText)),
       bases,
       methods,
       fields,

--- a/src/main/resources/typescript/daemon.js
+++ b/src/main/resources/typescript/daemon.js
@@ -35,11 +35,15 @@ function writeError(id, code, message, data) {
 
 function stableImplementationHash(text) {
   const normalized = String(text || "").replace(/\r\n/g, "\n").trim();
+  if (!normalized.length) {
+    return 0;
+  }
   let hash = 0;
   for (let i = 0; i < normalized.length; i += 1) {
     hash = ((hash * 31) + normalized.charCodeAt(i)) | 0;
   }
-  return hash;
+  // Zero is reserved for "nothing to hash", so that the Java side can tell a real hash from a missing one.
+  return hash === 0 ? 1 : hash;
 }
 
 function loadTypeScript(repoRoot) {
@@ -344,6 +348,11 @@ function collectModifiers(ts, node) {
       default:
         break;
     }
+  }
+  // `export` puts a declaration on the module's public surface. Spell that out as `public` too, so that
+  // asking "is this public?" means the same thing here as it does for Java, C# or Python.
+  if (modifiers.indexOf("export") >= 0 && modifiers.indexOf("public") < 0) {
+    modifiers.push("public");
   }
   return modifiers;
 }
@@ -703,6 +712,7 @@ function buildLocalVariableModel(declaration, checker) {
     kind: "local",
     name: declaration.name.text,
     type: checker.typeToString(variableType),
+    implementationHash: stableImplementationHash(declaration.getText()),
     modifiers: collectVariableModifiers(state.ts, declaration),
     jsDoc: getJsDoc(declaration),
     references
@@ -800,6 +810,7 @@ function buildParameterModels(parameters, checker) {
       kind: "parameter",
       name: param.name.getText(),
       type: typeToString(checker, param),
+      implementationHash: stableImplementationHash(param.getText()),
       modifiers: collectModifiers(state.ts, param),
       jsDoc: getJsDoc(param),
       references: buildReferenceModelsFromType(paramType, checker, "type")
@@ -817,6 +828,7 @@ function buildFieldModel(node, checker) {
     kind: "field",
     name: node.name.getText(),
     type: typeToString(checker, node),
+    implementationHash: stableImplementationHash(node.getText()),
     modifiers: collectModifiers(state.ts, node),
     jsDoc: getJsDoc(node),
     references: buildReferenceModelsFromType(fieldType, checker, "type")
@@ -833,7 +845,9 @@ function buildMethodModel(node, checker, kindLabel) {
     kind: kindLabel,
     name,
     signature,
-    implementationHash: stableImplementationHash(node.body ? node.body.getText() : ""),
+    // The whole declaration, not just the body: a changed return type or modifier is a change too, and a
+    // body-less declaration (an interface method, an abstract method) still gets a real hash this way.
+    implementationHash: stableImplementationHash(node.getText()),
     returnType: kindLabel === "constructor" ? "" : getReturnType(checker, node),
     modifiers: collectModifiers(state.ts, node),
     jsDoc: getJsDoc(node),
@@ -856,7 +870,7 @@ function buildAccessorModel(node, checker, accessorKind) {
     kind: "method",
     name,
     signature,
-    implementationHash: stableImplementationHash(node.body ? node.body.getText() : ""),
+    implementationHash: stableImplementationHash(node.getText()),
     returnType: accessorKind === "set" ? "" : getReturnType(checker, node),
     modifiers,
     jsDoc: getJsDoc(node),
@@ -869,11 +883,13 @@ function buildAccessorModel(node, checker, accessorKind) {
 function buildEnumModel(node) {
   const members = node.members.map((member) => ({
     kind: "enumMember",
-    name: member.name.getText()
+    name: member.name.getText(),
+    implementationHash: stableImplementationHash(member.getText())
   }));
   return {
     kind: "enum",
     name: node.name.text,
+    implementationHash: stableImplementationHash(node.getText()),
     modifiers: collectModifiers(state.ts, node),
     jsDoc: getJsDoc(node),
     members,
@@ -896,6 +912,7 @@ function buildInterfaceModel(node, checker) {
   return {
     kind: "interface",
     name: node.name.text,
+    implementationHash: stableImplementationHash(node.getText()),
     modifiers: collectModifiers(state.ts, node),
     jsDoc: getJsDoc(node),
     members,
@@ -940,6 +957,7 @@ function buildClassModel(node, checker) {
     kind: "class",
     name: node.name.text,
     signature: typeParams,
+    implementationHash: stableImplementationHash(node.getText()),
     modifiers: collectModifiers(state.ts, node),
     jsDoc: getJsDoc(node),
     members,

--- a/src/test/java/com/hadi/test/ComponentModifierContractTest.java
+++ b/src/test/java/com/hadi/test/ComponentModifierContractTest.java
@@ -1,0 +1,64 @@
+package com.hadi.test;
+
+import com.hadi.clarpse.sourcemodel.Component;
+import com.hadi.clarpse.sourcemodel.OOPSourceModelConstants;
+import com.hadi.clarpse.sourcemodel.OOPSourceModelConstants.AccessModifiers;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * {@code Component}'s two modifier mutators must agree on what is legal, and the vocabulary they enforce
+ * has to cover every language the compilers support - not just Java.
+ */
+public class ComponentModifierContractTest {
+
+    @Test
+    public void bothMutatorsEnforceTheSameVocabulary() {
+        final Component component = new Component();
+        assertThrows(IllegalArgumentException.class, () -> component.insertAccessModifier("wat"));
+        assertThrows(IllegalArgumentException.class, () -> component.setAccessModifiers(List.of("wat")));
+    }
+
+    @Test
+    public void nonJavaModifiersAreLegal() {
+        final Component component = new Component();
+        component.setAccessModifiers(List.of("partial", "internal", "readonly", "override"));
+        component.insertAccessModifier("export");
+        component.insertAccessModifier("ASYNC");
+        assertTrue(component.modifiers().contains("partial"));
+        assertTrue(component.modifiers().contains("export"));
+        assertTrue("modifiers are normalised to lower case", component.modifiers().contains("async"));
+    }
+
+    @Test
+    public void modernJavaModifiersAreLegal() {
+        final Component component = new Component();
+        component.setAccessModifiers(List.of("sealed", "non-sealed", "default", "transitive"));
+        assertTrue(component.modifiers().contains("non-sealed"));
+    }
+
+    @Test
+    public void everyModifierResolvesBackToItsEnum() {
+        for (final String modifier : OOPSourceModelConstants.getAccessModifierMap().values()) {
+            assertNotNull("modifier " + modifier + " should resolve to an enum constant",
+                    OOPSourceModelConstants.accessModifier(modifier));
+        }
+        assertEquals(AccessModifiers.PUBLIC, OOPSourceModelConstants.accessModifier("PUBLIC"));
+        assertEquals("+", OOPSourceModelConstants.accessModifier("public").getUMLClassDigramSymbol());
+        assertNull(OOPSourceModelConstants.accessModifier("wat"));
+        assertNull(OOPSourceModelConstants.accessModifier(null));
+    }
+
+    @Test
+    public void theVocabularyIsASupersetOfJava() {
+        assertTrue(OOPSourceModelConstants.getAccessModifierMap().entrySet()
+                .containsAll(OOPSourceModelConstants.getJavaAccessModifierMap().entrySet()));
+    }
+}

--- a/src/test/java/com/hadi/test/ComponentModifierContractTest.java
+++ b/src/test/java/com/hadi/test/ComponentModifierContractTest.java
@@ -5,6 +5,7 @@ import com.hadi.clarpse.sourcemodel.OOPSourceModelConstants;
 import com.hadi.clarpse.sourcemodel.OOPSourceModelConstants.AccessModifiers;
 import org.junit.Test;
 
+import java.util.Collection;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -57,8 +58,15 @@ public class ComponentModifierContractTest {
     }
 
     @Test
-    public void theVocabularyIsASupersetOfJava() {
-        assertTrue(OOPSourceModelConstants.getAccessModifierMap().entrySet()
-                .containsAll(OOPSourceModelConstants.getJavaAccessModifierMap().entrySet()));
+    public void theVocabularyCoversEveryLanguage() {
+        final Collection<String> vocabulary = OOPSourceModelConstants.getAccessModifierMap().values();
+        assertTrue("java", vocabulary.containsAll(
+                List.of("public", "protected", "private", "static", "final", "abstract", "synchronized",
+                        "native", "strictfp", "transient", "volatile", "default", "sealed", "non-sealed",
+                        "transitive")));
+        assertTrue("c#", vocabulary.containsAll(
+                List.of("internal", "partial", "readonly", "virtual", "override", "unsafe", "async", "const")));
+        assertTrue("typescript", vocabulary.containsAll(
+                List.of("export", "declare", "const", "let", "var", "get", "set", "async")));
     }
 }

--- a/src/test/java/com/hadi/test/CrossLanguageCodeHashTest.java
+++ b/src/test/java/com/hadi/test/CrossLanguageCodeHashTest.java
@@ -1,0 +1,139 @@
+package com.hadi.test;
+
+import com.hadi.clarpse.compiler.ClarpseProject;
+import com.hadi.clarpse.compiler.CompileResult;
+import com.hadi.clarpse.compiler.Lang;
+import com.hadi.clarpse.compiler.ProjectFile;
+import com.hadi.clarpse.compiler.ProjectFiles;
+import com.hadi.clarpse.compiler.typescript.NodeRuntime;
+import com.hadi.clarpse.sourcemodel.Component;
+import com.hadi.clarpse.sourcemodel.OOPSourceCodeModel;
+import org.junit.Assume;
+import org.junit.Test;
+
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * {@code codeHash} is the model's change-detection primitive: two parses of the same source must agree,
+ * an implementation edit must not, and no component may be left without a hash. Asserted for every
+ * supported language, since the four compilers derive it independently.
+ */
+public class CrossLanguageCodeHashTest {
+
+    private static final String JAVA_V1 = "package app;\npublic class Svc {\n  public int size() { return 0; }\n}\n";
+    private static final String JAVA_V2 = "package app;\npublic class Svc {\n  public int size() { return 42; }\n}\n";
+    private static final String CSHARP_V1 =
+            "namespace App {\n  public class Svc {\n    public int Size() { return 0; }\n  }\n}\n";
+    private static final String CSHARP_V2 =
+            "namespace App {\n  public class Svc {\n    public int Size() { return 42; }\n  }\n}\n";
+
+    @Test
+    public void javaBodyEditChangesTheHash() throws Exception {
+        assertBodyEditIsVisible(
+                hashes(inMemory("/app/Svc.java", JAVA_V1), Lang.JAVA),
+                hashes(inMemory("/app/Svc.java", JAVA_V2), Lang.JAVA),
+                "METHOD app.Svc.size()", "CLASS app.Svc");
+    }
+
+    @Test
+    public void csharpBodyEditChangesTheHash() throws Exception {
+        assertBodyEditIsVisible(
+                hashes(inMemory("/Svc.cs", CSHARP_V1), Lang.CSHARP),
+                hashes(inMemory("/Svc.cs", CSHARP_V2), Lang.CSHARP),
+                "METHOD App.Svc.Size()", "CLASS App.Svc");
+    }
+
+    @Test
+    public void typescriptBodyEditChangesTheHash() throws Exception {
+        Assume.assumeTrue(NodeRuntime.isNodeAvailable());
+        assertBodyEditIsVisible(
+                hashes(fixture("typescript", "code-hash-v1"), Lang.TYPESCRIPT),
+                hashes(fixture("typescript", "code-hash-v2"), Lang.TYPESCRIPT),
+                "METHOD src.svc.Svc.size()", "CLASS src.svc.Svc");
+    }
+
+    @Test
+    public void pythonBodyEditChangesTheHash() throws Exception {
+        Assume.assumeTrue(NodeRuntime.isNodeAvailable());
+        assertBodyEditIsVisible(
+                hashes(fixture("python", "code-hash-v1"), Lang.PYTHON),
+                hashes(fixture("python", "code-hash-v2"), Lang.PYTHON),
+                "METHOD src.svc.Svc.size() : int", "CLASS src.svc.Svc");
+    }
+
+    @Test
+    public void everyComponentCarriesAHash() throws Exception {
+        assertEveryComponentIsHashed(compile(inMemory("/app/Svc.java", JAVA_V1), Lang.JAVA));
+        assertEveryComponentIsHashed(compile(inMemory("/Svc.cs", CSHARP_V1), Lang.CSHARP));
+        if (NodeRuntime.isNodeAvailable()) {
+            assertEveryComponentIsHashed(compile(fixture("typescript", "code-hash-v1"), Lang.TYPESCRIPT));
+            assertEveryComponentIsHashed(compile(fixture("python", "code-hash-v1"), Lang.PYTHON));
+        }
+    }
+
+    @Test
+    public void hashesAreStableAcrossParses() throws Exception {
+        assertEquals(hashes(inMemory("/app/Svc.java", JAVA_V1), Lang.JAVA),
+                hashes(inMemory("/app/Svc.java", JAVA_V1), Lang.JAVA));
+        assertEquals(hashes(inMemory("/Svc.cs", CSHARP_V1), Lang.CSHARP),
+                hashes(inMemory("/Svc.cs", CSHARP_V1), Lang.CSHARP));
+        if (NodeRuntime.isNodeAvailable()) {
+            assertEquals(hashes(fixture("typescript", "code-hash-v1"), Lang.TYPESCRIPT),
+                    hashes(fixture("typescript", "code-hash-v1"), Lang.TYPESCRIPT));
+            assertEquals(hashes(fixture("python", "code-hash-v1"), Lang.PYTHON),
+                    hashes(fixture("python", "code-hash-v1"), Lang.PYTHON));
+        }
+    }
+
+    private static void assertBodyEditIsVisible(final Map<String, Integer> before,
+                                                final Map<String, Integer> after,
+                                                final String... changedKeys) {
+        assertEquals("the same components should be modelled either side of a body edit",
+                before.keySet(), after.keySet());
+        for (final String key : changedKeys) {
+            assertTrue("expected to model " + key + ", modelled " + before.keySet(), before.containsKey(key));
+            assertNotEquals("a changed method body should change " + key + "'s code hash",
+                    before.get(key), after.get(key));
+        }
+    }
+
+    private static void assertEveryComponentIsHashed(final OOPSourceCodeModel model) {
+        final List<String> unhashed = model.components()
+                .filter(component -> component.codeHash() == 0)
+                .map(Component::uniqueName)
+                .toList();
+        assertTrue("components left without a code hash: " + unhashed, unhashed.isEmpty());
+    }
+
+    private static Map<String, Integer> hashes(final ProjectFiles files, final Lang lang) throws Exception {
+        final Map<String, Integer> hashes = new TreeMap<>();
+        compile(files, lang).components().forEach(
+                component -> hashes.put(component.componentType() + " " + component.uniqueName(),
+                        component.codeHash()));
+        return hashes;
+    }
+
+    private static OOPSourceCodeModel compile(final ProjectFiles files, final Lang lang) throws Exception {
+        final CompileResult result = new ClarpseProject(files, lang).result();
+        assertTrue("fixture failed to compile: " + result.failures(), result.failures().isEmpty());
+        return result.model();
+    }
+
+    private static ProjectFiles inMemory(final String path, final String content) {
+        final ProjectFiles files = new ProjectFiles();
+        files.insertFile(new ProjectFile(path, content));
+        return files;
+    }
+
+    private static ProjectFiles fixture(final String language, final String fixtureName) throws Exception {
+        return new ProjectFiles(
+                Paths.get("src/test/resources", language, fixtureName).toAbsolutePath().toString());
+    }
+}

--- a/src/test/java/com/hadi/test/CrossLanguageModifiersTest.java
+++ b/src/test/java/com/hadi/test/CrossLanguageModifiersTest.java
@@ -1,0 +1,139 @@
+package com.hadi.test;
+
+import com.hadi.clarpse.compiler.ClarpseProject;
+import com.hadi.clarpse.compiler.CompileResult;
+import com.hadi.clarpse.compiler.Lang;
+import com.hadi.clarpse.compiler.ProjectFile;
+import com.hadi.clarpse.compiler.ProjectFiles;
+import com.hadi.clarpse.compiler.typescript.NodeRuntime;
+import com.hadi.clarpse.sourcemodel.Component;
+import com.hadi.clarpse.sourcemodel.OOPSourceCodeModel;
+import com.hadi.clarpse.sourcemodel.OOPSourceModelConstants;
+import org.junit.Assume;
+import org.junit.Test;
+
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * {@code modifiers()} should answer "is this public?" and "is this static?" the same way in every
+ * language, and should only ever hold tokens the model can resolve back through its own
+ * {@link OOPSourceModelConstants.AccessModifiers} enum.
+ */
+public class CrossLanguageModifiersTest {
+
+    private static final String JAVA = String.join("\n",
+            "package app;",
+            "public abstract class Svc {",
+            "    private static final int CAP = 3;",
+            "    protected abstract void run();",
+            "    public final synchronized int size() { return 0; }",
+            "    public static int make() { return 3; }",
+            "}");
+
+    private static final String CSHARP = String.join("\n",
+            "namespace App {",
+            "  public abstract partial class Svc {",
+            "    private static readonly int Cap = 3;",
+            "    internal protected virtual void Run() { }",
+            "    public sealed override string ToString() { return null; }",
+            "    public static int Make() { return 3; }",
+            "  }",
+            "}");
+
+    @Test
+    public void javaPublicAndStaticAreExplicit() throws Exception {
+        final OOPSourceCodeModel model = compile(inMemory("/app/Svc.java", JAVA), Lang.JAVA);
+        assertTrue(component(model, "app.Svc").modifiers().contains("public"));
+        assertTrue(component(model, "app.Svc.size()").modifiers().contains("public"));
+        assertTrue(component(model, "app.Svc.make()").modifiers().contains("static"));
+        assertEveryModifierIsResolvable(model);
+    }
+
+    @Test
+    public void csharpPublicAndStaticAreExplicit() throws Exception {
+        final OOPSourceCodeModel model = compile(inMemory("/Svc.cs", CSHARP), Lang.CSHARP);
+        assertTrue(component(model, "App.Svc").modifiers().contains("public"));
+        assertTrue(component(model, "App.Svc.ToString()").modifiers().contains("public"));
+        assertTrue(component(model, "App.Svc.Make()").modifiers().contains("static"));
+        assertEveryModifierIsResolvable(model);
+    }
+
+    @Test
+    public void typescriptExportedDeclarationsArePublic() throws Exception {
+        Assume.assumeTrue(NodeRuntime.isNodeAvailable());
+        final OOPSourceCodeModel model = compile(fixture("typescript"), Lang.TYPESCRIPT);
+        assertTrue(component(model, "src.svc.Svc").modifiers().contains("public"));
+        assertTrue("export is still reported alongside it",
+                component(model, "src.svc.Svc").modifiers().contains("export"));
+        assertTrue(component(model, "src.svc.Shape").modifiers().contains("public"));
+        assertTrue(component(model, "src.svc.Color").modifiers().contains("public"));
+        assertTrue(component(model, "src.svc.helper").modifiers().contains("public"));
+        assertTrue("a module-private type is not public",
+                component(model, "src.svc.Internal").modifiers().isEmpty());
+        assertTrue(component(model, "src.svc.Svc.cap").modifiers().contains("private"));
+        assertTrue(component(model, "src.svc.Svc.cap").modifiers().contains("static"));
+        assertEveryModifierIsResolvable(model);
+    }
+
+    @Test
+    public void pythonVisibilityAndStaticnessAreExplicit() throws Exception {
+        Assume.assumeTrue(NodeRuntime.isNodeAvailable());
+        final OOPSourceCodeModel model = compile(fixture("python"), Lang.PYTHON);
+        assertTrue(component(model, "src.svc.Svc").modifiers().contains("public"));
+        assertTrue(component(model, "src.svc.Svc.size() : int").modifiers().contains("public"));
+        assertTrue(component(model, "src.svc.Svc.owner").modifiers().contains("public"));
+        assertTrue("a dunder method is public API",
+                component(model, "src.svc.Svc.__str__() : str").modifiers().contains("public"));
+        assertTrue(component(model, "src.svc.Svc._helper() : int").modifiers().contains("protected"));
+        assertTrue(component(model, "src.svc.Svc.__secret() : int").modifiers().contains("private"));
+        assertTrue("@staticmethod is static",
+                component(model, "src.svc.Svc.make() : int").modifiers().contains("static"));
+        assertTrue("@classmethod is static too",
+                component(model, "src.svc.Svc.of() : int").modifiers().contains("static"));
+        assertTrue(component(model, "src.svc._Hidden").modifiers().contains("protected"));
+        assertEveryModifierIsResolvable(model);
+    }
+
+    /**
+     * Whatever a compiler emits must round-trip through the model's own modifier vocabulary, so that a
+     * consumer can reach {@link OOPSourceModelConstants.AccessModifiers#getUMLClassDigramSymbol()}
+     * without guessing.
+     */
+    private static void assertEveryModifierIsResolvable(final OOPSourceCodeModel model) {
+        final List<String> unresolvable = new ArrayList<>();
+        model.components().forEach(component -> component.modifiers().forEach(modifier -> {
+            if (OOPSourceModelConstants.accessModifier(modifier) == null) {
+                unresolvable.add(component.uniqueName() + " -> " + modifier);
+            }
+        }));
+        assertTrue("modifiers outside the model's vocabulary: " + unresolvable, unresolvable.isEmpty());
+    }
+
+    private static Component component(final OOPSourceCodeModel model, final String uniqueName) {
+        final Component component = model.getComponent(uniqueName).orElse(null);
+        assertNotNull("no component named " + uniqueName, component);
+        return component;
+    }
+
+    private static OOPSourceCodeModel compile(final ProjectFiles files, final Lang lang) throws Exception {
+        final CompileResult result = new ClarpseProject(files, lang).result();
+        assertTrue("fixture failed to compile: " + result.failures(), result.failures().isEmpty());
+        return result.model();
+    }
+
+    private static ProjectFiles inMemory(final String path, final String content) {
+        final ProjectFiles files = new ProjectFiles();
+        files.insertFile(new ProjectFile(path, content));
+        return files;
+    }
+
+    private static ProjectFiles fixture(final String language) throws Exception {
+        return new ProjectFiles(Paths.get("src/test/resources", language, "cross-language-modifiers")
+                .toAbsolutePath().toString());
+    }
+}

--- a/src/test/java/com/hadi/test/java/JavaRecordTest.java
+++ b/src/test/java/com/hadi/test/java/JavaRecordTest.java
@@ -1,0 +1,155 @@
+package com.hadi.test.java;
+
+import com.hadi.clarpse.compiler.ClarpseProject;
+import com.hadi.clarpse.compiler.Lang;
+import com.hadi.clarpse.compiler.ProjectFile;
+import com.hadi.clarpse.compiler.ProjectFiles;
+import com.hadi.clarpse.reference.ComponentReference;
+import com.hadi.clarpse.sourcemodel.Component;
+import com.hadi.clarpse.sourcemodel.OOPSourceCodeModel;
+import com.hadi.clarpse.sourcemodel.OOPSourceModelConstants.ComponentType;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Records are modelled as classes whose record components are fields, with the canonical constructor
+ * present however it was declared.
+ */
+public class JavaRecordTest {
+
+    private static final String ORDER = String.join("\n",
+            "package app;",
+            "import java.util.List;",
+            "/** An order. */",
+            "public record Order(Price price, List<String> tags) implements Comparable<Order> {",
+            "    static final int MAX = 10;",
+            "    public Order {",
+            "        if (price == null) { throw new IllegalArgumentException(); }",
+            "    }",
+            "    public int compareTo(Order other) { return 0; }",
+            "    record Nested(int a) { }",
+            "}");
+
+    private static final String PRICE = "package app;\npublic class Price { }\n";
+
+    private static final String POINT = String.join("\n",
+            "package app;",
+            "public record Point(int x, int y) {",
+            "    public Point(int x, int y) { this.x = x; this.y = y; }",
+            "    public Point(int both) { this(both, both); }",
+            "}");
+
+    private static final String HOLDER = String.join("\n",
+            "package app;",
+            "public class Holder {",
+            "    public record Inner(String s) { }",
+            "}");
+
+    private static OOPSourceCodeModel model;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        final ProjectFiles files = new ProjectFiles();
+        files.insertFile(new ProjectFile("/app/Order.java", ORDER));
+        files.insertFile(new ProjectFile("/app/Price.java", PRICE));
+        files.insertFile(new ProjectFile("/app/Point.java", POINT));
+        files.insertFile(new ProjectFile("/app/Holder.java", HOLDER));
+        model = new ClarpseProject(files, Lang.JAVA).result().model();
+    }
+
+    @Test
+    public void recordIsModelledAsAClass() {
+        final Component order = component("app.Order");
+        assertEquals(ComponentType.CLASS, order.componentType());
+        assertTrue(order.modifiers().contains("public"));
+        assertTrue("a record is implicitly final", order.modifiers().contains("final"));
+        assertTrue(order.comment().contains("An order."));
+    }
+
+    @Test
+    public void recordComponentsAreFields() {
+        final Component price = component("app.Order.price");
+        assertEquals(ComponentType.FIELD, price.componentType());
+        assertEquals("price : Price", price.codeFragment());
+        assertTrue(price.modifiers().contains("private"));
+        assertTrue(price.modifiers().contains("final"));
+        assertEquals("tags : List<String>", component("app.Order.tags").codeFragment());
+    }
+
+    @Test
+    public void recordComponentTypesReachTheDependencyGraph() {
+        assertTrue(references(component("app.Order.price")).contains("app.Price"));
+        assertTrue(references(component("app.Order")).contains("app.Price"));
+    }
+
+    @Test
+    public void compactConstructorIsModelledAsTheCanonicalConstructor() {
+        final Component ctor = component("app.Order.Order(Price, List<String>)");
+        assertEquals(ComponentType.CONSTRUCTOR, ctor.componentType());
+        assertTrue(ctor.modifiers().contains("public"));
+        assertTrue(ctor.children().contains("app.Order.Order(Price, List<String>).price"));
+        assertTrue(ctor.children().contains("app.Order.Order(Price, List<String>).tags"));
+        assertEquals(ComponentType.CONSTRUCTOR_PARAMETER_COMPONENT,
+                component("app.Order.Order(Price, List<String>).price").componentType());
+    }
+
+    @Test
+    public void compactConstructorBodyReachesTheDependencyGraph() {
+        assertTrue(references(component("app.Order.Order(Price, List<String>)"))
+                .contains("java.lang.IllegalArgumentException"));
+    }
+
+    @Test
+    public void implicitCanonicalConstructorIsModelled() {
+        final Component ctor = component("app.Holder.Inner.Inner(String)");
+        assertEquals(ComponentType.CONSTRUCTOR, ctor.componentType());
+        assertTrue(ctor.modifiers().contains("public"));
+        assertTrue(ctor.children().contains("app.Holder.Inner.Inner(String).s"));
+    }
+
+    @Test
+    public void explicitCanonicalConstructorIsNotDuplicated() {
+        final Component ctor = component("app.Point.Point(int, int)");
+        assertEquals(ComponentType.CONSTRUCTOR, ctor.componentType());
+        assertTrue(model.containsComponent("app.Point.Point(int)"));
+        assertEquals(2, model.components()
+                .filter(cmp -> cmp.componentType() == ComponentType.CONSTRUCTOR)
+                .filter(cmp -> cmp.uniqueName().startsWith("app.Point."))
+                .count());
+        assertTrue(ctor.children().contains("app.Point.Point(int, int).x"));
+    }
+
+    @Test
+    public void recordMembersAreModelledAlongsideRecordComponents() {
+        assertEquals(ComponentType.FIELD, component("app.Order.MAX").componentType());
+        assertEquals(ComponentType.METHOD, component("app.Order.compareTo(Order)").componentType());
+    }
+
+    @Test
+    public void nestedRecordsAreModelledUnderTheirEnclosingType() {
+        assertTrue(component("app.Order").children().contains("app.Order.Nested"));
+        assertEquals(ComponentType.CLASS, component("app.Order.Nested").componentType());
+        assertEquals(ComponentType.FIELD, component("app.Order.Nested.a").componentType());
+        assertTrue(component("app.Holder").children().contains("app.Holder.Inner"));
+        assertEquals(ComponentType.CLASS, component("app.Holder.Inner").componentType());
+    }
+
+    @Test
+    public void recordComponentsCarryDistinctCodeHashes() {
+        assertFalse(component("app.Order.price").codeHash() == 0);
+        assertFalse(component("app.Order.price").codeHash() == component("app.Order.tags").codeHash());
+    }
+
+    private static Component component(final String uniqueName) {
+        return model.getComponent(uniqueName).orElseThrow(
+                () -> new AssertionError("no component named " + uniqueName));
+    }
+
+    private static java.util.List<String> references(final Component component) {
+        return component.references().stream().map(ComponentReference::invokedComponent).toList();
+    }
+}

--- a/src/test/resources/python/code-hash-v1/src/svc.py
+++ b/src/test/resources/python/code-hash-v1/src/svc.py
@@ -1,0 +1,3 @@
+class Svc:
+    def size(self) -> int:
+        return 0

--- a/src/test/resources/python/code-hash-v2/src/svc.py
+++ b/src/test/resources/python/code-hash-v2/src/svc.py
@@ -1,0 +1,3 @@
+class Svc:
+    def size(self) -> int:
+        return 42

--- a/src/test/resources/python/cross-language-modifiers/src/svc.py
+++ b/src/test/resources/python/cross-language-modifiers/src/svc.py
@@ -1,0 +1,26 @@
+class Svc:
+    owner: str
+
+    def size(self) -> int:
+        return 0
+
+    def _helper(self) -> int:
+        return 1
+
+    def __secret(self) -> int:
+        return 2
+
+    def __str__(self) -> str:
+        return "Svc"
+
+    @staticmethod
+    def make() -> int:
+        return 3
+
+    @classmethod
+    def of(cls) -> int:
+        return 4
+
+
+class _Hidden:
+    pass

--- a/src/test/resources/typescript/code-hash-v1/src/svc.ts
+++ b/src/test/resources/typescript/code-hash-v1/src/svc.ts
@@ -1,0 +1,5 @@
+export class Svc {
+  size(): number {
+    return 0;
+  }
+}

--- a/src/test/resources/typescript/code-hash-v1/tsconfig.json
+++ b/src/test/resources/typescript/code-hash-v1/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["**/*.ts"]
+}

--- a/src/test/resources/typescript/code-hash-v2/src/svc.ts
+++ b/src/test/resources/typescript/code-hash-v2/src/svc.ts
@@ -1,0 +1,5 @@
+export class Svc {
+  size(): number {
+    return 42;
+  }
+}

--- a/src/test/resources/typescript/code-hash-v2/tsconfig.json
+++ b/src/test/resources/typescript/code-hash-v2/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["**/*.ts"]
+}

--- a/src/test/resources/typescript/cross-language-modifiers/src/svc.ts
+++ b/src/test/resources/typescript/cross-language-modifiers/src/svc.ts
@@ -1,0 +1,27 @@
+export abstract class Svc {
+  private static readonly cap: number = 3;
+  protected abstract run(): void;
+  public size(): number {
+    return 0;
+  }
+  get label(): string {
+    return "";
+  }
+}
+
+export interface Shape {
+  area(): number;
+}
+
+export enum Color {
+  RED,
+  GREEN
+}
+
+class Internal {
+}
+
+export const LIMIT = 5;
+
+export function helper(): void {
+}

--- a/src/test/resources/typescript/cross-language-modifiers/tsconfig.json
+++ b/src/test/resources/typescript/cross-language-modifiers/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["**/*.ts"]
+}


### PR DESCRIPTION
Fixes #152, fixes #153, fixes #154. Version bumped 9.8.2 → **10.0.0** (one breaking API removal, see below).

## Breaking change

`OOPSourceModelConstants.getJavaAccessModifierMap()` is **removed**. Use
`getAccessModifierMap()` — every modifier token the model accepts, across all supported
languages — or `accessModifier(String)` to resolve a single token to its enum. Once
`Component` validated against the cross-language vocabulary the Java-only map had no
remaining consumer, and a second public accessor that only ever answered "is this a *Java*
modifier?" was not worth the surface. The two maps are now one, grouped by language in a
single static block.

Three defects that all come down to the same thing: the language-agnostic model meant
different things depending on which compiler filled it in.

## Java records (#152)

A `record` produced **no components at all** — `JavaTreeListener` had no
`RecordDeclaration` visitor, so records were silently dropped and any type only reachable
through one disappeared from the dependency graph.

Records now model as `CLASS` components, matching the existing C# precedent of mapping
`record` → `CLASS` (`CSharpModelAssembler.mapTypeComponent`) and avoiding a new
`ComponentType` value that would break consumers switching on it. Per the issue's Expected
list:

- record components become `private final` `FIELD`s with a `name : Type` code fragment;
- the canonical constructor and its `CONSTRUCTOR_PARAMETER_COMPONENT`s are present whether
  it was declared explicitly, declared compactly, or left implicit — an explicit one is
  left to the existing constructor visitor, so it is never duplicated;
- record component types are walked the same way a field declaration's type is walked, so
  `record Order(Price price)` yields the `Order -> Price` edge, and `List<String>` yields
  the same edges an equivalent field would;
- nested records model under their enclosing type, and records nested inside records,
  classes and enums are all visited.

A record also reports `final`, which is a defining property of records and something its
JavaParser modifier list does not spell out. Implicit `static` on a nested record is *not*
added, since clarpse does not add it for nested interfaces or enums either.

Not implemented, deliberately: synthetic accessor `METHOD` components for record
components. The issue's Expected list omits them, and inventing methods that appear in no
source line would be a bigger change than the gap being fixed.

## codeHash (#153)

`codeHash` is the downstream change-detection primitive, and it only worked for Java.

- **C#** hashed `codeFragment`, which is the declaration text cut at the first `{` or `;`.
  A method body edit was therefore *never* visible; field/property hashes came from
  `name : Type` alone; parameters and locals got no hash at all.
- **TypeScript** left `codeFragment` empty for classes and interfaces and emitted no
  `implementationHash` for types, fields or enum members, so those components had
  `codeHash == 0` — indistinguishable from "unchanged".
- **Python** emitted `implementationHash` for methods only; classes and fields sat at 0.

All three now hash the **whole declaration, body included** (whitespace-normalised, so a
reformat is invisible), and every component — C# parameters and locals, TypeScript
parameters, locals and enum members, Python classes, fields and parameters — gets a hash.
Method hashes now cover the signature and modifiers too, not just the body, so a changed
return type registers and a body-less declaration (an interface method, an abstract
method) still gets a real hash. C# partial types sum their parts' hashes, so the merged
hash does not depend on parse order.

On the issue's optional suggestion to make "no hash" distinguishable via `OptionalInt` or
`hasCodeHash()`: `Component` is annotated `@JsonAutoDetect(fieldVisibility = ANY)`, so any
new field lands in the JSON payload of *every* component — exactly the kind of consumer
break the issue is guarding against. Instead, **zero is now never emitted**: each compiler
falls back to the signature and then to the component name, so a zero unambiguously means
"never computed".

## Modifiers (#154)

`Component` had two mutators that disagreed on what was legal — `insertAccessModifier`
validated against the Java-only vocabulary and threw `IllegalArgumentException`, while
`setAccessModifiers` accepted anything. Every non-Java assembler used the unvalidated one,
so `modifiers()` routinely held tokens (`partial`, `internal`, `virtual`, `export`, `let`,
…) that the model's own `AccessModifiers` enum could not resolve.

- The vocabulary now covers every token the four compilers actually emit, across C#,
  TypeScript and modern Java (`sealed`, `non-sealed`, `default`, `transitive`), and both
  mutators enforce it — verified exhaustively against all 15 JavaParser
  `Modifier.Keyword` values and the closed token sets in the C#, TypeScript and Python
  paths, so the now-validating setter cannot throw mid-parse.
- `OOPSourceModelConstants.accessModifier(String)` resolves a token back to its enum, so a
  caller can reach `getUMLClassDigramSymbol()` without guessing at the enum name.
- **Python** now spells out visibility on classes, methods, functions, fields and module
  variables: `__x` private, `_x` protected, everything else — dunder methods included —
  `public`. `@staticmethod` and `@classmethod` map onto `static`, using the flags the
  daemon already computed and nothing read.
- **TypeScript** exported declarations report `public` alongside `export`. `export` is kept
  because it is real information; `public` is added because it is the effective visibility,
  so a module-private type reports neither — mirroring a package-private Java type
  reporting no visibility at all.

## Tests

- `JavaRecordTest` — 10 tests over the record shapes above.
- `CrossLanguageCodeHashTest` — for each of the four languages: a method body edit changes
  the method's and its type's hash, hashes are stable across parses, and no component is
  left with `codeHash == 0`.
- `CrossLanguageModifiersTest` — `public`/`static` mean the same thing in each language,
  and every modifier every compiler emits round-trips through the model's own enum.
- `ComponentModifierContractTest` — both mutators enforce one vocabulary.

668 tests pass locally, with checkstyle and PMD clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
