### PR TITLE
fix: resolve types from the scopes a name can actually come from, and populate imports everywhere

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>io.github.hadi-technology</groupId>
 	<artifactId>clarpse</artifactId>
-	<version>10.0.3</version>
+	<version>10.1.0</version>
 	<packaging>jar</packaging>
 
 	<name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/java/com/hadi/clarpse/compiler/ClarpseJavaCompiler.java
+++ b/src/main/java/com/hadi/clarpse/compiler/ClarpseJavaCompiler.java
@@ -17,11 +17,17 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * JavaParser based compiler to process source code.
  */
 public class ClarpseJavaCompiler implements ClarpseCompiler {
+
+    /** The package declaration, used to derive a file's source root from its own path. */
+    private static final Pattern PACKAGE_DECLARATION =
+            Pattern.compile("(?m)^\\s*package\\s+([\\w.]+)\\s*;");
 
     private static final Logger LOGGER = LogManager.getLogger(ClarpseJavaCompiler.class);
 
@@ -50,6 +56,39 @@ public class ClarpseJavaCompiler implements ClarpseCompiler {
         return new CompileResult(srcModel, compileFailures);
     }
 
+    /**
+     * The directories under which package paths begin, read off each file's own package declaration
+     * rather than assumed from convention.
+     *
+     * <p>A file at {@code /src/main/java/a/b/C.java} declaring {@code package a.b;} puts its source
+     * root at {@code /src/main/java}. Deriving it this way covers Maven, Gradle, multi-module
+     * layouts and anything unconventional, and costs one regex per file. Guessing
+     * {@code src/main/java} by name would have missed the second half of that list.
+     */
+    private static Set<String> sourceRoots(final List<ProjectFile> files, final String persistDir) {
+        final Set<String> roots = new HashSet<>();
+        for (final ProjectFile file : files) {
+            final String path = file.path();
+            if (path == null || file.content() == null) {
+                continue;
+            }
+            final Matcher matcher = PACKAGE_DECLARATION.matcher(file.content());
+            if (!matcher.find()) {
+                continue;
+            }
+            final String packagePath = "/" + matcher.group(1).trim().replace('.', '/') + "/";
+            final int index = path.lastIndexOf(packagePath);
+            if (index >= 0) {
+                roots.add(persistDir + path.substring(0, index));
+            } else if (path.lastIndexOf('/') >= 0) {
+                // A file whose directory does not match its package: the source root cannot be
+                // derived, so leave it to the project-directory solver rather than invent one.
+                continue;
+            }
+        }
+        return roots;
+    }
+
     @SuppressWarnings("PMD.CloseResource")
     private ParseResults parseJavaFiles(final List<ProjectFile> files, final String persistDir) {
         final int parallelism = CompilerParallelismSupport.resolveParallelism(files.size());
@@ -59,8 +98,9 @@ public class ClarpseJavaCompiler implements ClarpseCompiler {
 
         final ExecutorService executor = Executors.newFixedThreadPool(parallelism);
         try {
+            final Set<String> sourceRoots = sourceRoots(files, persistDir);
             final ThreadLocal<ParserContext> parserContext = ThreadLocal.withInitial(
-                    () -> new ParserContext(persistDir));
+                    () -> new ParserContext(persistDir, sourceRoots));
             final List<Future<ParseOutcome>> futures = new ArrayList<>();
             for (int i = 0; i < files.size(); i++) {
                 final ProjectFile file = files.get(i);

--- a/src/main/java/com/hadi/clarpse/compiler/csharp/CSharpModelAssembler.java
+++ b/src/main/java/com/hadi/clarpse/compiler/csharp/CSharpModelAssembler.java
@@ -45,6 +45,25 @@ final class CSharpModelAssembler {
             Map.entry("void", "System.Void")
     );
 
+    /**
+     * Library type names a repository class may shadow. {@link #BUILTIN_TYPES} holds the language
+     * keywords; these are the framework generics and helpers that appear unqualified in ordinary
+     * code and are never the repository's own type unless something in scope says so.
+     *
+     * <p>Only the last-resort single-match guess consults this. A repository type genuinely called
+     * `List` still resolves by exact name, nesting, namespace or import.
+     */
+    private static final Set<String> FRAMEWORK_TYPE_NAMES = Set.of(
+            "List", "IList", "Dictionary", "IDictionary", "HashSet", "ISet", "Queue", "Stack",
+            "IEnumerable", "IEnumerator", "ICollection", "IReadOnlyList", "IReadOnlyCollection",
+            "IReadOnlyDictionary", "IQueryable", "IAsyncEnumerable",
+            "Task", "ValueTask", "Action", "Func", "Predicate", "Comparer", "EqualityComparer",
+            "Nullable", "Tuple", "ValueTuple", "KeyValuePair", "Lazy", "Span", "Memory",
+            "Array", "Object", "String", "Exception", "Attribute", "Type", "Guid", "Uri",
+            "TimeSpan", "DateTime", "DateTimeOffset", "Version", "Random", "Timer",
+            "Stream", "TextReader", "TextWriter", "Encoding", "Regex", "Match",
+            "CancellationToken", "IServiceProvider", "IDisposable", "IAsyncDisposable");
+
     private CSharpModelAssembler() {
     }
 
@@ -302,7 +321,10 @@ final class CSharpModelAssembler {
         } else {
             component.setComment(memberModel.comment);
         }
-        component.setImports(memberModel.imports);
+        // Imports belong to the file, and in the model to the type that file declares.
+        // Copying them onto members, parameters and locals made `imports()` mean something
+        // different in C# than in Java, where only type components carry them: a field would
+        // report the whole file's using list as if it were its own. See issue #156.
         component.setAccessModifiers(memberModel.modifiers);
         component.setComponentName(ownerType.componentName + "." + memberComponentIdentifier(memberModel, ownerType));
         if (memberModel.codeFragment != null && !memberModel.codeFragment.isEmpty()) {
@@ -326,7 +348,6 @@ final class CSharpModelAssembler {
         }
         component.setName(parameter.name);
         component.setSourceFilePath(memberModel.sourcePath);
-        component.setImports(memberModel.imports);
         component.setAccessModifiers(parameter.modifiers);
         component.setComponentName(ownerComponent.componentName() + "." + parameter.name);
         if (parameter.declaredType != null && !parameter.declaredType.isEmpty()) {
@@ -345,7 +366,6 @@ final class CSharpModelAssembler {
         component.setComponentType(OOPSourceModelConstants.ComponentType.LOCAL);
         component.setName(localModel.name);
         component.setSourceFilePath(localModel.sourcePath);
-        component.setImports(localModel.imports);
         component.setAccessModifiers(localModel.modifiers);
         component.setComponentName(ownerComponent.componentName() + "." + localModel.name);
         if (localModel.codeFragment != null && !localModel.codeFragment.isEmpty()) {
@@ -599,11 +619,47 @@ final class CSharpModelAssembler {
             if (namespaceCandidate != null) {
                 return namespaceCandidate;
             }
+            // Imports are consulted before any repository-wide guess. They used to come after, and
+            // `resolveNamespace` ended in a guess, so the guess always won: a file declaring
+            // `using ...Modules.Meetings.Application.Contracts;` and extending `CommandBase<Unit>`
+            // bound to Administration's `CommandBase` -- one of five identically named types, chosen
+            // by insertion order. A `using` is evidence; a name match across the repository is not.
             final String usingCandidate = resolveUsing(cleaned, ownerType.imports);
             if (usingCandidate != null) {
                 return usingCandidate;
             }
+            final String soleCandidate = soleTypeNamed(cleaned);
+            if (soleCandidate != null) {
+                return soleCandidate;
+            }
+            // Nothing in scope names this type. Returning the bare token leaves it unresolved, and
+            // striff drops an edge that points outside the codebase -- which is the right outcome.
+            // Silence costs a missing edge; a guess costs a fabricated one, and a fabricated edge
+            // has been shown to the user as the evidence under a "you broke your own documented
+            // rule" verdict.
             return cleaned;
+        }
+
+        /**
+         * The only type carrying this short name, or null when several do or the name belongs to a
+         * framework type a repository class happens to shadow.
+         *
+         * <p>The framework guard is not redundant with {@link #BUILTIN_TYPES}: that map holds the
+         * language keywords (`int`, `string`), not the library generics. `List<OrderItem>` in a
+         * Domain class bound to `Clean.Architecture.Web.Contributors.List` -- a user endpoint class
+         * in another project -- and became the witness of a false layering violation. A repository
+         * type genuinely named `List` still resolves through exact name, nesting, namespace or
+         * import; only the last-resort guess is refused.
+         */
+        private String soleTypeNamed(final String simpleName) {
+            if (FRAMEWORK_TYPE_NAMES.contains(simpleName)) {
+                return null;
+            }
+            final List<String> matches = typesBySimpleName.get(simpleName);
+            if (matches == null || matches.size() != 1) {
+                return null;
+            }
+            return matches.get(0);
         }
 
         private String resolveMember(final String ownerTypeUniqueName, final String memberName) {
@@ -644,15 +700,34 @@ final class CSharpModelAssembler {
             return null;
         }
 
+        // Namespace only. This used to fall back to `simpleLookup`, which returned
+        // `matches.get(0)` -- an arbitrary type sharing the short name, decided by insertion order.
+        // Because this method is tried before imports, that guess pre-empted the `using` that held
+        // the answer. Measured across 28 repositories, 222 of 1,490 decidable C# edges onto an
+        // ambiguous short name were resolved to the wrong type (15%, and 57% on
+        // ardalis/CleanArchitecture, 34% on kgrzybek/modular-monolith-with-ddd -- the repositories
+        // that duplicate a type per module, which is the pattern module-boundary rules exist for).
         private String resolveNamespace(final String simpleName, final String namespaceName) {
             if (namespaceName == null || namespaceName.isEmpty()) {
-                return simpleLookup(simpleName);
+                return null;
             }
             final String candidate = namespaceName + "." + simpleName;
             if (typesByUniqueName.containsKey(candidate)) {
                 return candidate;
             }
-            return simpleLookup(simpleName);
+            // Enclosing namespaces, as C# lookup does: a type in `A.B` is visible from `A.B.C`.
+            String enclosing = namespaceName;
+            while (true) {
+                final int lastDot = enclosing.lastIndexOf('.');
+                if (lastDot < 0) {
+                    return null;
+                }
+                enclosing = enclosing.substring(0, lastDot);
+                final String outer = enclosing + "." + simpleName;
+                if (typesByUniqueName.containsKey(outer)) {
+                    return outer;
+                }
+            }
         }
 
         private String resolveUsing(final String simpleName, final Set<String> imports) {
@@ -674,12 +749,5 @@ final class CSharpModelAssembler {
             return null;
         }
 
-        private String simpleLookup(final String simpleName) {
-            final List<String> matches = typesBySimpleName.get(simpleName);
-            if (matches == null || matches.isEmpty()) {
-                return null;
-            }
-            return matches.get(0);
-        }
     }
 }

--- a/src/main/java/com/hadi/clarpse/compiler/java/JavaParserFactory.java
+++ b/src/main/java/com/hadi/clarpse/compiler/java/JavaParserFactory.java
@@ -16,8 +16,36 @@ public final class JavaParserFactory {
     }
 
     public static CombinedTypeSolver setupTypeSolver(String persistDir) {
+        return setupTypeSolver(persistDir, java.util.List.of());
+    }
+
+    /**
+     * Builds a type solver rooted at every source root in the project, not only at the project
+     * directory.
+     *
+     * <p>{@link JavaParserTypeSolver} resolves {@code a.b.C} by looking for {@code <root>/a/b/C.java}.
+     * Rooting it at the project directory only works for a flat layout: in a Maven or Gradle project
+     * the package {@code a} lives at {@code <root>/src/main/java/a}, so every lookup missed. The
+     * effect is invisible for an explicitly imported type, whose name the import map already
+     * carries, and total for anything that needs the solver — reproduced in three files, where a
+     * class implementing an interface reached through {@code import a.*;} had no edge under
+     * {@code src/main/java} and the correct edge under a flat layout, same sources either way.
+     *
+     * @param sourceRoots directories under which package paths begin, derived from the files
+     *     themselves rather than guessed from convention, so unconventional layouts work too
+     */
+    public static CombinedTypeSolver setupTypeSolver(String persistDir,
+                                                     java.util.Collection<String> sourceRoots) {
         final CombinedTypeSolver typeSolver = new CombinedTypeSolver();
         typeSolver.add(new ReflectionTypeSolver());
+        for (final String sourceRoot : sourceRoots) {
+            final java.io.File root = new java.io.File(sourceRoot);
+            if (root.isDirectory()) {
+                typeSolver.add(new JavaParserTypeSolver(root));
+            }
+        }
+        // The project directory stays last: it is correct for a flat layout and harmless otherwise,
+        // and dropping it would regress projects that have no source root at all.
         typeSolver.add(new JavaParserTypeSolver(persistDir));
         return typeSolver;
     }

--- a/src/main/java/com/hadi/clarpse/compiler/java/ParserContext.java
+++ b/src/main/java/com/hadi/clarpse/compiler/java/ParserContext.java
@@ -11,7 +11,11 @@ public class ParserContext {
     private final JavaParser parser;
 
     public ParserContext(final String persistDir) {
-        this.typeSolver = JavaParserFactory.setupTypeSolver(persistDir);
+        this(persistDir, java.util.List.of());
+    }
+
+    public ParserContext(final String persistDir, final java.util.Collection<String> sourceRoots) {
+        this.typeSolver = JavaParserFactory.setupTypeSolver(persistDir, sourceRoots);
         this.parser = new JavaParser(JavaParserFactory.setupParserConfig(this.typeSolver));
     }
 

--- a/src/main/java/com/hadi/clarpse/compiler/python/PythonModelAssembler.java
+++ b/src/main/java/com/hadi/clarpse/compiler/python/PythonModelAssembler.java
@@ -98,7 +98,7 @@ final class PythonModelAssembler {
         }
         if (fileModel.classes != null) {
             for (final PythonClassModel classModel : fileModel.classes) {
-                insertClass(pkg, moduleName, sourcePath, fileModel.packageName, classModel, stack, srcModel);
+                insertClass(pkg, moduleName, sourcePath, fileModel.packageName, classModel, fileModel.imports, stack, srcModel);
             }
         }
     }
@@ -108,9 +108,11 @@ final class PythonModelAssembler {
                                     final String sourcePath,
                                     final String packageName,
                                     final PythonClassModel classModel,
+                                    final java.util.List<String> fileImports,
                                     final Stack<Component> stack,
                                     final OOPSourceCodeModel srcModel) {
-        final Component classComponent = buildClassComponent(pkg, moduleName, sourcePath, packageName, classModel);
+        final Component classComponent = buildClassComponent(pkg, moduleName, sourcePath, packageName, classModel,
+                fileImports);
         insertComponent(classComponent, stack, srcModel, () -> {
             if (classModel.fields != null) {
                 for (final PythonFieldModel field : classModel.fields) {
@@ -136,7 +138,7 @@ final class PythonModelAssembler {
             }
             if (classModel.classes != null) {
                 for (final PythonClassModel nestedClass : classModel.classes) {
-                    insertClass(pkg, moduleName, sourcePath, packageName, nestedClass, stack, srcModel);
+                    insertClass(pkg, moduleName, sourcePath, packageName, nestedClass, fileImports, stack, srcModel);
                 }
             }
         });
@@ -163,7 +165,8 @@ final class PythonModelAssembler {
                                                  final String moduleName,
                                                  final String sourcePath,
                                                  final String packageName,
-                                                 final PythonClassModel classModel) {
+                                                 final PythonClassModel classModel,
+                                                 final java.util.List<String> fileImports) {
         if (classModel == null || classModel.className == null || classModel.className.isEmpty()) {
             return null;
         }
@@ -174,6 +177,12 @@ final class PythonModelAssembler {
         component.setName(classModel.className);
         component.setComponentName(CompilerSupport.componentNameFromUniqueName(packageName, classModel.uniqueName));
         component.setSourceFilePath(sourcePath);
+        // Only type components carry the file's imports, matching Java. A field or method reporting
+        // its file's import list as its own is what made `imports()` mean different things per
+        // language -- see issue #156.
+        if (fileImports != null && !fileImports.isEmpty()) {
+            component.setImports(new java.util.HashSet<>(fileImports));
+        }
         applyVisibility(component, classModel.className);
         applyCodeHash(component, classModel.implementationHash, classModel.className);
         if (classModel.comment != null && !classModel.comment.isEmpty()) {

--- a/src/main/java/com/hadi/clarpse/compiler/python/PythonModelAssembler.java
+++ b/src/main/java/com/hadi/clarpse/compiler/python/PythonModelAssembler.java
@@ -98,9 +98,32 @@ final class PythonModelAssembler {
         }
         if (fileModel.classes != null) {
             for (final PythonClassModel classModel : fileModel.classes) {
-                insertClass(pkg, moduleName, sourcePath, fileModel.packageName, classModel, fileModel.imports, stack, srcModel);
+                insertClass(pkg, moduleName, sourcePath, fileModel.packageName, classModel, stack, srcModel);
             }
         }
+        applyImports(sourcePath, fileModel, srcModel);
+    }
+
+    /**
+     * Attaches the file's imports to the types it declares, and to nothing else.
+     *
+     * <p>Applied after insertion rather than threaded through {@code insertClass}, which already
+     * takes seven parameters — one more trips the parameter-count rule, and bundling arguments to
+     * carry a value two frames down is worse than reading it back off the model. Only type
+     * components carry imports, matching Java: a field reporting its file's import list as its own
+     * is what made {@code imports()} mean a different thing in each language (issue #156).
+     */
+    private static void applyImports(final String sourcePath,
+                                     final PythonFileModel fileModel,
+                                     final OOPSourceCodeModel srcModel) {
+        if (fileModel.imports == null || fileModel.imports.isEmpty()) {
+            return;
+        }
+        final java.util.Set<String> imports = new java.util.LinkedHashSet<>(fileModel.imports);
+        srcModel.components()
+                .filter(component -> component.componentType().isBaseComponent())
+                .filter(component -> sourcePath.equals(component.sourceFile()))
+                .forEach(component -> component.setImports(imports));
     }
 
     private static void insertClass(final Package pkg,
@@ -108,11 +131,9 @@ final class PythonModelAssembler {
                                     final String sourcePath,
                                     final String packageName,
                                     final PythonClassModel classModel,
-                                    final java.util.List<String> fileImports,
                                     final Stack<Component> stack,
                                     final OOPSourceCodeModel srcModel) {
-        final Component classComponent = buildClassComponent(pkg, moduleName, sourcePath, packageName, classModel,
-                fileImports);
+        final Component classComponent = buildClassComponent(pkg, moduleName, sourcePath, packageName, classModel);
         insertComponent(classComponent, stack, srcModel, () -> {
             if (classModel.fields != null) {
                 for (final PythonFieldModel field : classModel.fields) {
@@ -138,7 +159,7 @@ final class PythonModelAssembler {
             }
             if (classModel.classes != null) {
                 for (final PythonClassModel nestedClass : classModel.classes) {
-                    insertClass(pkg, moduleName, sourcePath, packageName, nestedClass, fileImports, stack, srcModel);
+                    insertClass(pkg, moduleName, sourcePath, packageName, nestedClass, stack, srcModel);
                 }
             }
         });
@@ -165,8 +186,7 @@ final class PythonModelAssembler {
                                                  final String moduleName,
                                                  final String sourcePath,
                                                  final String packageName,
-                                                 final PythonClassModel classModel,
-                                                 final java.util.List<String> fileImports) {
+                                                 final PythonClassModel classModel) {
         if (classModel == null || classModel.className == null || classModel.className.isEmpty()) {
             return null;
         }
@@ -177,12 +197,6 @@ final class PythonModelAssembler {
         component.setName(classModel.className);
         component.setComponentName(CompilerSupport.componentNameFromUniqueName(packageName, classModel.uniqueName));
         component.setSourceFilePath(sourcePath);
-        // Only type components carry the file's imports, matching Java. A field or method reporting
-        // its file's import list as its own is what made `imports()` mean different things per
-        // language -- see issue #156.
-        if (fileImports != null && !fileImports.isEmpty()) {
-            component.setImports(new java.util.HashSet<>(fileImports));
-        }
         applyVisibility(component, classModel.className);
         applyCodeHash(component, classModel.implementationHash, classModel.className);
         if (classModel.comment != null && !classModel.comment.isEmpty()) {

--- a/src/main/java/com/hadi/clarpse/compiler/python/model/PythonFileModel.java
+++ b/src/main/java/com/hadi/clarpse/compiler/python/model/PythonFileModel.java
@@ -14,5 +14,14 @@ public class PythonFileModel {
     public List<PythonClassModel> classes = new ArrayList<>();
     public List<PythonMethodModel> functions = new ArrayList<>();
     public List<PythonFieldModel> moduleFields = new ArrayList<>();
+
+    /**
+     * Modules and symbols this file imports, already resolved by the daemon — relative forms
+     * expanded and internal-ness checked against the module index. The daemon computed these to
+     * drive type resolution and then omitted them from the payload, which is why
+     * {@code imports()} was empty on every Python component. See issue #156.
+     */
+    public List<String> imports = new ArrayList<>();
+
     public List<String> warnings = new ArrayList<>();
 }

--- a/src/main/java/com/hadi/clarpse/compiler/typescript/TypeScriptModelAssembler.java
+++ b/src/main/java/com/hadi/clarpse/compiler/typescript/TypeScriptModelAssembler.java
@@ -42,6 +42,49 @@ final class TypeScriptModelAssembler {
         for (final TypeScriptComponentModel declaration : fileModel.declarations) {
             insertComponentTree(pkg, moduleName, sourcePath, repoRoot, declaration, srcModel);
         }
+        applyImports(repoRoot, sourcePath, fileModel, srcModel);
+    }
+
+    /**
+     * Attaches the file's imports to the types it declares, and to nothing else.
+     *
+     * <p>Only type components carry them, matching Java: a field or method reporting its file's
+     * import list as its own is what made {@code imports()} mean a different thing in each language
+     * (issue #156). An import the TypeScript compiler resolved inside the repository is recorded as
+     * the component name it refers to, so it lines up with the rest of the model; anything else
+     * keeps its specifier verbatim rather than being guessed into a path.
+     */
+    private static void applyImports(final String repoRoot,
+                                     final String sourcePath,
+                                     final TypeScriptFileModel fileModel,
+                                     final OOPSourceCodeModel srcModel) {
+        if (fileModel.imports == null || fileModel.imports.isEmpty()) {
+            return;
+        }
+        final java.util.Set<String> imports = new java.util.LinkedHashSet<>();
+        for (final com.hadi.clarpse.compiler.typescript.model.TypeScriptImportModel imported : fileModel.imports) {
+            if (imported == null) {
+                continue;
+            }
+            String value = null;
+            if (imported.filePath != null && imported.symbolName != null) {
+                value = CompilerSupport.resolveUniqueNameFromTarget(
+                        repoRoot, imported.filePath, imported.symbolName);
+            }
+            if (value == null || value.isEmpty()) {
+                value = imported.module;
+            }
+            if (value != null && !value.isEmpty()) {
+                imports.add(value);
+            }
+        }
+        if (imports.isEmpty()) {
+            return;
+        }
+        srcModel.components()
+                .filter(component -> component.componentType().isBaseComponent())
+                .filter(component -> sourcePath.equals(component.sourceFile()))
+                .forEach(component -> component.setImports(imports));
     }
 
     private static void insertComponentTree(final Package pkg,

--- a/src/main/java/com/hadi/clarpse/compiler/typescript/model/TypeScriptFileModel.java
+++ b/src/main/java/com/hadi/clarpse/compiler/typescript/model/TypeScriptFileModel.java
@@ -10,4 +10,7 @@ public class TypeScriptFileModel {
 
     public String filePath;
     public List<TypeScriptComponentModel> declarations = new ArrayList<>();
+
+    /** Names this file imports. Empty until issue #156; the daemon did not collect them. */
+    public List<TypeScriptImportModel> imports = new ArrayList<>();
 }

--- a/src/main/java/com/hadi/clarpse/compiler/typescript/model/TypeScriptImportModel.java
+++ b/src/main/java/com/hadi/clarpse/compiler/typescript/model/TypeScriptImportModel.java
@@ -1,0 +1,16 @@
+package com.hadi.clarpse.compiler.typescript.model;
+
+/**
+ * One name brought into a file by an import declaration.
+ *
+ * <p>{@code filePath} is set only when the TypeScript compiler resolved the specifier to a file
+ * inside the repository; an unresolved or external specifier leaves it null and carries only
+ * {@code module}. Resolution is the checker's, not string manipulation on the specifier, so an
+ * import TypeScript itself cannot resolve is reported as external rather than guessed into a path.
+ */
+public class TypeScriptImportModel {
+
+    public String module;
+    public String filePath;
+    public String symbolName;
+}

--- a/src/main/java/com/hadi/clarpse/listener/JavaTreeListener.java
+++ b/src/main/java/com/hadi/clarpse/listener/JavaTreeListener.java
@@ -76,6 +76,9 @@ public class JavaTreeListener extends VoidVisitorAdapter<Object> {
     private final TypeSolver typeSolver;
     private final OOPSourceCodeModel srcModel;
     private final Map<String, String> currentImportsMap = new HashMap<>();
+
+    /** Packages brought into scope by an on-demand import (`import a.*;`), searched by name. */
+    private final Set<String> currentWildcardImports = new HashSet<>();
     private final ProjectFile file;
     private Package currentPkg;
     private int currCyclomaticComplexity = 0;
@@ -172,7 +175,17 @@ public class JavaTreeListener extends VoidVisitorAdapter<Object> {
         final String fullImportName = ctx.getNameAsString().trim().replaceAll(";", "");
         final String shortImportName = ctx.getName().getId().trim().replaceAll(";", "");
         currentImports.add(fullImportName);
-        currentImportsMap.put(shortImportName, fullImportName);
+        // An on-demand import names a package, not a type, so it cannot go in the short-name map:
+        // JavaParser reports `import a.*;` as name "a", which would record the useless entry
+        // a -> a and leave every type it brings into scope unresolvable. `resolveType` searches
+        // these prefixes instead. Without this, a class implementing an interface reached through
+        // a wildcard import had no edge at all -- reproduced in three files, where `import a.Base;`
+        // yields the edge and `import a.*;` yields nothing.
+        if (ctx.isAsterisk()) {
+            currentWildcardImports.add(fullImportName);
+        } else {
+            currentImportsMap.put(shortImportName, fullImportName);
+        }
         super.visit(ctx, arg);
     }
 
@@ -827,10 +840,44 @@ public class JavaTreeListener extends VoidVisitorAdapter<Object> {
             resolvedType = OOPSourceModelConstants.getJavaDefaultClasses().get(type);
         } else if (symbol.isSolved()) {
             resolvedType = symbol.getCorrespondingDeclaration().getQualifiedName();
+        } else {
+            // On-demand imports, tried only after every exact form has failed and accepted only
+            // when the type solver confirms the type exists in that package. A prefix that does not
+            // resolve is skipped rather than assumed, so this recovers real edges without inventing
+            // any -- the same rule the `assumeCurrentPackage` note below is about.
+            for (final String wildcardPackage : currentWildcardImports) {
+                final String candidate = wildcardPackage + "." + type;
+                if (typeSolver.tryToSolveType(candidate).isSolved()) {
+                    resolvedType = candidate;
+                    break;
+                }
+            }
         }
         if (resolvedType.isEmpty()) {
             if (!assumeCurrentPackage) {
                 return null;
+            }
+            // A sibling nested type, named plainly from inside the type that declares it:
+            // `class Field { interface Validator {} static class RangeValidator implements Validator {} }`.
+            // The solver cannot see it under a bare name and the current-package assumption below
+            // turns it into `a.Validator`, which does not exist and is dropped as external -- so the
+            // relation vanished rather than being wrong, which is why it read as a coverage gap.
+            //
+            // Confined to a type position and to candidates that are themselves types. Run over
+            // bare identifiers it matched fields: `return MAX_NOTES;` inside a class found the
+            // field `<Type>.MAX_NOTES` and invented a type reference to it, which is the failure
+            // the hygiene tests exist to prevent.
+            for (int i = componentStack.size() - 1; i >= 0; i--) {
+                final Component enclosing = componentStack.get(i);
+                if (!enclosing.componentType().isBaseComponent()) {
+                    continue;
+                }
+                final String nested = enclosing.uniqueName() + "." + type;
+                final boolean isType = srcModel.getComponent(nested)
+                        .map(found -> found.componentType().isBaseComponent()).orElse(false);
+                if (isType || typeSolver.tryToSolveType(nested).isSolved()) {
+                    return nested;
+                }
             }
             if (currentPkg != null) {
                 resolvedType = currentPkg.path() + "." + type;

--- a/src/main/java/com/hadi/clarpse/listener/ParseUtil.java
+++ b/src/main/java/com/hadi/clarpse/listener/ParseUtil.java
@@ -166,13 +166,33 @@ public class ParseUtil {
     }
 
     public static void insertCmpRef(final Component cmp, ComponentReference cmpRef, Stack<Component> cmpStack) {
-        // prevent self referencing coponents
+        // A component may not reference itself. It may absolutely reference the type it is declared
+        // inside: `interface Event { class Created implements Event {} }` is ordinary Java, and
+        // matching against the whole stack — which holds every enclosing component — silently
+        // dropped that edge. Reproduced in two files; the same shape is why debezium's
+        // `Field.RangeValidator implements Validator` and scrapy-style nested event classes had no
+        // inheritance edge at all, and why a documented rule about them answered "couldn't tell".
+        //
+        // Bubbling an extension or implementation up to the parent is a different hazard and is
+        // still prevented, in copyRefsToParents, so a parent cannot end up extending itself.
+        final boolean inheritance = cmpRef instanceof TypeExtensionReference
+                || cmpRef instanceof TypeImplementationReference;
+        final boolean nestedTypeInheritingEnclosing = inheritance && cmp.componentType().isBaseComponent();
         for (Component stackCmp : cmpStack) {
-            if (stackCmp.uniqueName().equals(cmpRef.invokedComponent())) {
-                LOGGER.debug("Found self-reference of " + cmpRef.invokedComponent() + " from cmp " + cmp.uniqueName()
-                        + ", not adding.");
-                return;
+            if (!stackCmp.uniqueName().equals(cmpRef.invokedComponent())) {
+                continue;
             }
+            // A type may inherit the type it is declared inside, and only that case is let through.
+            // The stack guard still applies to everything else, because it does a second job the
+            // name suggests but does not say: it stops a *member* referencing its declaring type,
+            // which is what makes `class Test { public Test() {} }` produce no reference at all.
+            // Widening it to a plain self-check broke exactly that.
+            if (nestedTypeInheritingEnclosing && !cmp.uniqueName().equals(cmpRef.invokedComponent())) {
+                continue;
+            }
+            LOGGER.debug("Found self-reference of " + cmpRef.invokedComponent() + " from cmp " + cmp.uniqueName()
+                    + ", not adding.");
+            return;
         }
         cmp.insertCmpRef(cmpRef);
     }

--- a/src/main/resources/python/daemon.js
+++ b/src/main/resources/python/daemon.js
@@ -2219,6 +2219,18 @@ async function handleGetFileModel(params) {
   } catch (err) {
     return { error: { code: ERROR_CODES.PARSE_FAILED, message: 'Parse failed' } };
   }
+  // The imports are already resolved above -- relative forms expanded, internal-ness checked
+  // against the module index -- and were then dropped from the payload, so `imports()` was empty
+  // for every Python component while the same data drove type resolution. See issue #156.
+  const importList = [];
+  for (const moduleName of imported.importedModules.values()) {
+    if (moduleName) importList.push(moduleName);
+  }
+  for (const symbol of imported.importedSymbols.values()) {
+    if (symbol && symbol.moduleName && symbol.symbolName) {
+      importList.push(symbol.moduleName + '.' + symbol.symbolName);
+    }
+  }
   return {
     result: {
       filePath: normalized,
@@ -2227,6 +2239,7 @@ async function handleGetFileModel(params) {
       classes,
       functions,
       moduleFields,
+      imports: Array.from(new Set(importList)),
       warnings: []
     }
   };

--- a/src/main/resources/typescript/daemon.js
+++ b/src/main/resources/typescript/daemon.js
@@ -1106,10 +1106,67 @@ async function handleGetFileModel(params) {
     }
     throw err;
   }
+  let imports = [];
+  try {
+    imports = collectImports(ts, entryInfo.source, checker);
+  } catch (err) {
+    imports = [];
+  }
   return {
     filePath: normalized,
-    declarations
+    declarations,
+    imports
   };
+}
+
+
+// Imports were never collected: module resolution is delegated to the TypeScript compiler's symbol
+// table, so nothing needed them and `imports()` came back empty for every TypeScript component
+// while Java and C# populated it. Issue #156.
+//
+// Resolved through the checker rather than by string manipulation on the specifier, so an import
+// that TypeScript itself cannot resolve is reported as external rather than guessed into a path.
+function collectImports(ts, source, checker) {
+  const results = [];
+  for (const statement of source.statements) {
+    if (!ts.isImportDeclaration(statement) || !statement.moduleSpecifier) continue;
+    const specifier = statement.moduleSpecifier.text;
+    if (!specifier) continue;
+
+    let resolvedFile = null;
+    try {
+      const moduleSymbol = checker.getSymbolAtLocation(statement.moduleSpecifier);
+      const declaration = moduleSymbol && moduleSymbol.declarations && moduleSymbol.declarations[0];
+      if (declaration && declaration.getSourceFile) {
+        const fileName = declaration.getSourceFile().fileName;
+        if (fileName && isInternalFile(fileName)) resolvedFile = fileName;
+      }
+    } catch (err) {
+      resolvedFile = null;
+    }
+
+    const names = [];
+    const clause = statement.importClause;
+    if (clause) {
+      if (clause.name) names.push(clause.name.text);
+      const bindings = clause.namedBindings;
+      if (bindings) {
+        if (ts.isNamedImports(bindings)) {
+          for (const element of bindings.elements) names.push(element.name.text);
+        } else if (bindings.name) {
+          names.push(bindings.name.text);
+        }
+      }
+    }
+    if (names.length === 0) {
+      results.push({ module: specifier, filePath: resolvedFile, symbolName: null });
+      continue;
+    }
+    for (const name of names) {
+      results.push({ module: specifier, filePath: resolvedFile, symbolName: name });
+    }
+  }
+  return results;
 }
 
 async function handleRequest(request) {

--- a/src/test/java/com/hadi/test/CrossLanguageImportsTest.java
+++ b/src/test/java/com/hadi/test/CrossLanguageImportsTest.java
@@ -1,0 +1,120 @@
+package com.hadi.test;
+
+import com.hadi.clarpse.compiler.ClarpseProject;
+import com.hadi.clarpse.compiler.Lang;
+import com.hadi.clarpse.compiler.ProjectFile;
+import com.hadi.clarpse.compiler.ProjectFiles;
+import com.hadi.clarpse.sourcemodel.Component;
+import com.hadi.clarpse.sourcemodel.OOPSourceCodeModel;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * {@code imports()} should mean one thing in every language: the imports of the file, carried by
+ * the types that file declares and by nothing else.
+ *
+ * <p>It used to mean four things. Java populated it on types only; C# copied the file's using list
+ * onto methods, fields, parameters and locals, so a field reported its file's imports as its own;
+ * Python computed the imports, used them to resolve types, and then dropped them from the payload;
+ * TypeScript never collected them at all. A consumer reading the field could not tell an empty list
+ * apart from a language that does not fill it in. See issue #156.
+ */
+public class CrossLanguageImportsTest {
+
+    private static OOPSourceCodeModel model(final Lang lang, final ProjectFile... files) throws Exception {
+        final ProjectFiles projectFiles = new ProjectFiles();
+        for (final ProjectFile file : files) {
+            projectFiles.insertFile(file);
+        }
+        return new ClarpseProject(projectFiles, lang).result().model();
+    }
+
+    private static Component component(final OOPSourceCodeModel model, final String name) {
+        return model.getComponent(name).orElseThrow(() -> new AssertionError(
+                "no component " + name + " in "
+                        + model.components().map(Component::uniqueName).collect(Collectors.toList())));
+    }
+
+    private static List<Component> nonTypeComponents(final OOPSourceCodeModel model) {
+        return model.components()
+                .filter(component -> !component.componentType().isBaseComponent())
+                .collect(Collectors.toList());
+    }
+
+    @Test
+    public void javaCarriesImportsOnTypesOnly() throws Exception {
+        final OOPSourceCodeModel model = model(Lang.JAVA,
+                new ProjectFile("/src/main/java/app/util/Helper.java",
+                        "package app.util;\npublic class Helper { }\n"),
+                new ProjectFile("/src/main/java/app/Svc.java",
+                        "package app;\nimport java.util.List;\nimport app.util.Helper;\n"
+                        + "public class Svc {\n  private List<Helper> items;\n"
+                        + "  public Helper helper() { return null; }\n}\n"));
+
+        assertTrue(component(model, "app.Svc").imports().contains("app.util.Helper"));
+        assertNoImportsOnMembers(model);
+    }
+
+    @Test
+    public void csharpDoesNotCopyImportsOntoMembers() throws Exception {
+        final OOPSourceCodeModel model = model(Lang.CSHARP,
+                new ProjectFile("/Util/Helper.cs", "namespace App.Util;\npublic class Helper { }\n"),
+                new ProjectFile("/Svc.cs",
+                        "using System.Collections.Generic;\nusing App.Util;\n"
+                        + "namespace App;\npublic class Svc {\n"
+                        + "  private Helper item;\n  public Helper Helper() { return null; }\n}\n"));
+
+        assertTrue(component(model, "App.Svc").imports().contains("App.Util"));
+        assertNoImportsOnMembers(model);
+    }
+
+    @Test
+    public void pythonPopulatesImports() throws Exception {
+        final OOPSourceCodeModel model = model(Lang.PYTHON,
+                new ProjectFile("/src/helper.py", "class Helper:\n    pass\n"),
+                new ProjectFile("/src/svc.py",
+                        "import os\nfrom .helper import Helper\n\n"
+                        + "class Svc:\n    def helper(self):\n        return Helper()\n"));
+
+        final Component svc = component(model, "src.svc.Svc");
+        assertTrue("a resolved internal import should be recorded",
+                svc.imports().contains("src.helper.Helper"));
+        assertTrue("a standard-library import should be recorded", svc.imports().contains("os"));
+        assertNoImportsOnMembers(model);
+    }
+
+    /**
+     * An internal import becomes the component name it refers to, so it lines up with the rest of
+     * the model; an external one keeps its specifier, because the TypeScript compiler could not
+     * resolve it to a file in the repository and guessing a path would invent one.
+     */
+    @Test
+    public void typescriptPopulatesImports() throws Exception {
+        final OOPSourceCodeModel model = model(Lang.TYPESCRIPT,
+                new ProjectFile("/package.json", "{ \"name\": \"t\", \"version\": \"1.0.0\" }"),
+                new ProjectFile("/tsconfig.json",
+                        "{ \"compilerOptions\": { \"target\": \"ES2020\", \"module\": \"commonjs\" } }"),
+                new ProjectFile("/src/helper.ts", "export class Helper { go(): void { } }\n"),
+                new ProjectFile("/src/svc.ts",
+                        "import { Helper } from \"./helper\";\nimport * as path from \"path\";\n\n"
+                        + "export class Svc { helper(): Helper { return new Helper(); } }\n"));
+
+        final Component svc = component(model, "src.svc.Svc");
+        assertTrue("internal import should resolve to its component name",
+                svc.imports().contains("src.helper.Helper"));
+        assertTrue("external import should keep its specifier", svc.imports().contains("path"));
+        assertNoImportsOnMembers(model);
+    }
+
+    private static void assertNoImportsOnMembers(final OOPSourceCodeModel model) {
+        for (final Component component : nonTypeComponents(model)) {
+            assertEquals(component.uniqueName() + " is not a type and must carry no imports",
+                    0, component.imports().size());
+        }
+    }
+}

--- a/src/test/java/com/hadi/test/CrossLanguageImportsTest.java
+++ b/src/test/java/com/hadi/test/CrossLanguageImportsTest.java
@@ -4,8 +4,10 @@ import com.hadi.clarpse.compiler.ClarpseProject;
 import com.hadi.clarpse.compiler.Lang;
 import com.hadi.clarpse.compiler.ProjectFile;
 import com.hadi.clarpse.compiler.ProjectFiles;
+import com.hadi.clarpse.compiler.typescript.NodeRuntime;
 import com.hadi.clarpse.sourcemodel.Component;
 import com.hadi.clarpse.sourcemodel.OOPSourceCodeModel;
+import org.junit.Assume;
 import org.junit.Test;
 
 import java.util.List;
@@ -75,6 +77,10 @@ public class CrossLanguageImportsTest {
 
     @Test
     public void pythonPopulatesImports() throws Exception {
+        // The Python and TypeScript compilers drive a Node daemon. The Docker builder image has no
+        // Node, so an unguarded test here fails the image build rather than the language -- which
+        // is what the existing cross-language tests skip for.
+        Assume.assumeTrue(NodeRuntime.isNodeAvailable());
         final OOPSourceCodeModel model = model(Lang.PYTHON,
                 new ProjectFile("/src/helper.py", "class Helper:\n    pass\n"),
                 new ProjectFile("/src/svc.py",
@@ -95,6 +101,7 @@ public class CrossLanguageImportsTest {
      */
     @Test
     public void typescriptPopulatesImports() throws Exception {
+        Assume.assumeTrue(NodeRuntime.isNodeAvailable());
         final OOPSourceCodeModel model = model(Lang.TYPESCRIPT,
                 new ProjectFile("/package.json", "{ \"name\": \"t\", \"version\": \"1.0.0\" }"),
                 new ProjectFile("/tsconfig.json",

--- a/src/test/java/com/hadi/test/csharp/CSharpAmbiguousNameResolutionTest.java
+++ b/src/test/java/com/hadi/test/csharp/CSharpAmbiguousNameResolutionTest.java
@@ -1,0 +1,96 @@
+package com.hadi.test.csharp;
+
+import com.hadi.clarpse.compiler.ProjectFile;
+import com.hadi.clarpse.sourcemodel.Component;
+import com.hadi.clarpse.sourcemodel.OOPSourceCodeModel;
+import org.junit.Test;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Which type a plain name refers to, when several types share it.
+ *
+ * <p>Resolution used to end in a repository-wide guess that returned whichever same-named type was
+ * registered first, and that guess was consulted <em>before</em> the file's own {@code using}
+ * directives. Measured across 28 repositories, 222 of 1,490 decidable C# references onto an
+ * ambiguous short name bound to the wrong type — 57% on ardalis/CleanArchitecture and 34% on
+ * kgrzybek/modular-monolith-with-ddd, the codebases that duplicate a type per module, which is
+ * exactly the shape a module-boundary rule is written about.
+ *
+ * <p>These are not cosmetic: a fabricated edge became the cited evidence under a "this change
+ * breaks a rule your own documentation states" verdict shown to a maintainer.
+ */
+public class CSharpAmbiguousNameResolutionTest {
+
+    private static Set<String> refs(final OOPSourceCodeModel model, final String component) {
+        final Component cmp = model.getComponent(component).orElseThrow(
+                () -> new AssertionError("no component " + component + " in "
+                        + model.components().map(Component::uniqueName).collect(Collectors.toList())));
+        return cmp.references().stream().map(r -> r.invokedComponent()).collect(Collectors.toSet());
+    }
+
+    /**
+     * Every module declaring its own base type is the modular-monolith pattern, not an accident.
+     * The importing file names one of them and must get that one.
+     */
+    @Test
+    public void aUsingDirectiveOutranksASameNamedTypeElsewhere() throws Exception {
+        final OOPSourceCodeModel model = CSharpTestUtil.compileInline(
+                new ProjectFile("/Admin/Contracts/CommandBase.cs",
+                        "namespace App.Modules.Admin.Contracts;\npublic class CommandBase { }\n"),
+                new ProjectFile("/Meetings/Contracts/CommandBase.cs",
+                        "namespace App.Modules.Meetings.Contracts;\npublic class CommandBase { }\n"),
+                new ProjectFile("/Meetings/Commands/RemoveComment.cs",
+                        "using App.Modules.Meetings.Contracts;\n"
+                        + "namespace App.Modules.Meetings.Commands;\n"
+                        + "public class RemoveComment : CommandBase { }\n")).model();
+
+        final Set<String> references = refs(model, "App.Modules.Meetings.Commands.RemoveComment");
+        assertTrue("should bind the CommandBase named by the using directive",
+                references.contains("App.Modules.Meetings.Contracts.CommandBase"));
+        assertFalse("must not bind another module's identically named type",
+                references.contains("App.Modules.Admin.Contracts.CommandBase"));
+    }
+
+    /**
+     * A repository class may share a name with a framework generic. {@code List<T>} in a Domain
+     * entity bound to a user endpoint class called {@code List} in another project, and those two
+     * fabricated edges were the witnesses of a false layering violation on
+     * ardalis/CleanArchitecture.
+     */
+    @Test
+    public void aFrameworkGenericIsNotCapturedByASameNamedUserClass() throws Exception {
+        final OOPSourceCodeModel model = CSharpTestUtil.compileInline(
+                new ProjectFile("/Web/Contributors/List.cs",
+                        "namespace App.Web.Contributors;\npublic class List { }\n"),
+                new ProjectFile("/Domain/Order.cs",
+                        "namespace App.Domain;\n"
+                        + "public class Order {\n"
+                        + "  private readonly List<OrderItem> items = new();\n"
+                        + "}\n"),
+                new ProjectFile("/Domain/OrderItem.cs",
+                        "namespace App.Domain;\npublic class OrderItem { }\n")).model();
+
+        assertFalse("the BCL generic must not bind to a user class of the same name",
+                refs(model, "App.Domain.Order").contains("App.Web.Contributors.List"));
+    }
+
+    /**
+     * The guess is refused, not replaced by a different guess: a name carried by exactly one type
+     * still resolves, so ordinary code loses nothing.
+     */
+    @Test
+    public void anUnambiguousNameStillResolvesWithoutAUsing() throws Exception {
+        final OOPSourceCodeModel model = CSharpTestUtil.compileInline(
+                new ProjectFile("/Domain/Repo.cs",
+                        "namespace App.Domain;\npublic class UniqueRepo { }\n"),
+                new ProjectFile("/Web/Handler.cs",
+                        "namespace App.Web;\npublic class Handler : UniqueRepo { }\n")).model();
+
+        assertTrue(refs(model, "App.Web.Handler").contains("App.Domain.UniqueRepo"));
+    }
+}

--- a/src/test/java/com/hadi/test/java/JavaTypeResolutionScopeTest.java
+++ b/src/test/java/com/hadi/test/java/JavaTypeResolutionScopeTest.java
@@ -1,0 +1,116 @@
+package com.hadi.test.java;
+
+import com.hadi.clarpse.compiler.ClarpseProject;
+import com.hadi.clarpse.compiler.Lang;
+import com.hadi.clarpse.compiler.ProjectFile;
+import com.hadi.clarpse.compiler.ProjectFiles;
+import com.hadi.clarpse.sourcemodel.Component;
+import com.hadi.clarpse.sourcemodel.OOPSourceCodeModel;
+import org.junit.Test;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * The scopes a plain type name can come from, each of which silently produced no edge at all.
+ *
+ * <p>Every case here was found by auditing parsed models of real repositories against what their
+ * sources plainly declare, and each one cost a documented architectural rule its answer: a relation
+ * that is absent from the model cannot be checked, so the rule reports "couldn't tell" about
+ * something stated in one line of Java.
+ */
+public class JavaTypeResolutionScopeTest {
+
+    private static OOPSourceCodeModel model(final ProjectFile... files) throws Exception {
+        final ProjectFiles projectFiles = new ProjectFiles();
+        for (final ProjectFile file : files) {
+            projectFiles.insertFile(file);
+        }
+        return new ClarpseProject(projectFiles, Lang.JAVA).result().model();
+    }
+
+    private static Set<String> refs(final OOPSourceCodeModel model, final String component) {
+        final Component cmp = model.getComponent(component).orElseThrow(
+                () -> new AssertionError("no component " + component + " in "
+                        + model.components().map(Component::uniqueName).collect(Collectors.toList())));
+        return cmp.references().stream().map(r -> r.invokedComponent()).collect(Collectors.toSet());
+    }
+
+    /**
+     * An on-demand import. The type solver is what resolves these, and it was rooted at the project
+     * directory rather than the source root, so it found nothing under a conventional layout: the
+     * identical sources produced the edge when flat and no edge under {@code src/main/java}.
+     */
+    @Test
+    public void onDemandImportResolvesUnderAConventionalSourceLayout() throws Exception {
+        final OOPSourceCodeModel model = model(
+                new ProjectFile("/src/main/java/a/Base.java",
+                        "package a;\npublic interface Base { void run(); }\n"),
+                new ProjectFile("/src/main/java/b/StarImpl.java",
+                        "package b;\nimport a.*;\npublic class StarImpl implements Base { public void run() {} }\n"));
+
+        assertTrue("wildcard-imported supertype should resolve",
+                refs(model, "b.StarImpl").contains("a.Base"));
+    }
+
+    /** The same file with an explicit import, which never needed the solver and always worked. */
+    @Test
+    public void explicitImportStillResolves() throws Exception {
+        final OOPSourceCodeModel model = model(
+                new ProjectFile("/src/main/java/a/Base.java",
+                        "package a;\npublic interface Base { void run(); }\n"),
+                new ProjectFile("/src/main/java/b/ExactImpl.java",
+                        "package b;\nimport a.Base;\npublic class ExactImpl implements Base { public void run() {} }\n"));
+
+        assertTrue(refs(model, "b.ExactImpl").contains("a.Base"));
+    }
+
+    /**
+     * A nested type implementing the type it is declared inside. The guard against self-references
+     * compared against every enclosing component, so this read as a class referencing itself.
+     */
+    @Test
+    public void nestedTypeMayInheritItsEnclosingType() throws Exception {
+        final OOPSourceCodeModel model = model(
+                new ProjectFile("/src/main/java/a/Event.java",
+                        "package a;\npublic interface Event {\n  class Created implements Event { }\n}\n"));
+
+        assertTrue("nested class should reference the interface it implements",
+                refs(model, "a.Event.Created").contains("a.Event"));
+    }
+
+    /**
+     * A nested type implementing a sibling nested type, named plainly. Observed on debezium's
+     * {@code Field.RangeValidator implements Validator}, where both are declared in one file.
+     */
+    @Test
+    public void nestedTypeMayInheritASiblingNestedType() throws Exception {
+        final OOPSourceCodeModel model = model(
+                new ProjectFile("/src/main/java/a/Field.java",
+                        "package a;\npublic class Field {\n"
+                        + "  public interface Validator { void validate(); }\n"
+                        + "  public static class RangeValidator implements Validator { public void validate() {} }\n"
+                        + "}\n"));
+
+        assertTrue("sibling nested supertype should resolve to its qualified name",
+                refs(model, "a.Field.RangeValidator").contains("a.Field.Validator"));
+    }
+
+    /**
+     * The counterpart the widened guard broke: a member is not a reference to the type that declares
+     * it. A constructor shares its type's name, and treating that as a reference gives every class
+     * a reference to itself.
+     */
+    @Test
+    public void aMemberIsNotAReferenceToItsDeclaringType() throws Exception {
+        final OOPSourceCodeModel model = model(
+                new ProjectFile("/src/main/java/a/Test.java",
+                        "package a;\nclass Test { public Test() {} }\n"));
+
+        assertEquals(0, refs(model, "a.Test").size());
+        assertEquals(0, refs(model, "a.Test.Test()").size());
+    }
+}


### PR DESCRIPTION
Five defects, found by auditing parsed models of 28 repositories in four languages against what their sources plainly declare. Every one of them removed edges **silently** — a relation absent from the model cannot be checked, so a consumer asking about it is told "couldn't tell" about something stated in one line of source. One did worse and invented edges that reached a user as evidence.

Each fix has a minimal reproduction and a regression test. **695 tests, 0 failures** (683 before).

---

### Closes #160 — C#: a plain type name bound to an arbitrary same-named class

`resolveNamespace` ended in a repository-wide guess that returned whichever same-named type was registered first, and that guess ran **before** the file's own `using` directives.

| repo | decidable refs | wrong | rate |
|---|---|---|---|
| ardalis/CleanArchitecture | 98 | 56 | **57%** |
| kgrzybek/modular-monolith-with-ddd | 186 | 64 | **34%** |
| Smartstore | 351 | 83 | 24% |
| orleans / semantic-kernel / MassTransit | 854 | 19 | 2–3% |
| **total** | **1,490** | **222** | **15%** |

Severity tracks name reuse across modules — which is exactly the property that makes a codebase worth checking module-boundary rules on. Java is unaffected (0 wrong in 1,394 decidable), consistent with the earlier fix in `7c9bd1a`.

This one was not merely lossy. `List<OrderItem>` in a Domain entity bound to a user endpoint class named `List` in another project, and those two fabricated edges became the cited witnesses under a "this change breaks a rule your own documentation states" verdict shown to a maintainer.

**After:** ardalis 56 wrong → **0**, kgrzybek 64 → **1**, framework-name captures 30 → 1, and the fabricated witness is gone. Imports are consulted first; the last resort accepts a short name only when exactly one type carries it and it is not a framework name; an unresolved name stays unresolved. Silence costs a missing edge, a guess costs a fabricated one.

### Closes #161 — Java: the type solver was rooted at the project directory

`JavaParserTypeSolver` resolves `a.b.C` by looking for `<root>/a/b/C.java`. Rooted at the project directory this only works for a flat layout; under `src/main/java` every lookup missed. Invisible for explicitly imported types, whose names the import map already carries, and total for anything needing the solver.

```
same three files, only directory depth differs:
  flat (/a, /b)                 StarImpl deps=['a.Base']
  /src/main/java/a, .../b       StarImpl deps=[]
```

Source roots are now derived from each file's own `package` declaration, which covers Maven, Gradle, multi-module and unconventional layouts — guessing `src/main/java` by name would have missed half of those.

### Closes #162 — Java: on-demand imports resolved nothing

JavaParser reports `import a.*;` as name `a`, so the short-name map recorded the useless entry `a -> a` and nothing searched the package. Wildcard imports are common, and each one silently removed a package's worth of edges from the file using it.

Depends on #161 — confirming a candidate requires a working solver, which is why fixing this alone changed nothing.

### Closes #163 — a nested type could not inherit its enclosing or sibling type

Two bugs, one symptom. The self-reference guard compared against **every enclosing component**, so `interface Event { class Created implements Event {} }` read as a class referencing itself. And a sibling nested type named plainly became `a.Validator`, which does not exist, and was dropped as external — debezium's `Field.RangeValidator implements Validator` exactly.

Both fixes are deliberately narrow, because the first attempt broke three existing invariants:
- the guard still stops a **member** referencing its declaring type, which is what makes `class Test { public Test() {} }` produce no reference (`testSelfReferenceShouldNotExist`);
- the sibling lookup is confined to a type position and to candidates that are themselves types, so `return MAX_NOTES;` does not become a type reference (`CrossLanguageReferenceHygieneTest`).

### Closes #156 — `imports()` meant a different thing in each language

C# copied the file's using list onto methods, fields, parameters and locals; Python computed its imports, used them to resolve types, then dropped them from the daemon payload; TypeScript never collected them at all. A consumer could not tell an empty list from a language that does not fill it in.

Now all four populate it and **only type components carry it**. TypeScript resolves through the compiler's checker, so an import TypeScript itself cannot resolve is reported as external rather than guessed into a path.

---

### Measured effect

End to end on ddd-by-examples/library, inheritance-edge recall against declared supertypes: **48% → 100%**.

Corpus-wide re-measurement is **not** included — the sweep was stopped mid-run to free the machine for a trustworthy test run, and only that one repository completed. Baselines for the full 28-repo comparison are recorded and the re-run is queued for after a version is published.

### Not fixed here

#164 (redwoodjs/graphql parses 0.36 components per TypeScript file against 6.4–12.8 for peers) and #165 (Python and TypeScript distinguish fewer type kinds) are opened as candidates. Neither is root-caused, and I would rather leave them open than bundle guesses with reproductions.