### PR TITLE
fix: stop recording Any and None as Python dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Clarpse is a multi-language architectural code analysis library for building bet
 <dependency>
   <groupId>io.github.hadi-technology</groupId>
   <artifactId>clarpse</artifactId>
-<version>10.0.0</version>
+<version>10.0.1</version>
 </dependency>
 ```
 

--- a/docs/python-architecture.md
+++ b/docs/python-architecture.md
@@ -75,6 +75,8 @@ and can be mapped through imports or local class declarations.
 - Docstrings are extracted and attached to the component's comment field.
 - Cyclomatic complexity is calculated and stored in the component's cyclo field.
 - Every component carries a non-zero code hash, derived from its full declaration, for change detection.
+- Type-system placeholders (`Any`, `None`, `NoReturn`) never become references; a missing annotation is
+  displayed as `Any` but is not a dependency on anything.
 - Visibility is inferred from naming: `__` is private, `_` is protected, everything else is public.
 - `@staticmethod` and `@classmethod` are reported as `static`.
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>io.github.hadi-technology</groupId>
 	<artifactId>clarpse</artifactId>
-	<version>10.0.0</version>
+	<version>10.0.1</version>
 	<packaging>jar</packaging>
 
 	<name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/java/com/hadi/clarpse/compiler/python/PythonModelAssembler.java
+++ b/src/main/java/com/hadi/clarpse/compiler/python/PythonModelAssembler.java
@@ -16,6 +16,7 @@ import com.hadi.clarpse.sourcemodel.OOPSourceCodeModel;
 import com.hadi.clarpse.sourcemodel.OOPSourceModelConstants;
 import com.hadi.clarpse.sourcemodel.Package;
 
+import java.util.Locale;
 import java.util.Set;
 import java.util.Stack;
 
@@ -476,20 +477,44 @@ final class PythonModelAssembler {
         }
     }
 
+    /**
+     * Annotations that stand in for "no type at all". These are type-system constructs rather than
+     * things a declaration depends on, and clarpse itself substitutes {@code Any} wherever an annotation
+     * is missing - so recording them would put an external dependency on essentially every Python
+     * component, and any rule of the form "this must not depend on anything external" would fire
+     * everywhere. Only consulted for annotations that did not resolve inside the repo, so a repo class
+     * that happens to be named {@code Any} is still a real dependency.
+     */
+    private static final Set<String> TYPE_SYSTEM_PLACEHOLDERS = Set.of(
+            "any", "none", "nonetype", "noreturn", "ellipsis");
+
+    private static boolean isTypeSystemPlaceholder(final String invoked) {
+        String name = invoked.trim();
+        if (name.startsWith("typing.")) {
+            name = name.substring("typing.".length());
+        }
+        return TYPE_SYSTEM_PLACEHOLDERS.contains(name.toLowerCase(Locale.ROOT));
+    }
+
     private static ComponentReference buildReference(final PythonTypeRefModel ref,
                                                      final boolean isExtends) {
         if (ref == null) {
             return null;
         }
         String invoked = null;
+        boolean resolvedInRepo = false;
         if (ref.targetUniqueName != null && !ref.targetUniqueName.isEmpty()) {
             invoked = ref.targetUniqueName;
+            resolvedInRepo = true;
         } else if (ref.externalLabel != null && !ref.externalLabel.isEmpty()) {
             invoked = ref.externalLabel;
         } else if (ref.raw != null && !ref.raw.isEmpty()) {
             invoked = ref.raw;
         }
         if (invoked == null || invoked.isEmpty()) {
+            return null;
+        }
+        if (!resolvedInRepo && isTypeSystemPlaceholder(invoked)) {
             return null;
         }
         if (isExtends) {

--- a/src/main/resources/python/daemon.js
+++ b/src/main/resources/python/daemon.js
@@ -1675,14 +1675,16 @@ function extractParams(funcNode, ctx, parseNodeType) {
       continue;
     }
     const annotationNode = getNodeProp(param, ['typeAnnotation', 'annotation', 'typeExpression']);
+    // `Any` is what an unannotated parameter *displays* as, not something the author depended on, so it
+    // stays in the signature but yields no reference.
     const rawType = annotationNode ? textForNode(annotationNode, ctx.fileText) : 'Any';
-    const ref = resolveTypeRef(annotationNode, rawType, ctx);
+    const ref = annotationNode ? resolveTypeRef(annotationNode, rawType, ctx) : null;
     params.push({
       name: paramName,
       rawType: ref ? ref.raw : rawType,
       implementationHash: stableImplementationHash(textForNode(param, ctx.fileText)),
       targetUniqueName: ref ? ref.targetUniqueName : null,
-      externalLabel: ref ? ref.externalLabel : (rawType || 'Any')
+      externalLabel: ref ? ref.externalLabel : null
     });
   }
   return params;
@@ -1769,7 +1771,8 @@ function extractMethod(methodNode, ctx, parseNodeType) {
   const returnRaw = normalizePythonTypeDisplay(returnRawText || 'Any');
   const signature = buildSignature(name, params, returnRaw || 'Any');
   const uniqueName = ctx.classUniqueName + '.' + signature;
-  const returnRef = resolveTypeRef(returnNode, returnRaw || 'Any', ctx);
+  // An absent return annotation displays as `Any` but is not a dependency on anything.
+  const returnRef = returnNode ? resolveTypeRef(returnNode, returnRaw || 'Any', ctx) : null;
   const cyclo = computeCyclo(methodNode, ctx.fileText);
   // The whole def, not just its suite: a changed signature or decorator is a change too.
   const implementationHash = stableImplementationHash(textForNode(methodNode, ctx.fileText));
@@ -1804,7 +1807,8 @@ function extractFunction(functionNode, ctx, parseNodeType) {
     ? ctx.packageName + '.' + ctx.moduleName
     : ctx.moduleName;
   const uniqueName = moduleUniqueName + '.' + signature;
-  const returnRef = resolveTypeRef(returnNode, returnRaw || 'Any', ctx);
+  // An absent return annotation displays as `Any` but is not a dependency on anything.
+  const returnRef = returnNode ? resolveTypeRef(returnNode, returnRaw || 'Any', ctx) : null;
   const cyclo = computeCyclo(functionNode, ctx.fileText);
   // The whole def, not just its suite: a changed signature or decorator is a change too.
   const implementationHash = stableImplementationHash(textForNode(functionNode, ctx.fileText));
@@ -1848,7 +1852,7 @@ function extractFieldFromStatement(statement, ctx, parseNodeType, options) {
     rawType: ref ? ref.raw : rawType,
     implementationHash: stableImplementationHash(textForNode(statement, ctx.fileText)),
     targetUniqueName: ref ? ref.targetUniqueName : null,
-    externalLabel: ref ? ref.externalLabel : (rawType || 'Any')
+    externalLabel: ref ? ref.externalLabel : null
   };
 }
 
@@ -1895,7 +1899,7 @@ function extractInstanceFieldFromStatement(statement, ctx) {
     rawType: ref ? ref.raw : rawType,
     implementationHash: stableImplementationHash(statementText),
     targetUniqueName: ref ? ref.targetUniqueName : null,
-    externalLabel: ref ? ref.externalLabel : (rawType || 'Any')
+    externalLabel: ref ? ref.externalLabel : null
   };
 }
 

--- a/src/test/java/com/hadi/test/python/PythonTypePlaceholderReferenceTest.java
+++ b/src/test/java/com/hadi/test/python/PythonTypePlaceholderReferenceTest.java
@@ -1,0 +1,100 @@
+package com.hadi.test.python;
+
+import com.hadi.clarpse.compiler.CompileResult;
+import com.hadi.clarpse.reference.ComponentReference;
+import com.hadi.clarpse.sourcemodel.Component;
+import com.hadi.clarpse.sourcemodel.OOPSourceCodeModel;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * {@code Any} is what clarpse displays for a missing annotation, and {@code None} is Python's way of
+ * spelling "returns nothing". Neither is a dependency on anything, so neither may reach
+ * {@code externalDependencies()} - otherwise a rule like "this must not depend on anything external"
+ * fires on essentially every Python component.
+ */
+public class PythonTypePlaceholderReferenceTest {
+
+    private static final String FIXTURE = "type-placeholders";
+    private static final String PACKAGE_PATH = "src";
+    private static final String MODULE = "svc";
+    private static final Set<String> PLACEHOLDERS = Set.of(
+            "any", "typing.any", "none", "nonetype", "noreturn", "ellipsis");
+
+    private static OOPSourceCodeModel model;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        CompileResult result = PythonTestUtil.compileFixture(FIXTURE);
+        Assert.assertTrue(result.failures().isEmpty());
+        model = result.model();
+    }
+
+    @Test
+    public void noComponentDependsOnATypeSystemPlaceholder() {
+        final List<String> offenders = new ArrayList<>();
+        model.components().forEach(component -> component.references().forEach(reference -> {
+            if (PLACEHOLDERS.contains(reference.invokedComponent().toLowerCase(Locale.ROOT))) {
+                offenders.add(component.uniqueName() + " -> " + reference.invokedComponent());
+            }
+        }));
+        Assert.assertTrue("type-system placeholders recorded as dependencies: " + offenders,
+                offenders.isEmpty());
+    }
+
+    @Test
+    public void anUnannotatedMethodHasNoTypeDependency() {
+        final Component method = component("Svc." + PythonTestUtil.signature("untyped", "Any", "n: Any"));
+        Assert.assertTrue(method.references().isEmpty());
+    }
+
+    @Test
+    public void anExplicitAnyAnnotationIsNotADependency() {
+        Assert.assertTrue(component("Svc.anything").references().isEmpty());
+    }
+
+    @Test
+    public void aNoneReturnIsNotADependency() {
+        Assert.assertTrue(component("Svc." + PythonTestUtil.signature("returns_none", "None"))
+                .references().isEmpty());
+    }
+
+    @Test
+    public void realAnnotationsStillResolve() {
+        final Component typed = component("Svc." + PythonTestUtil.signature("typed", "Helper", "n: int"));
+        Assert.assertTrue("internal return type", invoked(typed).contains("src.helper.Helper"));
+        Assert.assertTrue("builtin parameter type", invoked(typed).contains("int"));
+        Assert.assertTrue("third-party return type", invoked(component("Svc." + PythonTestUtil.signature("external", "requests.Response"))).contains("requests.Response"));
+        Assert.assertTrue("generic container", invoked(component("Svc.items")).contains("typing.List"));
+        Assert.assertTrue("type inside Optional[...]", invoked(component("Svc." + PythonTestUtil.signature("optional", "Optional[Helper]"))).contains("src.helper.Helper"));
+    }
+
+    @Test
+    public void missingAnnotationsStillDisplayAsAny() {
+        Assert.assertTrue("Any remains in the signature, it just is not a dependency",
+                model.containsComponent(name("Svc." + PythonTestUtil.signature("untyped", "Any", "n: Any"))));
+    }
+
+    private static List<String> invoked(final Component component) {
+        final List<String> names = new ArrayList<>();
+        for (final ComponentReference reference : component.references()) {
+            names.add(reference.invokedComponent());
+        }
+        return names;
+    }
+
+    private static Component component(final String symbolPath) {
+        return model.getComponent(name(symbolPath)).orElseThrow(
+                () -> new AssertionError("no component named " + name(symbolPath)));
+    }
+
+    private static String name(final String symbolPath) {
+        return PythonTestUtil.uniqueName(PACKAGE_PATH, MODULE, symbolPath);
+    }
+}

--- a/src/test/resources/python/type-placeholders/src/helper.py
+++ b/src/test/resources/python/type-placeholders/src/helper.py
@@ -1,0 +1,2 @@
+class Helper:
+    pass

--- a/src/test/resources/python/type-placeholders/src/svc.py
+++ b/src/test/resources/python/type-placeholders/src/svc.py
@@ -1,0 +1,28 @@
+from typing import Any, List, Optional
+
+import requests
+
+from .helper import Helper
+
+
+class Svc:
+    items: List[str]
+    anything: Any
+
+    def __init__(self, helper: Helper):
+        self.helper = helper
+
+    def typed(self, n: int) -> Helper:
+        return self.helper
+
+    def untyped(self, n):
+        return n
+
+    def returns_none(self) -> None:
+        return None
+
+    def external(self) -> requests.Response:
+        return requests.get("x")
+
+    def optional(self) -> Optional[Helper]:
+        return None


### PR DESCRIPTION
Fixes the third defect on #156 (the `Any` pollution). The imports and granularity halves of that issue
are **not** addressed here and stay open. Version bumped 10.0.0 → 10.0.1.

## The defect

`externalDependencies()` on Python reported a dependency on `Any` for essentially every component:

```
CLASS       src.svc.Svc                                ext=[typing.List, typing.Any, Any, int, None, requests.Response]
CONSTRUCTOR src.svc.Svc.__init__(helper: Helper) : Any  ext=[typing.Any]
FIELD       src.svc.Svc.anything                        ext=[typing.Any]     <-- annotated `Any`
FIELD       src.svc.Svc.helper                          ext=[Any]            <-- unannotated
METHOD      src.svc.Svc.returns_none() : None           ext=[None]
METHOD      src.svc.Svc.untyped(n: Any) : Any           ext=[typing.Any]     <-- nothing annotated at all
```

`Any` is a type-system construct rather than something code depends on, and clarpse *substitutes it
itself* wherever an annotation is missing — so the label was usually not even written by the author.
`None` on a `-> None` return had the same problem, where Java's `void` yields no reference. The
consequence is false positives, not silence: any rule of the form "X must not depend on anything
external" fires everywhere, so `externalDependencies()` could not be trusted on Python without the
consumer filtering these itself.

## The fix

Two layers, because there were two distinct causes:

1. **The daemon no longer invents a reference where there is no annotation.** `extractParams`,
   `extractMethod` and `extractFunction` only resolve a type ref when an annotation node exists, and the
   field extractors no longer fall back to `externalLabel: 'Any'`. `Any` is still what a missing
   annotation *displays* as — signatures and unique names such as `untyped(n: Any) : Any` are unchanged —
   it just is not a dependency.
2. **`PythonModelAssembler.buildReference` drops type-system placeholders** (`Any`, `typing.Any`, `None`,
   `NoneType`, `NoReturn`, `Ellipsis`) when the annotation did not resolve inside the repo. Only the
   unresolved path is filtered, so a repo class that happens to be named `Any` is still a real
   dependency. This layer is needed because `buildReference` also falls back to the raw annotation text,
   and because an explicitly written `Any` is a real annotation that still is not a dependency.

After:

```
CLASS       src.svc.Svc                                ext=[typing.List, int, requests.Response]  int=[src.helper.Helper]
FIELD       src.svc.Svc.anything                       ext=[]
FIELD       src.svc.Svc.helper                         ext=[]
METHOD      src.svc.Svc.returns_none() : None          ext=[]
METHOD      src.svc.Svc.untyped(n: Any) : Any          ext=[]
METHOD      src.svc.Svc.typed(n: int) : Helper         ext=[int]  int=[src.helper.Helper]
```

## Tests

`PythonTypePlaceholderReferenceTest` over a new `type-placeholders` fixture asserts that no component in
the model depends on a placeholder, that an unannotated method / an explicit `Any` field / a `-> None`
return each carry no references at all, that real annotations all still resolve (internal
`src.helper.Helper`, builtin `int`, generic `typing.List`, third-party `requests.Response`, and the type
inside `Optional[Helper]`), and that a missing annotation still displays as `Any` so unique names are
unaffected.

674 tests pass locally, checkstyle and PMD clean.

## Deliberately not changed

`int` is still reported as an external dependency. Python's `int` is a real class, so recording it is
defensible — but Java skips primitives entirely while recording `java.lang.String`, so "builtin types"
are still not treated alike across languages. That is a judgement call about what a builtin is, noted on
#156 rather than decided here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
