### PR TITLE
chore: bump to 10.1.2 to release the JavaParserFacade leak fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Add the dependency (check the badge above for the latest version):
 <dependency>
   <groupId>io.github.hadi-technology</groupId>
   <artifactId>clarpse</artifactId>
-  <version>10.1.1</version>
+  <version>10.1.2</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>io.github.hadi-technology</groupId>
 	<artifactId>clarpse</artifactId>
-	<version>10.1.1</version>
+	<version>10.1.2</version>
 	<packaging>jar</packaging>
 
 	<name>${project.groupId}:${project.artifactId}</name>


### PR DESCRIPTION
#171 merged without a version bump, so the master publish failed:

```
Component with package url: 'pkg:maven/io.github.hadi-technology/clarpse@10.1.1' already exists
```

`publish` runs `mvn deploy` against whatever `pom.xml` carries on every master push, so a code change without a bump cannot release. The leak fix is on master but not consumable until a new coordinate exists.

Patch bump — #171 is a behaviour-preserving memory fix with no API change. README carries the same coordinate and is bumped with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)