### PR TITLE
fix: release JavaParser's static facade registry after a Java compile

### DIFF
--- a/src/main/java/com/hadi/clarpse/compiler/ClarpseJavaCompiler.java
+++ b/src/main/java/com/hadi/clarpse/compiler/ClarpseJavaCompiler.java
@@ -1,5 +1,6 @@
 package com.hadi.clarpse.compiler;
 
+import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
 import com.hadi.clarpse.compiler.java.ParseOutcome;
 import com.hadi.clarpse.compiler.java.ParseResults;
 import com.hadi.clarpse.compiler.java.ParseTask;
@@ -129,6 +130,23 @@ public class ClarpseJavaCompiler implements ClarpseCompiler {
             return new ParseResults(mergedModel, compileFailures);
         } finally {
             CompilerParallelismSupport.shutdownExecutor(executor);
+            // JavaParserFacade keeps a private static Map<TypeSolver, JavaParserFacade> that
+            // get() writes to during symbol resolution and nothing ever prunes. Every entry
+            // strongly retains its solver, which retains that solver's cache of parsed
+            // CompilationUnits, which retains a whole AST -- so without this the process holds
+            // every AST it has ever parsed. The key is the solver instance and we build a fresh
+            // one per thread per compile, so the map can never hit a cache; it only grows,
+            // measured at one entry per parser thread per compile.
+            //
+            // Shutting the executor down is not enough. That ends the threads and releases the
+            // ThreadLocal, but the static map holds the solvers independently of the thread that
+            // made them, which is why this leaked while looking like it was cleaned up.
+            //
+            // Nothing of value is dropped: these solvers belong to the compile that is ending.
+            // The registry is process-wide, so a compile running concurrently in the same JVM
+            // loses its facade's resolution cache here -- get() rebuilds it lazily and the
+            // results are unchanged, so the cost is recomputation, not correctness. See #170.
+            JavaParserFacade.clearInstances();
         }
     }
 }

--- a/src/test/java/com/hadi/test/JavaParserFacadeLeakTest.java
+++ b/src/test/java/com/hadi/test/JavaParserFacadeLeakTest.java
@@ -1,0 +1,109 @@
+package com.hadi.test;
+
+import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+import com.hadi.clarpse.compiler.ClarpseProject;
+import com.hadi.clarpse.compiler.Lang;
+import com.hadi.clarpse.compiler.ProjectFiles;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Compiling a Java project must not leave anything behind in JavaParser's static state.
+ *
+ * <p>{@code JavaParserFacade} keeps a {@code private static final Map<TypeSolver, JavaParserFacade>
+ * instances}, populated by {@code JavaParserFacade.get(typeSolver)} during symbol resolution and
+ * never pruned. Clarpse builds a fresh {@code CombinedTypeSolver} per thread per compile, so every
+ * compile inserts up to {@code parallelism} entries that nothing ever removes. Each entry strongly
+ * retains its solver, each solver retains the {@code JavaParserTypeSolver} caches of parsed
+ * {@code CompilationUnit}s, and each compilation unit retains a whole AST. In a JVM that compiles
+ * one project and exits this is invisible; in a long-lived process that compiles many, it is an
+ * unbounded leak of every AST the process has ever parsed.
+ *
+ * <p>The leak is measured here rather than inferred, because what makes it hard to observe in
+ * production is that it does not announce itself. The retaining caches hold their values softly,
+ * and a JVM must clear every soft reference before it is allowed to throw {@code OutOfMemoryError}
+ * — so instead of failing, the process settles into near-continuous full GC, collecting and
+ * re-resolving forever. Heap-dump-on-OOM and exit-on-OOM never fire, because no OOM is ever thrown.
+ *
+ * <p>The assertions are on the map's size, not on heap usage: a heap-based test would have to
+ * distinguish a leak from ordinary garbage awaiting collection, which is precisely the ambiguity
+ * that let this survive.
+ */
+public class JavaParserFacadeLeakTest {
+
+    /** A Java project of non-trivial size, so several parser threads and solvers are in play. */
+    private static final String JAVA_PROJECT_ZIP = "/clarpse.zip";
+
+    @Before
+    public void clearFacadeState() {
+        JavaParserFacade.clearInstances();
+    }
+
+    /**
+     * Reads the private static registry directly. Reflection is the point of the test: the field is
+     * the leak, and any assertion that did not look at it would be measuring a proxy.
+     */
+    private static int facadeInstanceCount() throws Exception {
+        final Field field = JavaParserFacade.class.getDeclaredField("instances");
+        field.setAccessible(true);
+        return ((Map<?, ?>) field.get(null)).size();
+    }
+
+    private static void compileJavaProject() throws Exception {
+        final ProjectFiles projectFiles =
+                new ProjectFiles(JavaParserFacadeLeakTest.class.getResourceAsStream(JAVA_PROJECT_ZIP));
+        new ClarpseProject(projectFiles, Lang.JAVA).result();
+    }
+
+    /**
+     * Guards the other two tests. They assert a count of zero, which is also what a broken accessor
+     * or a renamed field would report — so without this, they would pass for the wrong reason and
+     * keep passing forever. This pins the mechanism itself: registering a solver grows the map, and
+     * clearing empties it.
+     */
+    @Test
+    public void theRegistryThisTestReadsIsTheOneResolutionPopulates() throws Exception {
+        assertEquals("clearInstances() should leave an empty registry", 0, facadeInstanceCount());
+
+        JavaParserFacade.get(new ReflectionTypeSolver());
+        assertTrue("JavaParserFacade.get() should register the solver; if this fails the field name "
+                        + "or the registry's behaviour has changed and the leak assertions below "
+                        + "are vacuous",
+                facadeInstanceCount() > 0);
+
+        JavaParserFacade.clearInstances();
+        assertEquals(0, facadeInstanceCount());
+    }
+
+    @Test
+    public void oneCompileLeavesNoFacadeInstancesBehind() throws Exception {
+        compileJavaProject();
+
+        assertEquals("compiling a project must not leave entries in JavaParserFacade.instances",
+                0, facadeInstanceCount());
+    }
+
+    @Test
+    public void repeatedCompilesDoNotAccumulateFacadeInstances() throws Exception {
+        compileJavaProject();
+        final int afterFirstCompile = facadeInstanceCount();
+
+        for (int i = 0; i < 3; i++) {
+            compileJavaProject();
+        }
+        final int afterFourthCompile = facadeInstanceCount();
+
+        assertEquals("JavaParserFacade.instances grew across compiles: " + afterFirstCompile
+                        + " -> " + afterFourthCompile + "; each retained entry pins a "
+                        + "CombinedTypeSolver and every AST it parsed",
+                afterFirstCompile, afterFourthCompile);
+        assertEquals("expected a clean registry after each compile", 0, afterFourthCompile);
+    }
+}


### PR DESCRIPTION
Fixes #170.

## The leak

`JavaParserFacade` keeps a `private static final Map<TypeSolver, JavaParserFacade> instances`, written by `get()` during symbol resolution and pruned by nothing. `ClarpseJavaCompiler` builds a fresh `CombinedTypeSolver` per thread per compile, so the map is keyed by an instance that never repeats — it cannot hit a cache, it only grows. Each entry strongly retains its solver → that solver's cache of parsed `CompilationUnit`s → a whole AST.

Measured on `master` with a real project: **one compile leaks 8 entries, four leak 32** — one per parser thread per compile, linear and unbounded.

Shutting the executor down did not cover this. That ends the threads and releases the `ThreadLocal` holding each `ParserContext`, but the static map retains the solvers independently of the thread that made them — so the leak persisted while the code read as though it cleaned up after itself.

## The fix

One call to `JavaParserFacade.clearInstances()` in the existing `finally` block of `parseJavaFiles`, beside the executor shutdown. The solvers belong to the compile that is ending, so nothing of value is dropped.

The registry is process-wide, so a compile running concurrently in the same JVM loses its facade's resolution cache at this point. `get()` rebuilds it lazily and resolution results are unchanged, so the cost is recomputation rather than correctness — noted in the code comment.

## Tests

`JavaParserFacadeLeakTest`, three cases:

- `theRegistryThisTestReadsIsTheOneResolutionPopulates` — registering a solver grows the map, clearing empties it. This exists so the two zero-assertions below cannot start passing for the wrong reason: a renamed field or a broken accessor would also report zero, and would then keep reporting it forever.
- `oneCompileLeavesNoFacadeInstancesBehind` — was `expected:<0> but was:<8>` before the fix.
- `repeatedCompilesDoNotAccumulateFacadeInstances` — was `8 -> 32` before the fix.

The assertions read the registry's size rather than heap usage on purpose: a heap-based test has to separate a leak from ordinary uncollected garbage, and that ambiguity is what let this survive.

## Verification

- The two leak tests fail on `master` with the numbers above, and pass with the fix.
- `mvn verify`: **698 tests, 0 failures**, 0 Checkstyle violations, PMD clean.

## Scope

Java only. Python, TypeScript and C# do not go through JavaParser's symbol solver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
