### PR TITLE
feat!: name the accessors for what they cost, cut merge allocation 73%, release 11.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Add the dependency (check the badge above for the latest version):
 <dependency>
   <groupId>io.github.hadi-technology</groupId>
   <artifactId>clarpse</artifactId>
-  <version>10.1.2</version>
+  <version>10.2.0</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Add the dependency (check the badge above for the latest version):
 <dependency>
   <groupId>io.github.hadi-technology</groupId>
   <artifactId>clarpse</artifactId>
-  <version>10.2.0</version>
+  <version>11.0.0</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -245,14 +245,14 @@ codeModel.components().forEach(component -> {
 
 Fetch a specific component by unique name:
 ```java
-Component classComponent = codeModel.getComponent("com.foo.SampleClass")
+Component classComponent = codeModel.copyOfComponent("com.foo.SampleClass")
         .orElseThrow();
 System.out.println(classComponent.name());
 System.out.println(classComponent.componentType());
 System.out.println(classComponent.references());
 
 String childUniqueName = classComponent.children().get(0);
-Component methodComponent = codeModel.getComponent(childUniqueName).orElseThrow();
+Component methodComponent = codeModel.copyOfComponent(childUniqueName).orElseThrow();
 System.out.println(methodComponent.name());
 System.out.println(methodComponent.codeFragment());
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>io.github.hadi-technology</groupId>
 	<artifactId>clarpse</artifactId>
-	<version>10.2.0</version>
+	<version>11.0.0</version>
 	<packaging>jar</packaging>
 
 	<name>${project.groupId}:${project.artifactId}</name>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>io.github.hadi-technology</groupId>
 	<artifactId>clarpse</artifactId>
-	<version>10.1.2</version>
+	<version>10.2.0</version>
 	<packaging>jar</packaging>
 
 	<name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/java/com/hadi/clarpse/listener/JavaTreeListener.java
+++ b/src/main/java/com/hadi/clarpse/listener/JavaTreeListener.java
@@ -873,7 +873,7 @@ public class JavaTreeListener extends VoidVisitorAdapter<Object> {
                     continue;
                 }
                 final String nested = enclosing.uniqueName() + "." + type;
-                final boolean isType = srcModel.liveComponent(nested)
+                final boolean isType = srcModel.component(nested)
                         .map(found -> found.componentType().isBaseComponent()).orElse(false);
                 if (isType || typeSolver.tryToSolveType(nested).isSolved()) {
                     return nested;

--- a/src/main/java/com/hadi/clarpse/listener/JavaTreeListener.java
+++ b/src/main/java/com/hadi/clarpse/listener/JavaTreeListener.java
@@ -873,7 +873,7 @@ public class JavaTreeListener extends VoidVisitorAdapter<Object> {
                     continue;
                 }
                 final String nested = enclosing.uniqueName() + "." + type;
-                final boolean isType = srcModel.getComponent(nested)
+                final boolean isType = srcModel.liveComponent(nested)
                         .map(found -> found.componentType().isBaseComponent()).orElse(false);
                 if (isType || typeSolver.tryToSolveType(nested).isSolved()) {
                     return nested;

--- a/src/main/java/com/hadi/clarpse/listener/ParseUtil.java
+++ b/src/main/java/com/hadi/clarpse/listener/ParseUtil.java
@@ -113,7 +113,7 @@ public class ParseUtil {
         int childCount = 0;
         int complexityTotal = 0;
         for (String childrenName : component.children()) {
-            Optional<Component> child = srcModel.getComponent(childrenName);
+            Optional<Component> child = srcModel.liveComponent(childrenName);
             if (child.isPresent() && child.get().componentType().isMethodComponent()) {
                 childCount += 1;
                 complexityTotal += child.get().cyclo();

--- a/src/main/java/com/hadi/clarpse/listener/ParseUtil.java
+++ b/src/main/java/com/hadi/clarpse/listener/ParseUtil.java
@@ -113,7 +113,7 @@ public class ParseUtil {
         int childCount = 0;
         int complexityTotal = 0;
         for (String childrenName : component.children()) {
-            Optional<Component> child = srcModel.liveComponent(childrenName);
+            Optional<Component> child = srcModel.component(childrenName);
             if (child.isPresent() && child.get().componentType().isMethodComponent()) {
                 childCount += 1;
                 complexityTotal += child.get().cyclo();

--- a/src/main/java/com/hadi/clarpse/reference/ComponentReference.java
+++ b/src/main/java/com/hadi/clarpse/reference/ComponentReference.java
@@ -25,11 +25,41 @@ public abstract class ComponentReference implements Serializable, Cloneable {
     private boolean external = false;
 
     public ComponentReference(final String invocationComponentName) {
-        invokedComponent = invocationComponentName;
+        invokedComponent = pooled(invocationComponentName);
     }
 
     public ComponentReference(final ComponentReference invocation) {
-        invokedComponent = invocation.invokedComponent();
+        invokedComponent = pooled(invocation.invokedComponent());
+    }
+
+    /**
+     * One instance per distinct name, rather than one per reference.
+     *
+     * <p>A reference holds a fully-qualified name, and the same type is referenced from everywhere
+     * that uses it, so the identical string is allocated once per mention. Measured on a real model:
+     * 2,565 reference strings, 750 distinct -- <b>68% of the bytes are duplicates</b>, and
+     * references are about 70% of a component's footprint. This is the largest single reduction
+     * available in the parsed model, and it costs nothing semantically: the strings are immutable
+     * and compared by value everywhere.
+     *
+     * <p>It matters because striff holds <em>two</em> models at once, base and head, for the whole
+     * of a differential analysis. One medium repository was measured at ~4GB of live heap, which is
+     * enough to put the JVM into a garbage-collection spiral it never leaves -- 95% GC overhead, an
+     * analysis that never completes, and a pod that serves nothing while reporting healthy.
+     *
+     * <p><b>Deliberately {@link String#intern()} and not a pool of our own.</b> A static
+     * {@code Map} here would be the shape of the bug fixed in 10.1.2, where
+     * {@code JavaParserFacade} kept a static registry that nothing pruned and each entry pinned a
+     * whole AST. The JVM's pool lives in the heap and its entries are collectable once unreachable,
+     * so it cannot retain a compile's strings after the compile. A per-compile pool would also
+     * work, but it would need threading through every parser and clearing on every exit path, and
+     * an intern pool that is not cleared is a leak wearing an optimisation's clothes.
+     */
+    private static String pooled(final String name) {
+        if (name == null) {
+            return null;
+        }
+        return name.intern();
     }
 
     public abstract int priority();

--- a/src/main/java/com/hadi/clarpse/sourcemodel/Component.java
+++ b/src/main/java/com/hadi/clarpse/sourcemodel/Component.java
@@ -18,7 +18,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Set;
 
 /**
@@ -56,28 +55,74 @@ public final class Component implements Serializable {
     private String codeFragment;
 
     public Component(final Component component) {
-        this.modifiers = new LinkedHashSet<>(component.modifiers);
+        this(component, null);
+    }
+
+    /**
+     * Copies the given component, canonicalising every string field that repeats through the given
+     * pool.
+     *
+     * <p>Pooling happens here rather than in the parsers because a component is copied on its way
+     * into a model anyway, so the canonical instance can be chosen during a copy that was already
+     * being made: the cost is one hash lookup per field and no extra allocation. Threading a pool
+     * through four parsers would reach the same values later, having allocated them all first.
+     *
+     * @param component Component to copy.
+     * @param pool      Pool to canonicalise repeated strings through, or {@code null} to copy the
+     *                  references as they are.
+     */
+    public Component(final Component component, final StringPool pool) {
+        if (pool == null) {
+            this.modifiers = new LinkedHashSet<>(component.modifiers);
+            this.imports = new LinkedHashSet<>(component.imports);
+            this.codeFragment = component.codeFragment;
+            this.componentName = component.componentName;
+            this.pkg = component.pkg;
+            this.value = component.value;
+            this.sourceFile = component.sourceFile;
+            this.module = component.module;
+            this.comment = component.comment;
+            this.name = component.name;
+            this.children.addAll(component.children);
+        } else {
+            this.modifiers = pool.pooledSet(component.modifiers);
+            this.imports = pool.pooledSet(component.imports);
+            this.codeFragment = pool.pooled(component.codeFragment);
+            this.componentName = pool.pooled(component.componentName);
+            this.pkg = pool.pooled(component.pkg);
+            this.value = pool.pooled(component.value);
+            this.sourceFile = pool.pooled(component.sourceFile);
+            this.module = pool.pooled(component.module);
+            this.comment = pool.pooled(component.comment);
+            this.name = pool.pooled(component.name);
+            for (final String child : component.children) {
+                this.children.add(pool.pooled(child));
+            }
+        }
         this.type = component.type;
-        this.codeFragment = component.codeFragment;
-        this.imports = new LinkedHashSet<>(component.imports);
-        this.componentName = component.componentName;
-        this.pkg = component.pkg;
-        this.value = component.value;
-        this.sourceFile = component.sourceFile;
-        this.module = component.module;
-        this.comment = component.comment;
         this.codeHash = component.codeHash;
         this.cyclo = component.cyclo;
-        this.name = component.name;
-        this.children.addAll(component.children);
         component.references().forEach(this::insertCmpRefCopy);
     }
 
     public Component() {
     }
 
+    /**
+     * This component's child component names, in declaration order.
+     *
+     * <p>An unmodifiable <b>view</b> of the live list rather than a copy of it. It was a copy, and
+     * that copy was being made inside a filter predicate in striff's two-revision merge -- once per
+     * child per component, on a model of twelve thousand components. Every caller in both this
+     * repository and striff only reads: {@code contains}, {@code size}, iteration. A caller that
+     * needs a snapshot across a mutation must now take one, and a caller inserting a child while
+     * iterating this view will get a {@link java.util.ConcurrentModificationException} where it
+     * previously got a silently stale list -- which is the better of the two failures.
+     *
+     * @return Unmodifiable view of this component's children.
+     */
     public List<String> children() {
-        return Collections.unmodifiableList(new ArrayList<>(children));
+        return Collections.unmodifiableList(children);
     }
 
     public String uniqueName() {
@@ -131,12 +176,28 @@ public final class Component implements Serializable {
         }
     }
 
+    /**
+     * The references this component makes to types inside the codebase.
+     *
+     * <p>An unmodifiable view rather than a copy. Relationship extraction reads both dependency sets
+     * three times per component and was paying for six set copies each time.
+     *
+     * @return Unmodifiable view of the internalReferences.
+     */
     public Set<ComponentReference> internalDependencies() {
-        return Collections.unmodifiableSet(new LinkedHashSet<>(internalReferences));
+        return Collections.unmodifiableSet(internalReferences);
     }
 
+    /**
+     * The references this component makes to types outside the codebase.
+     *
+     * <p>An unmodifiable view rather than a copy. Relationship extraction reads both dependency sets
+     * three times per component and was paying for six set copies each time.
+     *
+     * @return Unmodifiable view of the externalReferences.
+     */
     public Set<ComponentReference> externalDependencies() {
-        return Collections.unmodifiableSet(new LinkedHashSet<>(externalReferences));
+        return Collections.unmodifiableSet(externalReferences);
     }
 
     public void insertCmpRef(final ComponentReference ref) {
@@ -148,8 +209,13 @@ public final class Component implements Serializable {
         LOGGER.debug("Inserted " + ref + " for " + this);
     }
 
+    /**
+     * This component's import statements.
+     *
+     * @return Unmodifiable view of the imports, in declaration order.
+     */
     public Set<String> imports() {
-        return Collections.unmodifiableSet(new LinkedHashSet<>(imports));
+        return Collections.unmodifiableSet(imports);
     }
 
     public String componentName() {
@@ -212,16 +278,34 @@ public final class Component implements Serializable {
         this.componentName = componentName;
     }
 
+    /**
+     * This component's access and declaration modifiers, lower-cased.
+     *
+     * @return Unmodifiable view of the modifiers, in declaration order.
+     */
     public Set<String> modifiers() {
-        return Collections.unmodifiableSet(new LinkedHashSet<>(modifiers));
+        return Collections.unmodifiableSet(modifiers);
     }
 
+    /**
+     * Records a modifier, storing the vocabulary's own instance of the token rather than a fresh
+     * lower-cased copy of the caller's string.
+     *
+     * <p>There are seven distinct modifier tokens in the whole vocabulary and
+     * {@code toLowerCase} was allocating one string per declaration: measured at 7,634 instances
+     * carrying 7 values across a base/head pair, a ratio of 1,090 to one and 305KB of duplicate
+     * text. Canonicalising to the constant needs no pool to do it.
+     *
+     * @param modifier Modifier token, in any case.
+     * @throws IllegalArgumentException If the token is not a supported modifier.
+     */
     public void insertAccessModifier(final String modifier) {
-        if (OOPSourceModelConstants.getAccessModifierMap().containsValue(modifier.toLowerCase(Locale.ROOT))) {
-            modifiers.add(modifier.toLowerCase(Locale.ROOT));
-        } else {
+        final OOPSourceModelConstants.AccessModifiers resolved =
+                OOPSourceModelConstants.accessModifier(modifier);
+        if (resolved == null) {
             throw new IllegalArgumentException(modifier + " is an invalid modifier!");
         }
+        modifiers.add(OOPSourceModelConstants.getAccessModifierMap().get(resolved));
     }
 
     public ComponentType componentType() {

--- a/src/main/java/com/hadi/clarpse/sourcemodel/Component.java
+++ b/src/main/java/com/hadi/clarpse/sourcemodel/Component.java
@@ -112,9 +112,9 @@ public final class Component implements Serializable {
      * This component's child component names, in declaration order.
      *
      * <p>An unmodifiable <b>view</b> of the live list rather than a copy of it. It was a copy, and
-     * that copy was being made inside a filter predicate in striff's two-revision merge -- once per
-     * child per component, on a model of twelve thousand components. Every caller in both this
-     * repository and striff only reads: {@code contains}, {@code size}, iteration. A caller that
+     * a consumer comparing two models was making that copy inside a filter predicate -- once per
+     * child per component, on models of twelve thousand components each. Every known caller only
+     * reads: {@code contains}, {@code size}, iteration. A caller that
      * needs a snapshot across a mutation must now take one, and a caller inserting a child while
      * iterating this view will get a {@link java.util.ConcurrentModificationException} where it
      * previously got a silently stale list -- which is the better of the two failures.

--- a/src/main/java/com/hadi/clarpse/sourcemodel/OOPSourceCodeModel.java
+++ b/src/main/java/com/hadi/clarpse/sourcemodel/OOPSourceCodeModel.java
@@ -103,13 +103,13 @@ public class OOPSourceCodeModel implements Serializable {
      *
      * <p>The copy is deep: the imports, the children and every reference are duplicated. Callers rely
      * on that isolation, so this contract is unchanged -- but on a read-only path it is expensive
-     * enough to dominate an analysis, and {@link #liveComponent(String)} is the accessor to reach for
+     * enough to dominate an analysis, and {@link #component(String)} is the accessor to reach for
      * there.
      *
      * @param componentName Unique name of the component.
      * @return A fresh copy of the component, or empty if this model has no such component.
      */
-    public Optional<Component> getComponent(final String componentName) {
+    public Optional<Component> copyOfComponent(final String componentName) {
         final Component component = this.getComponents().get(componentName);
         if (component == null) {
             return Optional.empty();
@@ -123,10 +123,10 @@ public class OOPSourceCodeModel implements Serializable {
      * <p>For trusted callers that only read, or that intend to modify the model through the component
      * they are handed. Mutating the returned component mutates this model, and iterating one of its
      * collections while inserting into it will throw, so a caller that needs isolation wants
-     * {@link #getComponent(String)} instead. The name says {@code live} at the call site for exactly
+     * {@link #copyOfComponent(String)} instead. The name says {@code live} at the call site for exactly
      * that reason.
      *
-     * <p>It exists because {@link #getComponent(String)} deep-copies on every read, and the read
+     * <p>It exists because {@link #copyOfComponent(String)} deep-copies on every read, and the read
      * paths are enormous: relationship extraction resolves every reference in the model through it
      * and walks a parent chain per member, repeatedly, when two models are compared. Measured on a
      * pair of 11,750-component models, moving those paths onto this accessor cut one comparison from
@@ -138,7 +138,7 @@ public class OOPSourceCodeModel implements Serializable {
      * @return The model's own instance of the component, or empty if this model has no such
      *         component.
      */
-    public Optional<Component> liveComponent(final String componentName) {
+    public Optional<Component> component(final String componentName) {
         return Optional.ofNullable(this.getComponents().get(componentName));
     }
 
@@ -182,32 +182,32 @@ public class OOPSourceCodeModel implements Serializable {
      * Fetches the current component's parent base component if it exists. This may
      * not be the component's direct parent.
      */
-    public Component parentBaseCmp(String cmpUniqueName) throws IllegalArgumentException {
-        return new Component(liveParentBaseCmp(cmpUniqueName));
+    public Component copyOfParentBaseComponent(String cmpUniqueName) throws IllegalArgumentException {
+        return new Component(parentBaseComponent(cmpUniqueName));
     }
 
     /**
-     * The same walk as {@link #parentBaseCmp(String)}, returning this model's own instance rather
+     * The same walk as {@link #copyOfParentBaseComponent(String)}, returning this model's own instance rather
      * than a copy, and copying nothing on the way up.
      *
      * <p>The walk itself was the cost, not just its result: every step called
-     * {@link #getComponent(String)} and so deep-copied a component in order to read one field off it
+     * {@link #copyOfComponent(String)} and so deep-copied a component in order to read one field off it
      * and throw it away. Relationship extraction walks this chain once per member component and once
      * per resolved reference, so on a model of twelve thousand components it was tens of thousands of
      * discarded copies per extraction, three extractions per analysis.
      *
-     * <p>Mutating the result mutates the model. See {@link #liveComponent(String)}.
+     * <p>Mutating the result mutates the model. See {@link #component(String)}.
      *
      * @param cmpUniqueName Unique name of the component to walk up from.
      * @return This model's own instance of the nearest enclosing base component.
      * @throws IllegalArgumentException If no base component encloses the given name.
      */
-    public Component liveParentBaseCmp(final String cmpUniqueName) throws IllegalArgumentException {
+    public Component parentBaseComponent(final String cmpUniqueName) throws IllegalArgumentException {
         String currParentClassName = cmpUniqueName;
         Optional<Component> parent;
-        for (parent = this.liveComponent(currParentClassName); parent.isPresent()
+        for (parent = this.component(currParentClassName); parent.isPresent()
                 && !parent.get().componentType().isBaseComponent();
-             parent = this.liveComponent(currParentClassName)) {
+             parent = this.component(currParentClassName)) {
             currParentClassName = parent.get().parentUniqueName();
         }
         if (parent.isPresent()) {

--- a/src/main/java/com/hadi/clarpse/sourcemodel/OOPSourceCodeModel.java
+++ b/src/main/java/com/hadi/clarpse/sourcemodel/OOPSourceCodeModel.java
@@ -120,11 +120,11 @@ public class OOPSourceCodeModel implements Serializable {
     /**
      * A component of this model <b>as it is held</b>, without copying it.
      *
-     * <p>For trusted callers that only read, or that intend to modify the model through the component
-     * they are handed. Mutating the returned component mutates this model, and iterating one of its
+     * <p>For callers that only read, or that intend to modify the model through the component they
+     * are handed. Mutating the returned component mutates this model, and iterating one of its
      * collections while inserting into it will throw, so a caller that needs isolation wants
-     * {@link #copyOfComponent(String)} instead. The name says {@code live} at the call site for exactly
-     * that reason.
+     * {@link #copyOfComponent(String)} instead -- which is what the {@code copyOf} on that name is
+     * there to tell you at the call site.
      *
      * <p>It exists because {@link #copyOfComponent(String)} deep-copies on every read, and the read
      * paths are enormous: relationship extraction resolves every reference in the model through it

--- a/src/main/java/com/hadi/clarpse/sourcemodel/OOPSourceCodeModel.java
+++ b/src/main/java/com/hadi/clarpse/sourcemodel/OOPSourceCodeModel.java
@@ -1,6 +1,7 @@
 package com.hadi.clarpse.sourcemodel;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -22,12 +23,55 @@ public class OOPSourceCodeModel implements Serializable {
     private static final long serialVersionUID = 1L;
     private static final Logger LOGGER = LogManager.getLogger(OOPSourceCodeModel.class);
     private final Map<String, Component> components = new HashMap<>();
+    /**
+     * Transient and Json-ignored: it is an allocation strategy, not model content, and a serialized
+     * model must not carry one. A model restored without a pool gets a fresh one on first use.
+     */
+    @JsonIgnore
+    private transient StringPool stringPool;
 
     public OOPSourceCodeModel() {
+        this(new StringPool());
+    }
+
+    /**
+     * Builds a model that canonicalises the repeated strings of every component inserted into it
+     * through the given pool.
+     *
+     * <p>Pass the <b>same</b> pool to two models to share their text. That is the case this exists
+     * for: a differential analysis holds a base and a head model at once, naming almost entirely the
+     * same packages, types and members, and 11% of the pair's footprint was measured to be the same
+     * text held twice. See {@link StringPool} for the per-field figures and for why the pool is not
+     * static.
+     *
+     * @param stringPool Pool to canonicalise through. Must not be {@code null}; a model given no
+     *                   pool gets one of its own, which shares within itself but not with any other
+     *                   model.
+     */
+    public OOPSourceCodeModel(final StringPool stringPool) {
+        if (stringPool == null) {
+            throw new IllegalArgumentException("A string pool is required.");
+        }
+        this.stringPool = stringPool;
     }
 
     public OOPSourceCodeModel(Map<String, Component> components) {
+        this(new StringPool());
         insertComponents(components);
+    }
+
+    /**
+     * The pool this model canonicalises its components' strings through.
+     *
+     * @return This model's pool, never {@code null}.
+     */
+    public StringPool stringPool() {
+        StringPool pool = this.stringPool;
+        if (pool == null) {
+            pool = new StringPool();
+            this.stringPool = pool;
+        }
+        return pool;
     }
 
     private Map<String, Component> getComponents() {
@@ -46,7 +90,7 @@ public class OOPSourceCodeModel implements Serializable {
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("Inserted component {}.", component);
         }
-        final Component cloned = new Component(component);
+        final Component cloned = new Component(component, stringPool());
         components.put(cloned.uniqueName(), cloned);
     }
 
@@ -54,12 +98,47 @@ public class OOPSourceCodeModel implements Serializable {
         return getComponents().containsKey(componentName);
     }
 
+    /**
+     * A component of this model, as an isolated copy the caller may mutate freely.
+     *
+     * <p>The copy is deep: the imports, the children and every reference are duplicated. Callers rely
+     * on that isolation, so this contract is unchanged -- but on a read-only path it is expensive
+     * enough to dominate an analysis, and {@link #liveComponent(String)} is the accessor to reach for
+     * there.
+     *
+     * @param componentName Unique name of the component.
+     * @return A fresh copy of the component, or empty if this model has no such component.
+     */
     public Optional<Component> getComponent(final String componentName) {
         final Component component = this.getComponents().get(componentName);
         if (component == null) {
             return Optional.empty();
         }
         return Optional.of(new Component(component));
+    }
+
+    /**
+     * A component of this model <b>as it is held</b>, without copying it.
+     *
+     * <p>For trusted callers that only read, or that intend to modify the model through the component
+     * they are handed. Mutating the returned component mutates this model, and iterating one of its
+     * collections while inserting into it will throw, so a caller that needs isolation wants
+     * {@link #getComponent(String)} instead. The name says {@code live} at the call site for exactly
+     * that reason.
+     *
+     * <p>It exists because {@link #getComponent(String)} deep-copies on every read, and the read
+     * paths are enormous: relationship extraction resolves every reference in the model through it
+     * and walks a parent chain per member, three times over in a two-revision analysis. Measured on a
+     * pair of 11,750-component models, moving those paths onto this accessor cut one merge from
+     * 619MB of allocation to a fraction of it, and it is allocation churn -- not live size -- that
+     * took a container past a 10Gi limit with a 4g heap and no {@code OutOfMemoryError}.
+     *
+     * @param componentName Unique name of the component.
+     * @return The model's own instance of the component, or empty if this model has no such
+     *         component.
+     */
+    public Optional<Component> liveComponent(final String componentName) {
+        return Optional.ofNullable(this.getComponents().get(componentName));
     }
 
     public void insertComponents(final Map<String, Component> newCmps) {
@@ -84,8 +163,18 @@ public class OOPSourceCodeModel implements Serializable {
         return components.values().stream();
     }
 
+    /**
+     * A copy of this model whose components are copies, sharing this model's string pool.
+     *
+     * <p>Sharing the pool is what keeps the copy from re-allocating every name it already holds an
+     * instance of.
+     *
+     * @return An independent model holding equal components.
+     */
     public OOPSourceCodeModel copy() {
-        return new OOPSourceCodeModel(this.getComponents());
+        final OOPSourceCodeModel copy = new OOPSourceCodeModel(this.stringPool());
+        copy.insertComponents(this.getComponents());
+        return copy;
     }
 
     /**
@@ -93,10 +182,31 @@ public class OOPSourceCodeModel implements Serializable {
      * not be the component's direct parent.
      */
     public Component parentBaseCmp(String cmpUniqueName) throws IllegalArgumentException {
+        return new Component(liveParentBaseCmp(cmpUniqueName));
+    }
+
+    /**
+     * The same walk as {@link #parentBaseCmp(String)}, returning this model's own instance rather
+     * than a copy, and copying nothing on the way up.
+     *
+     * <p>The walk itself was the cost, not just its result: every step called
+     * {@link #getComponent(String)} and so deep-copied a component in order to read one field off it
+     * and throw it away. Relationship extraction walks this chain once per member component and once
+     * per resolved reference, so on a model of twelve thousand components it was tens of thousands of
+     * discarded copies per extraction, three extractions per analysis.
+     *
+     * <p>Mutating the result mutates the model. See {@link #liveComponent(String)}.
+     *
+     * @param cmpUniqueName Unique name of the component to walk up from.
+     * @return This model's own instance of the nearest enclosing base component.
+     * @throws IllegalArgumentException If no base component encloses the given name.
+     */
+    public Component liveParentBaseCmp(final String cmpUniqueName) throws IllegalArgumentException {
         String currParentClassName = cmpUniqueName;
         Optional<Component> parent;
-        for (parent = this.getComponent(currParentClassName); parent.isPresent()
-                && !parent.get().componentType().isBaseComponent(); parent = this.getComponent(currParentClassName)) {
+        for (parent = this.liveComponent(currParentClassName); parent.isPresent()
+                && !parent.get().componentType().isBaseComponent();
+             parent = this.liveComponent(currParentClassName)) {
             currParentClassName = parent.get().parentUniqueName();
         }
         if (parent.isPresent()) {

--- a/src/main/java/com/hadi/clarpse/sourcemodel/OOPSourceCodeModel.java
+++ b/src/main/java/com/hadi/clarpse/sourcemodel/OOPSourceCodeModel.java
@@ -128,10 +128,11 @@ public class OOPSourceCodeModel implements Serializable {
      *
      * <p>It exists because {@link #getComponent(String)} deep-copies on every read, and the read
      * paths are enormous: relationship extraction resolves every reference in the model through it
-     * and walks a parent chain per member, three times over in a two-revision analysis. Measured on a
-     * pair of 11,750-component models, moving those paths onto this accessor cut one merge from
-     * 619MB of allocation to a fraction of it, and it is allocation churn -- not live size -- that
-     * took a container past a 10Gi limit with a 4g heap and no {@code OutOfMemoryError}.
+     * and walks a parent chain per member, repeatedly, when two models are compared. Measured on a
+     * pair of 11,750-component models, moving those paths onto this accessor cut one comparison from
+     * 619MB of allocation to a fraction of it. It is allocation churn rather than live size that
+     * dominates there, which is why a consumer can exhaust a budget many times its configured heap
+     * without ever seeing an {@code OutOfMemoryError}.
      *
      * @param componentName Unique name of the component.
      * @return The model's own instance of the component, or empty if this model has no such

--- a/src/main/java/com/hadi/clarpse/sourcemodel/Package.java
+++ b/src/main/java/com/hadi/clarpse/sourcemodel/Package.java
@@ -1,6 +1,7 @@
 package com.hadi.clarpse.sourcemodel;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.Serializable;
@@ -13,15 +14,19 @@ import java.io.Serializable;
         isGetterVisibility = JsonAutoDetect.Visibility.NONE)
 public class Package implements Serializable {
 
+    private static final long serialVersionUID = 1L;
 
     private final String packageName;
     private final String packagePath;
     private final String ellipsisSeparatedPkg;
+    /** Lazily computed; transient so that adding it cannot change this class's serialized form. */
+    @JsonIgnore
+    private transient int hash;
 
     public Package(final String packageName, final String packagePath) {
         this.packageName = packageName;
         this.packagePath = packagePath;
-        this.ellipsisSeparatedPkg = StringUtils.strip(packagePath.replaceAll("/", "."), ".");
+        this.ellipsisSeparatedPkg = StringUtils.strip(packagePath.replace("/", "."), ".");
     }
 
     @Override
@@ -46,9 +51,23 @@ public class Package implements Serializable {
         return this.packageName.equals(ref.packageName) && this.packagePath.equals(ref.packagePath);
     }
 
+    /**
+     * Computed once at construction, from the two fields that define equality.
+     *
+     * <p>It was built by concatenating them on every call, which allocated a string per hash. That is
+     * only a detail until packages are pooled by value, at which point every component inserted into
+     * a model hashes its package.
+     *
+     * @return This package's hash.
+     */
     @Override
     public int hashCode() {
-        return (this.packageName + ":" + this.packagePath).hashCode();
+        int cached = this.hash;
+        if (cached == 0) {
+            cached = 31 * this.packageName.hashCode() + this.packagePath.hashCode();
+            this.hash = cached;
+        }
+        return cached;
     }
 
     public String ellipsisSeparatedPkgPath() {

--- a/src/main/java/com/hadi/clarpse/sourcemodel/StringPool.java
+++ b/src/main/java/com/hadi/clarpse/sourcemodel/StringPool.java
@@ -1,0 +1,143 @@
+package com.hadi.clarpse.sourcemodel;
+
+import java.io.Serializable;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * One string instance per distinct value, for the fields of a parsed model that repeat.
+ *
+ * <p><b>Why it exists.</b> A differential analysis parses a repository twice, at base and at head,
+ * and holds both models for its whole duration. A pull request touching three files out of 452
+ * leaves the two models naming almost entirely the same packages, types and members, so nearly every
+ * name is allocated twice over and both copies stay reachable until the analysis ends. Measured on
+ * two revisions of a 4,330-component model, {@code 50,844} distinct string objects carry only
+ * {@code 12,466} distinct values -- 2.45MB of a 21.4MB pair of models, or 11%, is the same text held
+ * twice.
+ *
+ * <p><b>Which fields, and why not all of them.</b> The gain is per field and it is not where reading
+ * the parser suggests. Recoverable bytes across a base/head pair, measured:
+ *
+ * <table border="1">
+ *   <caption>Recoverable bytes per field, base and head together</caption>
+ *   <tr><th>field</th><th>ratio</th><th>recovered</th></tr>
+ *   <tr><td>children</td><td>2.0x</td><td>536,648</td></tr>
+ *   <tr><td>module</td><td>64.6x</td><td>442,144</td></tr>
+ *   <tr><td>componentName</td><td>2.0x</td><td>413,912</td></tr>
+ *   <tr><td>name</td><td>4.8x</td><td>315,672</td></tr>
+ *   <tr><td>modifiers</td><td>1090.6x</td><td>305,104</td></tr>
+ *   <tr><td>codeFragment</td><td>4.0x</td><td>245,320</td></tr>
+ *   <tr><td>imports</td><td>7.2x</td><td>98,392</td></tr>
+ *   <tr><td>comment</td><td>2.1x</td><td>66,320</td></tr>
+ *   <tr><td>pkg</td><td>12.2x</td><td>15,312</td></tr>
+ *   <tr><td>sourceFile</td><td>2.0x</td><td>11,536</td></tr>
+ * </table>
+ *
+ * <p>{@code componentName} is the field that shows why this had to be measured twice. Within one
+ * revision it is a fully-qualified name, unique by construction, and a census of a single model puts
+ * it at 1.0x -- pooling it there is pure loss. Across a <em>pair</em> of revisions it is 2.0x and the
+ * third largest saving available, because the same 4,330 names are allocated once per parse. A
+ * one-model measurement would have excluded the field.
+ *
+ * <p>Nothing is pooled speculatively. A reference's target name is absent from the table because it
+ * is canonicalised where it is constructed; {@code Component.value} measured zero because the Java
+ * parser never populates it, and it is pooled anyway, being a declared type name in the languages
+ * that do.
+ *
+ * <p><b>Lifetime, which is the whole safety argument.</b> A pool that is never emptied is a leak, and
+ * this codebase has already paid for one: 10.1.2 fixed a static registry in {@code JavaParserFacade}
+ * where each entry pinned a whole AST. So this pool is <b>not static</b>. An instance is owned by the
+ * {@link OOPSourceCodeModel}s that were given it and becomes unreachable with them, which is exactly
+ * the scope the saving is wanted over -- one analysis. It also retains nothing the models do not
+ * already hold: every value in it is a string a component points at, so the only cost above the
+ * saving is the map's own entries.
+ *
+ * <p>{@link String#intern()} is deliberately not used. It would make the sharing global and permanent
+ * rather than scoped to an analysis, and its table is sized outside the heap where none of this
+ * platform's memory instrumentation can see it.
+ *
+ * <p>Instances are safe for use by several threads, because the two revisions of an analysis are
+ * parsed concurrently.
+ */
+public final class StringPool implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final Map<String, String> strings = new ConcurrentHashMap<>();
+    private final Map<Package, Package> packages = new ConcurrentHashMap<>();
+
+    /**
+     * The canonical instance for the given value.
+     *
+     * @param value Any string, or {@code null}.
+     * @return The first instance this pool saw carrying that value, or {@code null} for {@code null}.
+     *         Empty strings are returned as they came, since they are already shared by the JVM.
+     */
+    public String pooled(final String value) {
+        if (value == null || value.isEmpty()) {
+            return value;
+        }
+        final String existing = strings.get(value);
+        if (existing != null) {
+            return existing;
+        }
+        final String previous = strings.putIfAbsent(value, value);
+        if (previous == null) {
+            return value;
+        }
+        return previous;
+    }
+
+    /**
+     * The canonical instance for the given package, which carries three strings of its own.
+     *
+     * @param pkg Any package, or {@code null}.
+     * @return The first equal package this pool saw, or {@code null} for {@code null}.
+     */
+    public Package pooled(final Package pkg) {
+        if (pkg == null) {
+            return null;
+        }
+        final Package existing = packages.get(pkg);
+        if (existing != null) {
+            return existing;
+        }
+        final Package previous = packages.putIfAbsent(pkg, pkg);
+        if (previous == null) {
+            return pkg;
+        }
+        return previous;
+    }
+
+    /**
+     * A set holding the canonical instance of each of the given values.
+     *
+     * <p>Iteration order is preserved, because a model's imports and modifiers are rendered in the
+     * order they were declared and a diagram must not change shape for this.
+     *
+     * @param values Values to canonicalise. May be {@code null}.
+     * @return A new set of pooled instances, empty if {@code values} was {@code null}.
+     */
+    public Set<String> pooledSet(final Set<String> values) {
+        final Set<String> pooled = new LinkedHashSet<>();
+        if (values == null) {
+            return pooled;
+        }
+        for (final String value : values) {
+            pooled.add(pooled(value));
+        }
+        return pooled;
+    }
+
+    /**
+     * How many distinct values this pool holds, for instrumentation and for tests that assert the
+     * pool is doing something.
+     *
+     * @return Distinct string values pooled so far.
+     */
+    public int size() {
+        return strings.size();
+    }
+}

--- a/src/test/java/com/hadi/test/ClarpseProjectTest.java
+++ b/src/test/java/com/hadi/test/ClarpseProjectTest.java
@@ -34,8 +34,8 @@ public class ClarpseProjectTest {
 
         CompileResult result = new ClarpseProject(projectFiles, Lang.JAVA, List.of("/kept.java")).result();
 
-        assertTrue(result.model().getComponent("Kept").isPresent());
-        assertFalse(result.model().getComponent("Ignored").isPresent());
+        assertTrue(result.model().copyOfComponent("Kept").isPresent());
+        assertFalse(result.model().copyOfComponent("Ignored").isPresent());
         assertEquals(2, projectFiles.size());
     }
 
@@ -49,8 +49,8 @@ public class ClarpseProjectTest {
         CompileResult result = new ClarpseProject(projectFiles, Lang.JAVA,
                 List.of("src\\main\\File1.java")).result();
 
-        assertTrue(result.model().getComponent("File1").isPresent());
-        assertFalse(result.model().getComponent("File2").isPresent());
+        assertTrue(result.model().copyOfComponent("File1").isPresent());
+        assertFalse(result.model().copyOfComponent("File2").isPresent());
     }
 
     @Test
@@ -62,7 +62,7 @@ public class ClarpseProjectTest {
         CompileResult result = new ClarpseProject(projectFiles, Lang.JAVA,
                 List.of("/src/File.java")).result();
 
-        assertTrue(result.model().getComponent("File").isPresent());
+        assertTrue(result.model().copyOfComponent("File").isPresent());
     }
 
     @Test
@@ -74,7 +74,7 @@ public class ClarpseProjectTest {
         CompileResult result = new ClarpseProject(projectFiles, Lang.JAVA,
                 List.of("/src/File.java/")).result();
 
-        assertTrue(result.model().getComponent("File").isPresent());
+        assertTrue(result.model().copyOfComponent("File").isPresent());
     }
 
     @Test
@@ -85,7 +85,7 @@ public class ClarpseProjectTest {
         // Empty collection should return empty result, not all files
         CompileResult result = new ClarpseProject(projectFiles, Lang.JAVA, List.of()).result();
 
-        assertFalse(result.model().getComponent("File").isPresent());
+        assertFalse(result.model().copyOfComponent("File").isPresent());
         assertEquals(0, result.model().size());
     }
 
@@ -98,8 +98,8 @@ public class ClarpseProjectTest {
         // null should analyze all files
         CompileResult result = new ClarpseProject(projectFiles, Lang.JAVA, null).result();
 
-        assertTrue(result.model().getComponent("File1").isPresent());
-        assertTrue(result.model().getComponent("File2").isPresent());
+        assertTrue(result.model().copyOfComponent("File1").isPresent());
+        assertTrue(result.model().copyOfComponent("File2").isPresent());
     }
 
     @Test

--- a/src/test/java/com/hadi/test/CrossLanguageImportsTest.java
+++ b/src/test/java/com/hadi/test/CrossLanguageImportsTest.java
@@ -37,7 +37,7 @@ public class CrossLanguageImportsTest {
     }
 
     private static Component component(final OOPSourceCodeModel model, final String name) {
-        return model.getComponent(name).orElseThrow(() -> new AssertionError(
+        return model.copyOfComponent(name).orElseThrow(() -> new AssertionError(
                 "no component " + name + " in "
                         + model.components().map(Component::uniqueName).collect(Collectors.toList())));
     }

--- a/src/test/java/com/hadi/test/CrossLanguageModifiersTest.java
+++ b/src/test/java/com/hadi/test/CrossLanguageModifiersTest.java
@@ -115,7 +115,7 @@ public class CrossLanguageModifiersTest {
     }
 
     private static Component component(final OOPSourceCodeModel model, final String uniqueName) {
-        final Component component = model.getComponent(uniqueName).orElse(null);
+        final Component component = model.copyOfComponent(uniqueName).orElse(null);
         assertNotNull("no component named " + uniqueName, component);
         return component;
     }

--- a/src/test/java/com/hadi/test/OOPSourceCodeModelTest.java
+++ b/src/test/java/com/hadi/test/OOPSourceCodeModelTest.java
@@ -55,7 +55,7 @@ public class OOPSourceCodeModelTest {
         codeModel.insertComponent(componentA);
         codeModel.insertComponent(componentB);
 
-        assertEquals(testComponent, codeModel.parentBaseCmp(componentB.uniqueName()));
+        assertEquals(testComponent, codeModel.copyOfParentBaseComponent(componentB.uniqueName()));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -63,6 +63,6 @@ public class OOPSourceCodeModelTest {
         OOPSourceCodeModel childCmp = new OOPSourceCodeModel();
         Component component = new Component();
         component.setComponentName("Test");
-        childCmp.parentBaseCmp("Test");
+        childCmp.copyOfParentBaseComponent("Test");
     }
 }

--- a/src/test/java/com/hadi/test/csharp/CSharpAccessModifiersTest.java
+++ b/src/test/java/com/hadi/test/csharp/CSharpAccessModifiersTest.java
@@ -29,24 +29,24 @@ public class CSharpAccessModifiersTest {
 
     @Test
     public void classModifiersAreCaptured() {
-        assertTrue(model.getComponent("Demo.User").get().modifiers().contains("public"));
-        assertTrue(model.getComponent("Demo.User").get().modifiers().contains("partial"));
+        assertTrue(model.copyOfComponent("Demo.User").get().modifiers().contains("public"));
+        assertTrue(model.copyOfComponent("Demo.User").get().modifiers().contains("partial"));
     }
 
     @Test
     public void fieldModifiersAreCaptured() {
-        assertTrue(model.getComponent("Demo.User.repo").get().modifiers().contains("private"));
-        assertTrue(model.getComponent("Demo.User.repo").get().modifiers().contains("readonly"));
+        assertTrue(model.copyOfComponent("Demo.User.repo").get().modifiers().contains("private"));
+        assertTrue(model.copyOfComponent("Demo.User.repo").get().modifiers().contains("readonly"));
     }
 
     @Test
     public void constructorModifiersAreCaptured() {
-        assertTrue(model.getComponent("Demo.User.User(Repo)").get().modifiers().contains("internal"));
+        assertTrue(model.copyOfComponent("Demo.User.User(Repo)").get().modifiers().contains("internal"));
     }
 
     @Test
     public void methodModifiersAreCaptured() {
-        assertTrue(model.getComponent("Demo.User.Save(string)").get().modifiers().contains("protected"));
-        assertTrue(model.getComponent("Demo.User.Save(string)").get().modifiers().contains("static"));
+        assertTrue(model.copyOfComponent("Demo.User.Save(string)").get().modifiers().contains("protected"));
+        assertTrue(model.copyOfComponent("Demo.User.Save(string)").get().modifiers().contains("static"));
     }
 }

--- a/src/test/java/com/hadi/test/csharp/CSharpAmbiguousNameResolutionTest.java
+++ b/src/test/java/com/hadi/test/csharp/CSharpAmbiguousNameResolutionTest.java
@@ -27,7 +27,7 @@ import static org.junit.Assert.assertTrue;
 public class CSharpAmbiguousNameResolutionTest {
 
     private static Set<String> refs(final OOPSourceCodeModel model, final String component) {
-        final Component cmp = model.getComponent(component).orElseThrow(
+        final Component cmp = model.copyOfComponent(component).orElseThrow(
                 () -> new AssertionError("no component " + component + " in "
                         + model.components().map(Component::uniqueName).collect(Collectors.toList())));
         return cmp.references().stream().map(r -> r.invokedComponent()).collect(Collectors.toSet());

--- a/src/test/java/com/hadi/test/csharp/CSharpChildComponentsTest.java
+++ b/src/test/java/com/hadi/test/csharp/CSharpChildComponentsTest.java
@@ -28,39 +28,39 @@ public class CSharpChildComponentsTest {
 
     @Test
     public void classHasMethodChild() {
-        assertTrue(model.getComponent("Demo.User").get().children().contains("Demo.User.Save(string)"));
+        assertTrue(model.copyOfComponent("Demo.User").get().children().contains("Demo.User.Save(string)"));
     }
 
     @Test
     public void classHasFieldChild() {
-        assertTrue(model.getComponent("Demo.User").get().children().contains("Demo.User.Name"));
+        assertTrue(model.copyOfComponent("Demo.User").get().children().contains("Demo.User.Name"));
     }
 
     @Test
     public void classHasNestedInterfaceChild() {
-        assertTrue(model.getComponent("Demo.User").get().children().contains("Demo.User.IRunner"));
+        assertTrue(model.copyOfComponent("Demo.User").get().children().contains("Demo.User.IRunner"));
     }
 
     @Test
     public void classHasNestedEnumChild() {
-        assertTrue(model.getComponent("Demo.User").get().children().contains("Demo.User.Status"));
+        assertTrue(model.copyOfComponent("Demo.User").get().children().contains("Demo.User.Status"));
     }
 
     @Test
     public void methodHasParameterChild() {
-        assertTrue(model.getComponent("Demo.User.Save(string)").get().children()
+        assertTrue(model.copyOfComponent("Demo.User.Save(string)").get().children()
                 .contains("Demo.User.Save(string).message"));
     }
 
     @Test
     public void methodHasLocalChild() {
-        assertTrue(model.getComponent("Demo.User.Save(string)").get().children()
+        assertTrue(model.copyOfComponent("Demo.User.Save(string)").get().children()
                 .contains("Demo.User.Save(string).local"));
     }
 
     @Test
     public void enumHasConstantChildren() {
-        assertTrue(model.getComponent("Demo.User.Status").get().children().contains("Demo.User.Status.Ready"));
-        assertTrue(model.getComponent("Demo.User.Status").get().children().contains("Demo.User.Status.Done"));
+        assertTrue(model.copyOfComponent("Demo.User.Status").get().children().contains("Demo.User.Status.Ready"));
+        assertTrue(model.copyOfComponent("Demo.User.Status").get().children().contains("Demo.User.Status.Done"));
     }
 }

--- a/src/test/java/com/hadi/test/csharp/CSharpCodeFragmentTest.java
+++ b/src/test/java/com/hadi/test/csharp/CSharpCodeFragmentTest.java
@@ -30,30 +30,30 @@ public class CSharpCodeFragmentTest {
 
     @Test
     public void classCodeFragmentIsCaptured() {
-        assertEquals("public class User", model.getComponent("Demo.User").get().codeFragment());
+        assertEquals("public class User", model.copyOfComponent("Demo.User").get().codeFragment());
     }
 
     @Test
     public void propertyCodeFragmentIsCaptured() {
         assertEquals("Names : System.Collections.Generic.List<string>",
-                model.getComponent("Demo.User.Names").get().codeFragment());
+                model.copyOfComponent("Demo.User.Names").get().codeFragment());
     }
 
     @Test
     public void methodCodeFragmentIsCaptured() {
         assertEquals("public void Save(string message)",
-                model.getComponent("Demo.User.Save(string)").get().codeFragment());
+                model.copyOfComponent("Demo.User.Save(string)").get().codeFragment());
     }
 
     @Test
     public void constructorCodeFragmentIsCaptured() {
         assertEquals("public User(Repo repo)",
-                model.getComponent("Demo.User.User(Repo)").get().codeFragment());
+                model.copyOfComponent("Demo.User.User(Repo)").get().codeFragment());
     }
 
     @Test
     public void delegateCodeFragmentIsCaptured() {
         assertEquals("public delegate void LogHandler(string value)",
-                model.getComponent("Demo.User.LogHandler").get().codeFragment());
+                model.copyOfComponent("Demo.User.LogHandler").get().codeFragment());
     }
 }

--- a/src/test/java/com/hadi/test/csharp/CSharpCommentsCycloTest.java
+++ b/src/test/java/com/hadi/test/csharp/CSharpCommentsCycloTest.java
@@ -32,17 +32,17 @@ public class CSharpCommentsCycloTest {
 
     @Test
     public void commentsAreAttached() {
-        assertTrue(model.getComponent("Demo.User").get().comment().contains("summary"));
-        assertTrue(model.getComponent("Demo.User.Save()").get().comment().contains("Saves a user"));
+        assertTrue(model.copyOfComponent("Demo.User").get().comment().contains("summary"));
+        assertTrue(model.copyOfComponent("Demo.User.Save()").get().comment().contains("Saves a user"));
     }
 
     @Test
     public void codeFragmentsAreCaptured() {
-        assertEquals("public void Save()", model.getComponent("Demo.User.Save()").get().codeFragment());
+        assertEquals("public void Save()", model.copyOfComponent("Demo.User.Save()").get().codeFragment());
     }
 
     @Test
     public void methodCycloIsComputed() {
-        assertEquals(4, model.getComponent("Demo.User.Save()").get().cyclo());
+        assertEquals(4, model.copyOfComponent("Demo.User.Save()").get().cyclo());
     }
 }

--- a/src/test/java/com/hadi/test/csharp/CSharpComponentProjectFilePathTest.java
+++ b/src/test/java/com/hadi/test/csharp/CSharpComponentProjectFilePathTest.java
@@ -35,31 +35,31 @@ public class CSharpComponentProjectFilePathTest {
 
     @Test
     public void classHasCorrectSourcePath() {
-        final Component component = model.getComponent("Demo.User").get();
+        final Component component = model.copyOfComponent("Demo.User").get();
         assertEquals(FILE_A, component.sourceFile());
     }
 
     @Test
     public void fieldHasCorrectSourcePath() {
-        final Component component = model.getComponent("Demo.User.Name").get();
+        final Component component = model.copyOfComponent("Demo.User.Name").get();
         assertEquals(FILE_A, component.sourceFile());
     }
 
     @Test
     public void methodHasCorrectSourcePath() {
-        final Component component = model.getComponent("Demo.User.Save(string)").get();
+        final Component component = model.copyOfComponent("Demo.User.Save(string)").get();
         assertEquals(FILE_A, component.sourceFile());
     }
 
     @Test
     public void nestedNamespaceClassHasCorrectSourcePath() {
-        final Component component = model.getComponent("Demo.Admin.Admin").get();
+        final Component component = model.copyOfComponent("Demo.Admin.Admin").get();
         assertEquals(FILE_B, component.sourceFile());
     }
 
     @Test
     public void nestedNamespaceMethodHasCorrectSourcePath() {
-        final Component component = model.getComponent("Demo.Admin.Admin.Run()").get();
+        final Component component = model.copyOfComponent("Demo.Admin.Admin.Run()").get();
         assertEquals(FILE_B, component.sourceFile());
     }
 }

--- a/src/test/java/com/hadi/test/csharp/CSharpComponentTypeTest.java
+++ b/src/test/java/com/hadi/test/csharp/CSharpComponentTypeTest.java
@@ -36,48 +36,48 @@ public class CSharpComponentTypeTest {
     @Test
     public void classIsMapped() {
         assertEquals(OOPSourceModelConstants.ComponentType.CLASS,
-                model.getComponent("Demo.User").get().componentType());
+                model.copyOfComponent("Demo.User").get().componentType());
     }
 
     @Test
     public void propertyIsMappedAsField() {
         assertEquals(OOPSourceModelConstants.ComponentType.FIELD,
-                model.getComponent("Demo.User.Name").get().componentType());
+                model.copyOfComponent("Demo.User.Name").get().componentType());
     }
 
     @Test
     public void constructorIsMapped() {
         assertEquals(OOPSourceModelConstants.ComponentType.CONSTRUCTOR,
-                model.getComponent("Demo.User.User(Repo)").get().componentType());
+                model.copyOfComponent("Demo.User.User(Repo)").get().componentType());
     }
 
     @Test
     public void methodIsMapped() {
         assertEquals(OOPSourceModelConstants.ComponentType.METHOD,
-                model.getComponent("Demo.User.Save(string)").get().componentType());
+                model.copyOfComponent("Demo.User.Save(string)").get().componentType());
     }
 
     @Test
     public void delegateIsMappedAsFunction() {
         assertEquals(OOPSourceModelConstants.ComponentType.FUNCTION,
-                model.getComponent("Demo.User.LogHandler").get().componentType());
+                model.copyOfComponent("Demo.User.LogHandler").get().componentType());
     }
 
     @Test
     public void recordIsMappedAsClass() {
         assertEquals(OOPSourceModelConstants.ComponentType.CLASS,
-                model.getComponent("Demo.User.Audit").get().componentType());
+                model.copyOfComponent("Demo.User.Audit").get().componentType());
     }
 
     @Test
     public void interfaceIsMapped() {
         assertEquals(OOPSourceModelConstants.ComponentType.INTERFACE,
-                model.getComponent("Demo.User.IRunner").get().componentType());
+                model.copyOfComponent("Demo.User.IRunner").get().componentType());
     }
 
     @Test
     public void enumIsMapped() {
         assertEquals(OOPSourceModelConstants.ComponentType.ENUM,
-                model.getComponent("Demo.User.Status").get().componentType());
+                model.copyOfComponent("Demo.User.Status").get().componentType());
     }
 }

--- a/src/test/java/com/hadi/test/csharp/CSharpCrossFileResolutionTest.java
+++ b/src/test/java/com/hadi/test/csharp/CSharpCrossFileResolutionTest.java
@@ -45,7 +45,7 @@ public class CSharpCrossFileResolutionTest {
     }
 
     private static boolean componentReferences(final String component, final String target) {
-        return model.getComponent(component).get().references().stream()
+        return model.copyOfComponent(component).get().references().stream()
                 .anyMatch(ref -> ref.invokedComponent().equals(target));
     }
 

--- a/src/test/java/com/hadi/test/csharp/CSharpImportExternalAndRecordVariantsTest.java
+++ b/src/test/java/com/hadi/test/csharp/CSharpImportExternalAndRecordVariantsTest.java
@@ -50,74 +50,74 @@ public class CSharpImportExternalAndRecordVariantsTest {
 
     @Test
     public void globalUsingResolvesCrossFileType() {
-        assertEquals("Demo.Shared.SharedThing", model.getComponent("Demo.App.ImportConsumer.Thing").get()
+        assertEquals("Demo.Shared.SharedThing", model.copyOfComponent("Demo.App.ImportConsumer.Thing").get()
                 .references(OOPSourceModelConstants.TypeReferences.SIMPLE).get(0).invokedComponent());
     }
 
     @Test
     public void globalAliasUsingResolvesCrossFileType() {
-        assertEquals("Demo.Shared.Repo", model.getComponent("Demo.App.ImportConsumer.Repo").get()
+        assertEquals("Demo.Shared.Repo", model.copyOfComponent("Demo.App.ImportConsumer.Repo").get()
                 .references(OOPSourceModelConstants.TypeReferences.SIMPLE).get(0).invokedComponent());
     }
 
     @Test
     public void normalUsingNamespaceImportIsRecorded() {
-        assertTrue(model.getComponent("Demo.App.ImportConsumer").get().imports().contains("System.Collections.Generic"));
+        assertTrue(model.copyOfComponent("Demo.App.ImportConsumer").get().imports().contains("System.Collections.Generic"));
     }
 
     @Test
     public void normalUsingTypeImportIsRecorded() {
-        assertTrue(model.getComponent("Demo.App.ImportConsumer").get().imports().contains("System.Text"));
+        assertTrue(model.copyOfComponent("Demo.App.ImportConsumer").get().imports().contains("System.Text"));
     }
 
     @Test
     public void staticUsingImportIsRecorded() {
-        assertTrue(model.getComponent("Demo.App.ImportConsumer").get().imports().contains("System.String"));
+        assertTrue(model.copyOfComponent("Demo.App.ImportConsumer").get().imports().contains("System.String"));
     }
 
     @Test
     public void globalStaticUsingImportIsRecorded() {
-        assertTrue(model.getComponent("Demo.App.ImportConsumer").get().imports().contains("System.Math"));
+        assertTrue(model.copyOfComponent("Demo.App.ImportConsumer").get().imports().contains("System.Math"));
     }
 
     @Test
     public void importedGenericCollectionTypeIsExternal() {
-        final Component component = model.getComponent("Demo.App.ImportConsumer.Names").get();
+        final Component component = model.copyOfComponent("Demo.App.ImportConsumer.Names").get();
         assertTrue(component.externalDependencies().stream()
                 .anyMatch(ref -> ref.invokedComponent().equals("List")));
     }
 
     @Test
     public void importedFrameworkBuilderTypeIsExternal() {
-        final Component component = model.getComponent("Demo.App.ImportConsumer.Builder").get();
+        final Component component = model.copyOfComponent("Demo.App.ImportConsumer.Builder").get();
         assertTrue(component.externalDependencies().stream()
                 .anyMatch(ref -> ref.invokedComponent().equals("StringBuilder")));
     }
 
     @Test
     public void builtinStringTypeIsExternal() {
-        final Component component = model.getComponent("Demo.App.ImportConsumer.Names").get();
+        final Component component = model.copyOfComponent("Demo.App.ImportConsumer.Names").get();
         assertTrue(component.externalDependencies().stream()
                 .anyMatch(ref -> ref.invokedComponent().equals("System.String")));
     }
 
     @Test
     public void externalStaticMathTypeReferenceIsCaptured() {
-        final Component component = model.getComponent("Demo.App.ImportConsumer.Measure()").get();
+        final Component component = model.copyOfComponent("Demo.App.ImportConsumer.Measure()").get();
         assertTrue(component.externalDependencies().stream()
                 .anyMatch(ref -> ref.invokedComponent().equals("Math")));
     }
 
     @Test
     public void externalDoubleReturnTypeIsCaptured() {
-        final Component component = model.getComponent("Demo.App.ImportConsumer.Measure()").get();
+        final Component component = model.copyOfComponent("Demo.App.ImportConsumer.Measure()").get();
         assertTrue(component.externalDependencies().stream()
                 .anyMatch(ref -> ref.invokedComponent().equals("System.Double")));
     }
 
     @Test
     public void externalReferencesAreNotClassifiedInternal() {
-        final Component component = model.getComponent("Demo.App.ImportConsumer.Builder").get();
+        final Component component = model.copyOfComponent("Demo.App.ImportConsumer.Builder").get();
         assertTrue(component.internalDependencies().stream()
                 .noneMatch(ref -> ref.invokedComponent().equals("StringBuilder")));
     }
@@ -125,13 +125,13 @@ public class CSharpImportExternalAndRecordVariantsTest {
     @Test
     public void recordClassMapsToClass() {
         assertEquals(OOPSourceModelConstants.ComponentType.CLASS,
-                model.getComponent("Demo.App.AuditRecord").get().componentType());
+                model.copyOfComponent("Demo.App.AuditRecord").get().componentType());
     }
 
     @Test
     public void recordStructMapsToStruct() {
         assertEquals(OOPSourceModelConstants.ComponentType.STRUCT,
-                model.getComponent("Demo.App.AuditPoint").get().componentType());
+                model.copyOfComponent("Demo.App.AuditPoint").get().componentType());
     }
 
     @Test
@@ -148,24 +148,24 @@ public class CSharpImportExternalAndRecordVariantsTest {
 
     @Test
     public void recordStructChildrenContainPositionalMembers() {
-        assertTrue(model.getComponent("Demo.App.AuditPoint").get().children().contains("Demo.App.AuditPoint.X"));
-        assertTrue(model.getComponent("Demo.App.AuditPoint").get().children().contains("Demo.App.AuditPoint.Y"));
+        assertTrue(model.copyOfComponent("Demo.App.AuditPoint").get().children().contains("Demo.App.AuditPoint.X"));
+        assertTrue(model.copyOfComponent("Demo.App.AuditPoint").get().children().contains("Demo.App.AuditPoint.Y"));
     }
 
     @Test
     public void delegateLikeChildrenRemainParentedCorrectly() {
-        assertTrue(model.getComponent("Demo.App.ImportConsumer").get().children().contains("Demo.App.ImportConsumer.Measure()"));
+        assertTrue(model.copyOfComponent("Demo.App.ImportConsumer").get().children().contains("Demo.App.ImportConsumer.Measure()"));
     }
 
     @Test
     public void propertyChildrenRemainParentedCorrectly() {
-        assertTrue(model.getComponent("Demo.App.ImportConsumer").get().children().contains("Demo.App.ImportConsumer.Repo"));
-        assertTrue(model.getComponent("Demo.App.ImportConsumer").get().children().contains("Demo.App.ImportConsumer.Thing"));
+        assertTrue(model.copyOfComponent("Demo.App.ImportConsumer").get().children().contains("Demo.App.ImportConsumer.Repo"));
+        assertTrue(model.copyOfComponent("Demo.App.ImportConsumer").get().children().contains("Demo.App.ImportConsumer.Thing"));
     }
 
     @Test
     public void recordClassComponentNamesAreStable() {
-        assertEquals("AuditRecord", model.getComponent("Demo.App.AuditRecord").get().name());
-        assertEquals("AuditPoint", model.getComponent("Demo.App.AuditPoint").get().name());
+        assertEquals("AuditRecord", model.copyOfComponent("Demo.App.AuditRecord").get().name());
+        assertEquals("AuditPoint", model.copyOfComponent("Demo.App.AuditPoint").get().name());
     }
 }

--- a/src/test/java/com/hadi/test/csharp/CSharpModernPatternsResolutionTest.java
+++ b/src/test/java/com/hadi/test/csharp/CSharpModernPatternsResolutionTest.java
@@ -68,7 +68,7 @@ public class CSharpModernPatternsResolutionTest {
     }
 
     private static boolean anyRefTo(final String component, final String target) {
-        return model.getComponent(component)
+        return model.copyOfComponent(component)
                 .map(c -> c.references().stream().anyMatch(r -> r.invokedComponent().equals(target)))
                 .orElse(false);
     }
@@ -76,7 +76,7 @@ public class CSharpModernPatternsResolutionTest {
     @Test
     public void genericBaseClassProducesExtensionReference() {
         assertTrue("OrderHandler should extend Acme.Contracts.ServiceBase",
-                model.getComponent("Acme.Services.OrderHandler").get()
+                model.copyOfComponent("Acme.Services.OrderHandler").get()
                         .references(com.hadi.clarpse.sourcemodel.OOPSourceModelConstants.TypeReferences.EXTENSION)
                         .contains(new TypeExtensionReference("Acme.Contracts.ServiceBase")));
     }
@@ -84,7 +84,7 @@ public class CSharpModernPatternsResolutionTest {
     @Test
     public void genericInterfaceProducesImplementationReference() {
         assertTrue("OrderHandler should implement Acme.Contracts.IHandler",
-                model.getComponent("Acme.Services.OrderHandler").get()
+                model.copyOfComponent("Acme.Services.OrderHandler").get()
                         .references(com.hadi.clarpse.sourcemodel.OOPSourceModelConstants.TypeReferences.IMPLEMENTATION)
                         .contains(new TypeImplementationReference("Acme.Contracts.IHandler")));
     }
@@ -135,10 +135,10 @@ public class CSharpModernPatternsResolutionTest {
                         }
                         """)
         ).model();
-        assertTrue(arity.getComponent("Demo.IFoo").isPresent());
-        assertTrue(arity.getComponent("Demo.User.Plain").get().references().stream()
+        assertTrue(arity.copyOfComponent("Demo.IFoo").isPresent());
+        assertTrue(arity.copyOfComponent("Demo.User.Plain").get().references().stream()
                 .anyMatch(r -> r.invokedComponent().equals("Demo.IFoo")));
-        assertTrue(arity.getComponent("Demo.User.Generic").get().references().stream()
+        assertTrue(arity.copyOfComponent("Demo.User.Generic").get().references().stream()
                 .anyMatch(r -> r.invokedComponent().equals("Demo.IFoo")));
     }
 }

--- a/src/test/java/com/hadi/test/csharp/CSharpMultiVariableDeclarationTest.java
+++ b/src/test/java/com/hadi/test/csharp/CSharpMultiVariableDeclarationTest.java
@@ -38,9 +38,9 @@ public class CSharpMultiVariableDeclarationTest {
                         """)
         ).model();
 
-        assertEquals("Demo.Repo", model.getComponent("Demo.User.first").get()
+        assertEquals("Demo.Repo", model.copyOfComponent("Demo.User.first").get()
                 .references(OOPSourceModelConstants.TypeReferences.SIMPLE).get(0).invokedComponent());
-        assertEquals("Demo.Repo", model.getComponent("Demo.User.second").get()
+        assertEquals("Demo.Repo", model.copyOfComponent("Demo.User.second").get()
                 .references(OOPSourceModelConstants.TypeReferences.SIMPLE).get(0).invokedComponent());
     }
 }

--- a/src/test/java/com/hadi/test/csharp/CSharpNamespaceAndModuleTest.java
+++ b/src/test/java/com/hadi/test/csharp/CSharpNamespaceAndModuleTest.java
@@ -27,14 +27,14 @@ public class CSharpNamespaceAndModuleTest {
 
     @Test
     public void namespaceBecomesPackage() {
-        final Component component = model.getComponent("Demo.Feature.User").get();
+        final Component component = model.copyOfComponent("Demo.Feature.User").get();
         assertEquals("Demo.Feature", component.pkg().name());
         assertEquals("Demo.Feature", component.pkg().path());
     }
 
     @Test
     public void fileNameBecomesModule() {
-        final Component component = model.getComponent("Demo.Feature.User").get();
+        final Component component = model.copyOfComponent("Demo.Feature.User").get();
         assertEquals("User", component.module());
     }
 
@@ -50,6 +50,6 @@ public class CSharpNamespaceAndModuleTest {
                         """)
         ).model();
 
-        assertTrue(nestedNamespaceModel.getComponent("Demo.Feature.NestedUser").isPresent());
+        assertTrue(nestedNamespaceModel.copyOfComponent("Demo.Feature.NestedUser").isPresent());
     }
 }

--- a/src/test/java/com/hadi/test/csharp/CSharpRealisticLayoutResolutionTest.java
+++ b/src/test/java/com/hadi/test/csharp/CSharpRealisticLayoutResolutionTest.java
@@ -57,7 +57,7 @@ public class CSharpRealisticLayoutResolutionTest {
     }
 
     private static boolean componentReferences(final String component, final String target) {
-        return model.getComponent(component).get().references().stream()
+        return model.copyOfComponent(component).get().references().stream()
                 .anyMatch(ref -> ref.invokedComponent().equals(target));
     }
 

--- a/src/test/java/com/hadi/test/csharp/CSharpReferenceTest.java
+++ b/src/test/java/com/hadi/test/csharp/CSharpReferenceTest.java
@@ -39,14 +39,14 @@ public class CSharpReferenceTest {
 
     @Test
     public void extensionReferenceIsResolved() {
-        assertTrue(model.getComponent("Demo.User").get()
+        assertTrue(model.copyOfComponent("Demo.User").get()
                 .references(OOPSourceModelConstants.TypeReferences.EXTENSION)
                 .contains(new TypeExtensionReference("Demo.BaseUser")));
     }
 
     @Test
     public void implementationReferenceIsResolved() {
-        assertTrue(model.getComponent("Demo.User").get()
+        assertTrue(model.copyOfComponent("Demo.User").get()
                 .references(OOPSourceModelConstants.TypeReferences.IMPLEMENTATION)
                 .contains(new TypeImplementationReference("Demo.IRunner")));
     }
@@ -54,7 +54,7 @@ public class CSharpReferenceTest {
     @Test
     public void propertyTypeReferenceIsResolved() {
         assertEquals("Demo.Tools.Repo",
-                model.getComponent("Demo.User.Repo").get()
+                model.copyOfComponent("Demo.User.Repo").get()
                         .references(OOPSourceModelConstants.TypeReferences.SIMPLE)
                         .get(0).invokedComponent());
     }
@@ -62,14 +62,14 @@ public class CSharpReferenceTest {
     @Test
     public void aliasUsingTypeReferenceIsResolved() {
         assertEquals("Demo.Tools.Repo",
-                model.getComponent("Demo.User.AliasRepo").get()
+                model.copyOfComponent("Demo.User.AliasRepo").get()
                         .references(OOPSourceModelConstants.TypeReferences.SIMPLE)
                         .get(0).invokedComponent());
     }
 
     @Test
     public void objectCreationReferenceIsResolved() {
-        assertTrue(model.getComponent("Demo.User.Save(string)").get()
+        assertTrue(model.copyOfComponent("Demo.User.Save(string)").get()
                 .references(OOPSourceModelConstants.TypeReferences.SIMPLE)
                 .stream()
                 .anyMatch(ref -> ref.invokedComponent().equals("Demo.Tools.Helper")));
@@ -89,11 +89,11 @@ public class CSharpReferenceTest {
                         """)
         ).model();
 
-        assertTrue(memberAccessModel.getComponent("Demo.Tracker.Reset()").get()
+        assertTrue(memberAccessModel.copyOfComponent("Demo.Tracker.Reset()").get()
                 .references(OOPSourceModelConstants.TypeReferences.SIMPLE)
                 .stream()
                 .noneMatch(ref -> ref.invokedComponent().equals("Store")));
-        assertTrue(memberAccessModel.getComponent("Demo.Tracker.Reset()").get()
+        assertTrue(memberAccessModel.copyOfComponent("Demo.Tracker.Reset()").get()
                 .references(OOPSourceModelConstants.TypeReferences.SIMPLE)
                 .stream()
                 .noneMatch(ref -> ref.invokedComponent().equals("Demo.Tracker.Store")));

--- a/src/test/java/com/hadi/test/csharp/CSharpSimpleTypeReferenceTest.java
+++ b/src/test/java/com/hadi/test/csharp/CSharpSimpleTypeReferenceTest.java
@@ -35,50 +35,50 @@ public class CSharpSimpleTypeReferenceTest {
 
     @Test
     public void fieldLikePropertyTypeResolves() {
-        assertEquals("Demo.Tools.Repo", model.getComponent("Demo.User.Repo").get()
+        assertEquals("Demo.Tools.Repo", model.copyOfComponent("Demo.User.Repo").get()
                 .references(OOPSourceModelConstants.TypeReferences.SIMPLE).get(0).invokedComponent());
     }
 
     @Test
     public void eventTypeResolves() {
-        assertEquals("Demo.User.LogHandler", model.getComponent("Demo.User.Saved").get()
+        assertEquals("Demo.User.LogHandler", model.copyOfComponent("Demo.User.Saved").get()
                 .references(OOPSourceModelConstants.TypeReferences.SIMPLE).get(0).invokedComponent());
     }
 
     @Test
     public void constructorParamTypeResolves() {
-        assertEquals("Demo.Tools.Repo", model.getComponent("Demo.User.User(Repo).repo").get()
+        assertEquals("Demo.Tools.Repo", model.copyOfComponent("Demo.User.User(Repo).repo").get()
                 .references(OOPSourceModelConstants.TypeReferences.SIMPLE).get(0).invokedComponent());
     }
 
     @Test
     public void methodParamBuiltinTypeResolves() {
-        assertEquals("System.String", model.getComponent("Demo.User.Save(string).message").get()
+        assertEquals("System.String", model.copyOfComponent("Demo.User.Save(string).message").get()
                 .references(OOPSourceModelConstants.TypeReferences.SIMPLE).get(0).invokedComponent());
     }
 
     @Test
     public void localTypedReferenceResolves() {
-        assertEquals("Demo.Tools.Helper", model.getComponent("Demo.User.Save(string).helper").get()
+        assertEquals("Demo.Tools.Helper", model.copyOfComponent("Demo.User.Save(string).helper").get()
                 .references(OOPSourceModelConstants.TypeReferences.SIMPLE).get(0).invokedComponent());
     }
 
     @Test
     public void methodCapturesObjectCreationReference() {
-        assertTrue(model.getComponent("Demo.User.Save(string)").get()
+        assertTrue(model.copyOfComponent("Demo.User.Save(string)").get()
                 .references(OOPSourceModelConstants.TypeReferences.SIMPLE).stream()
                 .anyMatch(ref -> ref.invokedComponent().equals("Demo.Tools.Helper")));
     }
 
     @Test
     public void delegateParamBuiltinTypeResolves() {
-        assertEquals("System.String", model.getComponent("Demo.User.LogHandler.value").get()
+        assertEquals("System.String", model.copyOfComponent("Demo.User.LogHandler.value").get()
                 .references(OOPSourceModelConstants.TypeReferences.SIMPLE).get(0).invokedComponent());
     }
 
     @Test
     public void constructorCapturesFieldAssignmentReference() {
-        assertTrue(model.getComponent("Demo.User.User(Repo)").get()
+        assertTrue(model.copyOfComponent("Demo.User.User(Repo)").get()
                 .references(OOPSourceModelConstants.TypeReferences.SIMPLE).stream()
                 .anyMatch(ref -> ref.invokedComponent().equals("Demo.User.Repo")));
     }

--- a/src/test/java/com/hadi/test/csharp/CSharpSpotCheckComponentsTest.java
+++ b/src/test/java/com/hadi/test/csharp/CSharpSpotCheckComponentsTest.java
@@ -42,87 +42,87 @@ public class CSharpSpotCheckComponentsTest {
     @Test
     public void abstractClassIsMappedAsClass() {
         assertEquals(OOPSourceModelConstants.ComponentType.CLASS,
-                model.getComponent("Demo.Shapes.ShapeRegistry").get().componentType());
+                model.copyOfComponent("Demo.Shapes.ShapeRegistry").get().componentType());
     }
 
     @Test
     public void abstractModifierIsCaptured() {
-        assertTrue(model.getComponent("Demo.Shapes.ShapeRegistry").get().modifiers().contains("abstract"));
+        assertTrue(model.copyOfComponent("Demo.Shapes.ShapeRegistry").get().modifiers().contains("abstract"));
     }
 
     @Test
     public void readonlyFieldModifierIsCaptured() {
-        assertTrue(model.getComponent("Demo.Shapes.ShapeRegistry._repo").get().modifiers().contains("readonly"));
+        assertTrue(model.copyOfComponent("Demo.Shapes.ShapeRegistry._repo").get().modifiers().contains("readonly"));
     }
 
     @Test
     public void privateFieldModifierIsCaptured() {
-        assertTrue(model.getComponent("Demo.Shapes.ShapeRegistry._repo").get().modifiers().contains("private"));
+        assertTrue(model.copyOfComponent("Demo.Shapes.ShapeRegistry._repo").get().modifiers().contains("private"));
     }
 
     @Test
     public void propertyIsMappedAsField() {
         assertEquals(OOPSourceModelConstants.ComponentType.FIELD,
-                model.getComponent("Demo.Shapes.ShapeRegistry.Name").get().componentType());
+                model.copyOfComponent("Demo.Shapes.ShapeRegistry.Name").get().componentType());
     }
 
     @Test
     public void eventIsMappedAsField() {
         assertEquals(OOPSourceModelConstants.ComponentType.FIELD,
-                model.getComponent("Demo.Shapes.ShapeRegistry.Changed").get().componentType());
+                model.copyOfComponent("Demo.Shapes.ShapeRegistry.Changed").get().componentType());
     }
 
     @Test
     public void delegateIsMappedAsFunction() {
         assertEquals(OOPSourceModelConstants.ComponentType.FUNCTION,
-                model.getComponent("Demo.Shapes.ShapeRegistry.ChangedHandler").get().componentType());
+                model.copyOfComponent("Demo.Shapes.ShapeRegistry.ChangedHandler").get().componentType());
     }
 
     @Test
     public void nestedStructIsMapped() {
         assertEquals(OOPSourceModelConstants.ComponentType.STRUCT,
-                model.getComponent("Demo.Shapes.ShapeRegistry.Point").get().componentType());
+                model.copyOfComponent("Demo.Shapes.ShapeRegistry.Point").get().componentType());
     }
 
     @Test
     public void nestedInterfaceIsMapped() {
         assertEquals(OOPSourceModelConstants.ComponentType.INTERFACE,
-                model.getComponent("Demo.Shapes.ShapeRegistry.IWorker").get().componentType());
+                model.copyOfComponent("Demo.Shapes.ShapeRegistry.IWorker").get().componentType());
     }
 
     @Test
     public void nestedEnumIsMapped() {
         assertEquals(OOPSourceModelConstants.ComponentType.ENUM,
-                model.getComponent("Demo.Shapes.ShapeRegistry.Status").get().componentType());
+                model.copyOfComponent("Demo.Shapes.ShapeRegistry.Status").get().componentType());
     }
 
     @Test
     public void recordIsMappedAsClass() {
         assertEquals(OOPSourceModelConstants.ComponentType.CLASS,
-                model.getComponent("Demo.Shapes.ShapeRegistry.Audit").get().componentType());
+                model.copyOfComponent("Demo.Shapes.ShapeRegistry.Audit").get().componentType());
     }
 
     @Test
     public void enumMemberIsMapped() {
         assertEquals(OOPSourceModelConstants.ComponentType.ENUM_CONSTANT,
-                model.getComponent("Demo.Shapes.ShapeRegistry.Status.Ready").get().componentType());
+                model.copyOfComponent("Demo.Shapes.ShapeRegistry.Status.Ready").get().componentType());
     }
 
     @Test
     public void constructorIsMapped() {
         assertEquals(OOPSourceModelConstants.ComponentType.CONSTRUCTOR,
-                model.getComponent("Demo.Shapes.ShapeRegistry.ShapeRegistry(Repo)").get().componentType());
+                model.copyOfComponent("Demo.Shapes.ShapeRegistry.ShapeRegistry(Repo)").get().componentType());
     }
 
     @Test
     public void protectedConstructorModifierIsCaptured() {
-        assertTrue(model.getComponent("Demo.Shapes.ShapeRegistry.ShapeRegistry(Repo)").get()
+        assertTrue(model.copyOfComponent("Demo.Shapes.ShapeRegistry.ShapeRegistry(Repo)").get()
                 .modifiers().contains("protected"));
     }
 
     @Test
     public void methodIsMapped() {
         assertEquals(OOPSourceModelConstants.ComponentType.METHOD,
-                model.getComponent("Demo.Shapes.ShapeRegistry.Build(string)").get().componentType());
+                model.copyOfComponent("Demo.Shapes.ShapeRegistry.Build(string)").get().componentType());
     }
 }

--- a/src/test/java/com/hadi/test/csharp/CSharpSpotCheckIdentityAndPathsTest.java
+++ b/src/test/java/com/hadi/test/csharp/CSharpSpotCheckIdentityAndPathsTest.java
@@ -64,75 +64,75 @@ public class CSharpSpotCheckIdentityAndPathsTest {
 
     @Test
     public void propertySourceFilePathComesFromFirstPart() {
-        final Component component = model.getComponent("Demo.Orders.Order.Id").get();
+        final Component component = model.copyOfComponent("Demo.Orders.Order.Id").get();
         assertEquals(ORDER_PART1, component.sourceFile());
     }
 
     @Test
     public void eventSourceFilePathComesFromSecondPart() {
-        final Component component = model.getComponent("Demo.Orders.Order.Saved").get();
+        final Component component = model.copyOfComponent("Demo.Orders.Order.Saved").get();
         assertEquals(ORDER_PART2, component.sourceFile());
     }
 
     @Test
     public void delegateSourceFilePathComesFromSecondPart() {
-        final Component component = model.getComponent("Demo.Orders.Order.OrderSaved").get();
+        final Component component = model.copyOfComponent("Demo.Orders.Order.OrderSaved").get();
         assertEquals(ORDER_PART2, component.sourceFile());
     }
 
     @Test
     public void fileScopedNamespaceBecomesPackage() {
-        final Component component = model.getComponent("Demo.FileScoped.Config").get();
+        final Component component = model.copyOfComponent("Demo.FileScoped.Config").get();
         assertEquals("Demo.FileScoped", component.pkg().name());
     }
 
     @Test
     public void fileScopedModuleUsesFilename() {
-        final Component component = model.getComponent("Demo.FileScoped.Config").get();
+        final Component component = model.copyOfComponent("Demo.FileScoped.Config").get();
         assertEquals("Config", component.module());
     }
 
     @Test
     public void orderModuleUsesFilenameWithoutExtension() {
-        final Component component = model.getComponent("Demo.Orders.Order").get();
+        final Component component = model.copyOfComponent("Demo.Orders.Order").get();
         assertEquals("Order.Part1", component.module());
     }
 
     @Test
     public void partialTypeChildrenIncludeNestedClass() {
-        assertTrue(model.getComponent("Demo.Orders.Order").get().children()
+        assertTrue(model.copyOfComponent("Demo.Orders.Order").get().children()
                 .contains("Demo.Orders.Order.Metadata"));
     }
 
     @Test
     public void partialTypeChildrenIncludeMethod() {
-        assertTrue(model.getComponent("Demo.Orders.Order").get().children()
+        assertTrue(model.copyOfComponent("Demo.Orders.Order").get().children()
                 .contains("Demo.Orders.Order.Add(LineItem)"));
     }
 
     @Test
     public void nestedClassFieldTypeIsCaptured() {
         assertEquals(OOPSourceModelConstants.ComponentType.FIELD,
-                model.getComponent("Demo.Orders.Order.Metadata.Version").get().componentType());
+                model.copyOfComponent("Demo.Orders.Order.Metadata.Version").get().componentType());
     }
 
     @Test
     public void methodParamSourceFilePathComesFromFirstPart() {
-        final Component component = model.getComponent("Demo.Orders.Order.Add(LineItem).item").get();
+        final Component component = model.copyOfComponent("Demo.Orders.Order.Add(LineItem).item").get();
         assertEquals(ORDER_PART1, component.sourceFile());
     }
 
     @Test
     public void methodLocalSourceFilePathComesFromFirstPart() {
-        final Component component = model.getComponent("Demo.Orders.Order.Add(LineItem).local").get();
+        final Component component = model.copyOfComponent("Demo.Orders.Order.Add(LineItem).local").get();
         assertEquals(ORDER_PART1, component.sourceFile());
     }
 
     @Test
     public void methodParamAndLocalTypeReferencesResolve() {
-        assertEquals("Demo.Orders.LineItem", model.getComponent("Demo.Orders.Order.Add(LineItem).item").get()
+        assertEquals("Demo.Orders.LineItem", model.copyOfComponent("Demo.Orders.Order.Add(LineItem).item").get()
                 .references(OOPSourceModelConstants.TypeReferences.SIMPLE).get(0).invokedComponent());
-        assertEquals("Demo.Orders.LineItem", model.getComponent("Demo.Orders.Order.Add(LineItem).local").get()
+        assertEquals("Demo.Orders.LineItem", model.copyOfComponent("Demo.Orders.Order.Add(LineItem).local").get()
                 .references(OOPSourceModelConstants.TypeReferences.SIMPLE).get(0).invokedComponent());
     }
 }

--- a/src/test/java/com/hadi/test/csharp/CSharpSpotCheckReferencesAndCommentsTest.java
+++ b/src/test/java/com/hadi/test/csharp/CSharpSpotCheckReferencesAndCommentsTest.java
@@ -51,92 +51,92 @@ public class CSharpSpotCheckReferencesAndCommentsTest {
 
     @Test
     public void classCommentIsCaptured() {
-        assertTrue(model.getComponent("Demo.App.User").get().comment().contains("Main user aggregate"));
+        assertTrue(model.copyOfComponent("Demo.App.User").get().comment().contains("Main user aggregate"));
     }
 
     @Test
     public void methodCommentIsCaptured() {
-        assertTrue(model.getComponent("Demo.App.User.Repo").get().comment().contains("Persists data"));
+        assertTrue(model.copyOfComponent("Demo.App.User.Repo").get().comment().contains("Persists data"));
     }
 
     @Test
     public void propertyTypeReferenceResolvesThroughAliasUsing() {
-        assertEquals("Demo.Common.Repo", model.getComponent("Demo.App.User.Repo").get()
+        assertEquals("Demo.Common.Repo", model.copyOfComponent("Demo.App.User.Repo").get()
                 .references(OOPSourceModelConstants.TypeReferences.SIMPLE).get(0).invokedComponent());
     }
 
     @Test
     public void eventTypeReferenceResolvesToNestedDelegate() {
-        assertEquals("Demo.App.User.SavedHandler", model.getComponent("Demo.App.User.Saved").get()
+        assertEquals("Demo.App.User.SavedHandler", model.copyOfComponent("Demo.App.User.Saved").get()
                 .references(OOPSourceModelConstants.TypeReferences.SIMPLE).get(0).invokedComponent());
     }
 
     @Test
     public void constructorParamTypeReferenceResolves() {
-        assertEquals("Demo.Common.Repo", model.getComponent("Demo.App.User.User(Repo).repo").get()
+        assertEquals("Demo.Common.Repo", model.copyOfComponent("Demo.App.User.User(Repo).repo").get()
                 .references(OOPSourceModelConstants.TypeReferences.SIMPLE).get(0).invokedComponent());
     }
 
     @Test
     public void methodParamBuiltinTypeReferenceResolves() {
-        assertEquals("System.String", model.getComponent("Demo.App.User.Save(string).message").get()
+        assertEquals("System.String", model.copyOfComponent("Demo.App.User.Save(string).message").get()
                 .references(OOPSourceModelConstants.TypeReferences.SIMPLE).get(0).invokedComponent());
     }
 
     @Test
     public void localTypeReferenceResolves() {
-        assertEquals("Demo.Common.Helper", model.getComponent("Demo.App.User.Save(string).helper").get()
+        assertEquals("Demo.Common.Helper", model.copyOfComponent("Demo.App.User.Save(string).helper").get()
                 .references(OOPSourceModelConstants.TypeReferences.SIMPLE).get(0).invokedComponent());
     }
 
     @Test
     public void methodCapturesObjectCreationReference() {
-        assertTrue(model.getComponent("Demo.App.User.Save(string)").get()
+        assertTrue(model.copyOfComponent("Demo.App.User.Save(string)").get()
                 .references(OOPSourceModelConstants.TypeReferences.SIMPLE).stream()
                 .anyMatch(ref -> ref.invokedComponent().equals("Demo.Common.Helper")));
     }
 
     @Test
     public void delegateParamBuiltinTypeResolves() {
-        assertEquals("System.String", model.getComponent("Demo.App.User.SavedHandler.value").get()
+        assertEquals("System.String", model.copyOfComponent("Demo.App.User.SavedHandler.value").get()
                 .references(OOPSourceModelConstants.TypeReferences.SIMPLE).get(0).invokedComponent());
     }
 
     @Test
     public void constructorCapturesAssignedPropertyReference() {
-        assertTrue(model.getComponent("Demo.App.User.User(Repo)").get()
+        assertTrue(model.copyOfComponent("Demo.App.User.User(Repo)").get()
                 .references(OOPSourceModelConstants.TypeReferences.SIMPLE).stream()
                 .anyMatch(ref -> ref.invokedComponent().equals("Demo.App.User.Repo")));
     }
 
     @Test
     public void extensionReferenceResolves() {
-        assertTrue(model.getComponent("Demo.App.User").get()
+        assertTrue(model.copyOfComponent("Demo.App.User").get()
                 .references(OOPSourceModelConstants.TypeReferences.EXTENSION)
                 .contains(new TypeExtensionReference("Demo.App.Entity")));
     }
 
     @Test
     public void implementationReferenceResolves() {
-        assertTrue(model.getComponent("Demo.App.User").get()
+        assertTrue(model.copyOfComponent("Demo.App.User").get()
                 .references(OOPSourceModelConstants.TypeReferences.IMPLEMENTATION)
                 .contains(new TypeImplementationReference("Demo.App.IRunner")));
     }
 
     @Test
     public void methodCycloIncludesIfAndLoop() {
-        assertEquals(4, model.getComponent("Demo.App.User.Save(string)").get().cyclo());
+        assertEquals(4, model.copyOfComponent("Demo.App.User.Save(string)").get().cyclo());
     }
 
     @Test
     public void methodCodeFragmentIsCaptured() {
         assertEquals("public Helper Save(string message)",
-                model.getComponent("Demo.App.User.Save(string)").get().codeFragment());
+                model.copyOfComponent("Demo.App.User.Save(string)").get().codeFragment());
     }
 
     @Test
     public void capitalizedPropertyReceiverIsNotTreatedAsTypeReference() {
-        assertTrue(model.getComponent("Demo.App.User.User(Repo)").get()
+        assertTrue(model.copyOfComponent("Demo.App.User.User(Repo)").get()
                 .references(OOPSourceModelConstants.TypeReferences.SIMPLE).stream()
                 .noneMatch(ref -> ref.invokedComponent().equals("Repo")));
     }

--- a/src/test/java/com/hadi/test/csharp/CSharpTypeExtensionReferenceTest.java
+++ b/src/test/java/com/hadi/test/csharp/CSharpTypeExtensionReferenceTest.java
@@ -18,7 +18,7 @@ public class CSharpTypeExtensionReferenceTest {
                 new ProjectFile("/User.cs", "namespace Demo; public class User : BaseUser {}")
         ).model();
 
-        assertTrue(model.getComponent("Demo.User").get()
+        assertTrue(model.copyOfComponent("Demo.User").get()
                 .references(OOPSourceModelConstants.TypeReferences.EXTENSION)
                 .contains(new TypeExtensionReference("Demo.BaseUser")));
     }
@@ -30,7 +30,7 @@ public class CSharpTypeExtensionReferenceTest {
                 new ProjectFile("/User.cs", "namespace Demo; public class User : BaseUser {}")
         ).model();
 
-        assertEquals(1, model.getComponent("Demo.User").get()
+        assertEquals(1, model.copyOfComponent("Demo.User").get()
                 .references(OOPSourceModelConstants.TypeReferences.EXTENSION).size());
     }
 
@@ -41,7 +41,7 @@ public class CSharpTypeExtensionReferenceTest {
                 new ProjectFile("/User.cs", "namespace Demo; public class User { public class Admin : BaseUser {} }")
         ).model();
 
-        assertTrue(model.getComponent("Demo.User.Admin").get()
+        assertTrue(model.copyOfComponent("Demo.User.Admin").get()
                 .references(OOPSourceModelConstants.TypeReferences.EXTENSION)
                 .contains(new TypeExtensionReference("Demo.BaseUser")));
     }

--- a/src/test/java/com/hadi/test/csharp/CSharpTypeImplementationReferenceTest.java
+++ b/src/test/java/com/hadi/test/csharp/CSharpTypeImplementationReferenceTest.java
@@ -18,7 +18,7 @@ public class CSharpTypeImplementationReferenceTest {
                 new ProjectFile("/User.cs", "namespace Demo; public class User : IRunner {}")
         ).model();
 
-        assertTrue(model.getComponent("Demo.User").get()
+        assertTrue(model.copyOfComponent("Demo.User").get()
                 .references(OOPSourceModelConstants.TypeReferences.IMPLEMENTATION)
                 .contains(new TypeImplementationReference("Demo.IRunner")));
     }
@@ -31,10 +31,10 @@ public class CSharpTypeImplementationReferenceTest {
                 new ProjectFile("/User.cs", "namespace Demo; public class User : IRunner, IPersisted {}")
         ).model();
 
-        assertTrue(model.getComponent("Demo.User").get()
+        assertTrue(model.copyOfComponent("Demo.User").get()
                 .references(OOPSourceModelConstants.TypeReferences.IMPLEMENTATION)
                 .contains(new TypeImplementationReference("Demo.IRunner")));
-        assertTrue(model.getComponent("Demo.User").get()
+        assertTrue(model.copyOfComponent("Demo.User").get()
                 .references(OOPSourceModelConstants.TypeReferences.IMPLEMENTATION)
                 .contains(new TypeImplementationReference("Demo.IPersisted")));
     }
@@ -47,7 +47,7 @@ public class CSharpTypeImplementationReferenceTest {
                 new ProjectFile("/User.cs", "namespace Demo; public class User : IRunner, IPersisted {}")
         ).model();
 
-        assertEquals(2, model.getComponent("Demo.User").get()
+        assertEquals(2, model.copyOfComponent("Demo.User").get()
                 .references(OOPSourceModelConstants.TypeReferences.IMPLEMENTATION).size());
     }
 
@@ -58,7 +58,7 @@ public class CSharpTypeImplementationReferenceTest {
                 new ProjectFile("/User.cs", "namespace Demo; public class User { public class Admin : IRunner {} }")
         ).model();
 
-        assertTrue(model.getComponent("Demo.User.Admin").get()
+        assertTrue(model.copyOfComponent("Demo.User.Admin").get()
                 .references(OOPSourceModelConstants.TypeReferences.IMPLEMENTATION)
                 .contains(new TypeImplementationReference("Demo.IRunner")));
     }

--- a/src/test/java/com/hadi/test/java/AccessModifiersTest.java
+++ b/src/test/java/com/hadi/test/java/AccessModifiersTest.java
@@ -20,7 +20,7 @@ public class AccessModifiersTest {
         rawData.insertFile(new ProjectFile("/file2.java", code));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         OOPSourceCodeModel generatedSourceModel = parseService.result().model();
-        assertTrue(((String) generatedSourceModel.getComponent("Test").get().modifiers().toArray()[0])
+        assertTrue(((String) generatedSourceModel.copyOfComponent("Test").get().modifiers().toArray()[0])
                 .equalsIgnoreCase("public"));
     }
 
@@ -32,7 +32,7 @@ public class AccessModifiersTest {
         rawData.insertFile(new ProjectFile("/file2.java", code));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         OOPSourceCodeModel generatedSourceModel = parseService.result().model();
-        assertTrue(((String) generatedSourceModel.getComponent("Test").get().modifiers().toArray()[0])
+        assertTrue(((String) generatedSourceModel.copyOfComponent("Test").get().modifiers().toArray()[0])
                 .equalsIgnoreCase("public"));
     }
 
@@ -44,7 +44,7 @@ public class AccessModifiersTest {
         rawData.insertFile(new ProjectFile("/file2.java", code));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         OOPSourceCodeModel generatedSourceModel = parseService.result().model();
-        assertTrue(((String) generatedSourceModel.getComponent("Tester.Test").get().modifiers().toArray()[0])
+        assertTrue(((String) generatedSourceModel.copyOfComponent("Tester.Test").get().modifiers().toArray()[0])
                 .equalsIgnoreCase("private"));
     }
 
@@ -56,7 +56,7 @@ public class AccessModifiersTest {
         rawData.insertFile(new ProjectFile("/file2.java", code));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         OOPSourceCodeModel generatedSourceModel = parseService.result().model();
-        assertTrue(((String) generatedSourceModel.getComponent("Tester.Test.lolcakes()").get().modifiers().toArray()[0])
+        assertTrue(((String) generatedSourceModel.copyOfComponent("Tester.Test.lolcakes()").get().modifiers().toArray()[0])
                 .equalsIgnoreCase("static"));
     }
 
@@ -68,7 +68,7 @@ public class AccessModifiersTest {
         rawData.insertFile(new ProjectFile("/file2.java", code));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         OOPSourceCodeModel generatedSourceModel = parseService.result().model();
-        assertTrue(generatedSourceModel.getComponent("Tester.Test.test()").get().modifiers().isEmpty());
+        assertTrue(generatedSourceModel.copyOfComponent("Tester.Test.test()").get().modifiers().isEmpty());
     }
 
     @Test
@@ -79,7 +79,7 @@ public class AccessModifiersTest {
         rawData.insertFile(new ProjectFile("/file2.java", code));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         OOPSourceCodeModel generatedSourceModel = parseService.result().model();
-        assertTrue(((String) generatedSourceModel.getComponent("Tester.Test.lolcakes()").get().modifiers().toArray()[0])
+        assertTrue(((String) generatedSourceModel.copyOfComponent("Tester.Test.lolcakes()").get().modifiers().toArray()[0])
                 .equalsIgnoreCase("abstract"));
     }
 
@@ -91,9 +91,9 @@ public class AccessModifiersTest {
         rawData.insertFile(new ProjectFile("/file2.java", code));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         OOPSourceCodeModel generatedSourceModel = parseService.result().model();
-        assertTrue(((String) generatedSourceModel.getComponent("Test.fieldVar").get().modifiers().toArray()[0])
+        assertTrue(((String) generatedSourceModel.copyOfComponent("Test.fieldVar").get().modifiers().toArray()[0])
                 .equalsIgnoreCase("public"));
-        assertTrue(((String) generatedSourceModel.getComponent("Test.fieldVar").get().modifiers().toArray()[1])
+        assertTrue(((String) generatedSourceModel.copyOfComponent("Test.fieldVar").get().modifiers().toArray()[1])
                 .equalsIgnoreCase("static"));
     }
 
@@ -106,7 +106,7 @@ public class AccessModifiersTest {
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         OOPSourceCodeModel generatedSourceModel = parseService.result().model();
         assertTrue(
-                ((String) generatedSourceModel.getComponent("Test.Test(String).str").get().modifiers().toArray()[0])
+                ((String) generatedSourceModel.copyOfComponent("Test.Test(String).str").get().modifiers().toArray()[0])
                         .equalsIgnoreCase("final"));
     }
 
@@ -118,7 +118,7 @@ public class AccessModifiersTest {
         rawData.insertFile(new ProjectFile("/file2.java", code));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         OOPSourceCodeModel generatedSourceModel = parseService.result().model();
-        assertEquals(1, generatedSourceModel.getComponent("Test.Test().str").get().modifiers().size());
+        assertEquals(1, generatedSourceModel.copyOfComponent("Test.Test().str").get().modifiers().size());
     }
 
     @Test
@@ -130,6 +130,6 @@ public class AccessModifiersTest {
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         OOPSourceCodeModel generatedSourceModel = parseService.result().model();
         assertTrue(
-                generatedSourceModel.getComponent("Test.Test().str").get().modifiers().isEmpty());
+                generatedSourceModel.copyOfComponent("Test.Test().str").get().modifiers().isEmpty());
     }
 }

--- a/src/test/java/com/hadi/test/java/ChildComponentsTest.java
+++ b/src/test/java/com/hadi/test/java/ChildComponentsTest.java
@@ -25,7 +25,7 @@ public class ChildComponentsTest {
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         final OOPSourceCodeModel generatedSourceModel = parseService.result().model();
         assertEquals("Test.method()",
-                     generatedSourceModel.getComponent("Test").get().children().toArray()[0]);
+                     generatedSourceModel.copyOfComponent("Test").get().children().toArray()[0]);
     }
 
     @Test
@@ -36,7 +36,7 @@ public class ChildComponentsTest {
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         final OOPSourceCodeModel generatedSourceModel = parseService.result().model();
         assertEquals("Test.fieldVar",
-                     generatedSourceModel.getComponent("Test").get().children().toArray()[0]);
+                     generatedSourceModel.copyOfComponent("Test").get().children().toArray()[0]);
     }
 
     @Test
@@ -46,7 +46,7 @@ public class ChildComponentsTest {
         rawData.insertFile(new ProjectFile("/file2.java", code));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         final OOPSourceCodeModel generatedSourceModel = parseService.result().model();
-        assertFalse(generatedSourceModel.getComponent("Test.method().Tester").isPresent());
+        assertFalse(generatedSourceModel.copyOfComponent("Test.method().Tester").isPresent());
         assertEquals(2, generatedSourceModel.size());
     }
 
@@ -58,7 +58,7 @@ public class ChildComponentsTest {
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         final OOPSourceCodeModel generatedSourceModel = parseService.result().model();
         assertEquals("Test.method()",
-                     generatedSourceModel.getComponent("Test").get().children().toArray()[0]);
+                     generatedSourceModel.copyOfComponent("Test").get().children().toArray()[0]);
     }
 
     @Test
@@ -68,7 +68,7 @@ public class ChildComponentsTest {
         rawData.insertFile(new ProjectFile("/file2.java", code));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         final OOPSourceCodeModel generatedSourceModel = parseService.result().model();
-        assertEquals("Test.method(String).str", generatedSourceModel.getComponent("Test.method" +
+        assertEquals("Test.method(String).str", generatedSourceModel.copyOfComponent("Test.method" +
                                                                                       "(String)").get().children().toArray()[0]);
     }
 
@@ -80,7 +80,7 @@ public class ChildComponentsTest {
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         final OOPSourceCodeModel generatedSourceModel = parseService.result().model();
         assertEquals("Test.NEAR_TO_QUERY",
-                     generatedSourceModel.getComponent("Test").get().children().toArray()[0]);
+                     generatedSourceModel.copyOfComponent("Test").get().children().toArray()[0]);
     }
 
     @Test
@@ -91,7 +91,7 @@ public class ChildComponentsTest {
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         final OOPSourceCodeModel generatedSourceModel = parseService.result().model();
         assertEquals("TestA.TestB",
-                     generatedSourceModel.getComponent("TestA").get().children().toArray()[0]);
+                     generatedSourceModel.copyOfComponent("TestA").get().children().toArray()[0]);
     }
 
     @Test
@@ -102,7 +102,7 @@ public class ChildComponentsTest {
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         final OOPSourceCodeModel generatedSourceModel = parseService.result().model();
         assertEquals("TestA.TestB",
-                     generatedSourceModel.getComponent("TestA").get().children().toArray()[0]);
+                     generatedSourceModel.copyOfComponent("TestA").get().children().toArray()[0]);
     }
 
     @Test
@@ -112,9 +112,9 @@ public class ChildComponentsTest {
         rawData.insertFile(new ProjectFile("/file2.java", code));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         final OOPSourceCodeModel generatedSourceModel = parseService.result().model();
-        assertTrue(generatedSourceModel.getComponent("TestA").get().children().contains("TestA.A"));
-        assertTrue(generatedSourceModel.getComponent("TestA").get().children().contains("TestA.B"));
-        assertTrue(generatedSourceModel.getComponent("TestA").get().children().contains("TestA.C"));
+        assertTrue(generatedSourceModel.copyOfComponent("TestA").get().children().contains("TestA.A"));
+        assertTrue(generatedSourceModel.copyOfComponent("TestA").get().children().contains("TestA.B"));
+        assertTrue(generatedSourceModel.copyOfComponent("TestA").get().children().contains("TestA.C"));
     }
 
     @Test
@@ -126,7 +126,7 @@ public class ChildComponentsTest {
         rawData.insertFile(new ProjectFile("/src/main/org/ClassB.java", codeB));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         OOPSourceCodeModel generatedSourceModel = parseService.result().model();
-        assertEquals("com.Test", generatedSourceModel.getComponent("com.Test.fieldVar")
+        assertEquals("com.Test", generatedSourceModel.copyOfComponent("com.Test.fieldVar")
                                                      .get().parentUniqueName());
     }
 
@@ -137,11 +137,11 @@ public class ChildComponentsTest {
         rawData.insertFile(new ProjectFile("/file2.java", code));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         final OOPSourceCodeModel generatedSourceModel = parseService.result().model();
-        assertTrue(Arrays.asList(generatedSourceModel.getComponent("TestA").get().children()
+        assertTrue(Arrays.asList(generatedSourceModel.copyOfComponent("TestA").get().children()
                                                      .toArray()).contains("TestA.fieldVar"));
-        assertTrue(Arrays.asList(generatedSourceModel.getComponent("TestA").get().children()
+        assertTrue(Arrays.asList(generatedSourceModel.copyOfComponent("TestA").get().children()
                                                      .toArray()).contains("TestA.method()"));
-        assertTrue(Arrays.asList(generatedSourceModel.getComponent("TestA").get().children()
+        assertTrue(Arrays.asList(generatedSourceModel.copyOfComponent("TestA").get().children()
                                                      .toArray()).contains("TestA.TestB"));
     }
 }

--- a/src/test/java/com/hadi/test/java/CodeFragmentTest.java
+++ b/src/test/java/com/hadi/test/java/CodeFragmentTest.java
@@ -18,7 +18,7 @@ public class CodeFragmentTest {
         rawData.insertFile(new ProjectFile("/file2.java", code));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         OOPSourceCodeModel generatedSourceModel = parseService.result().model();
-        assertEquals("<List>", generatedSourceModel.getComponent("Test").get().codeFragment());
+        assertEquals("<List>", generatedSourceModel.copyOfComponent("Test").get().codeFragment());
     }
 
     @Test
@@ -29,7 +29,7 @@ public class CodeFragmentTest {
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         OOPSourceCodeModel generatedSourceModel = parseService.result().model();
         assertEquals("<T extends List>",
-                     generatedSourceModel.getComponent("Test").get().codeFragment());
+                     generatedSourceModel.copyOfComponent("Test").get().codeFragment());
     }
 
     @Test
@@ -39,10 +39,10 @@ public class CodeFragmentTest {
         rawData.insertFile(new ProjectFile("/file2.java", code));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         OOPSourceCodeModel generatedSourceModel = parseService.result().model();
-        assertEquals("fieldVar : List<Integer>", generatedSourceModel.getComponent("Test.fieldVar"
+        assertEquals("fieldVar : List<Integer>", generatedSourceModel.copyOfComponent("Test.fieldVar"
         ).get().codeFragment());
         assertEquals("x : List<Integer>",
-                     generatedSourceModel.getComponent("Test.x").get().codeFragment());
+                     generatedSourceModel.copyOfComponent("Test.x").get().codeFragment());
     }
 
     @Test
@@ -52,10 +52,10 @@ public class CodeFragmentTest {
         rawData.insertFile(new ProjectFile("/file2.java", code));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         OOPSourceCodeModel generatedSourceModel = parseService.result().model();
-        assertEquals("fieldVar : Map<String, List<String>>", generatedSourceModel.getComponent(
+        assertEquals("fieldVar : Map<String, List<String>>", generatedSourceModel.copyOfComponent(
             "Test.fieldVar").get().codeFragment());
         assertEquals("x : Map<String, List<String>>",
-                     generatedSourceModel.getComponent("Test.x").get().codeFragment());
+                     generatedSourceModel.copyOfComponent("Test.x").get().codeFragment());
     }
 
     @Test
@@ -65,7 +65,7 @@ public class CodeFragmentTest {
         rawData.insertFile(new ProjectFile("/file2.java", code));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         OOPSourceCodeModel generatedSourceModel = parseService.result().model();
-        assertEquals("sMethod() : Map<String, List<Integer>>", generatedSourceModel.getComponent(
+        assertEquals("sMethod() : Map<String, List<Integer>>", generatedSourceModel.copyOfComponent(
             "Test.sMethod()").get().codeFragment());
     }
 
@@ -76,7 +76,7 @@ public class CodeFragmentTest {
         rawData.insertFile(new ProjectFile("/file2.java", code));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         OOPSourceCodeModel generatedSourceModel = parseService.result().model();
-        assertEquals("sMethod() : Map<String, List<Integer>>", generatedSourceModel.getComponent(
+        assertEquals("sMethod() : Map<String, List<Integer>>", generatedSourceModel.copyOfComponent(
             "Test.sMethod()").get().codeFragment());
     }
 
@@ -87,8 +87,8 @@ public class CodeFragmentTest {
         rawData.insertFile(new ProjectFile("/file2.java", code));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         OOPSourceCodeModel generatedSourceModel = parseService.result().model();
-        System.out.println(generatedSourceModel.getComponent("Test.sMethod(String, int)").get().codeFragment());
+        System.out.println(generatedSourceModel.copyOfComponent("Test.sMethod(String, int)").get().codeFragment());
         assertEquals("sMethod(String, int) : Map<List<String>, String[]>",
-                     generatedSourceModel.getComponent("Test.sMethod(String, int)").get().codeFragment());
+                     generatedSourceModel.copyOfComponent("Test.sMethod(String, int)").get().codeFragment());
     }
 }

--- a/src/test/java/com/hadi/test/java/CommentsParsingTest.java
+++ b/src/test/java/com/hadi/test/java/CommentsParsingTest.java
@@ -21,7 +21,7 @@ public class CommentsParsingTest {
         final OOPSourceCodeModel generatedSourceModel = parseService.result().model();
         assertEquals("/**\n" +
                 " * A comment\n" +
-                " */\n", generatedSourceModel.getComponent("test.Test").get().comment());
+                " */\n", generatedSourceModel.copyOfComponent("test.Test").get().comment());
     }
 
     @Test
@@ -31,7 +31,7 @@ public class CommentsParsingTest {
         rawData.insertFile(new ProjectFile("/file2.java", code));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         final OOPSourceCodeModel generatedSourceModel = parseService.result().model();
-        assertEquals("", generatedSourceModel.getComponent("test.Test").get().comment());
+        assertEquals("", generatedSourceModel.copyOfComponent("test.Test").get().comment());
     }
 
     @Test
@@ -44,7 +44,7 @@ public class CommentsParsingTest {
         assertEquals("/**\n" +
                 " * A\n" +
                 " *  comment\n" +
-                " */\n", generatedSourceModel.getComponent("test.Test").get().comment());
+                " */\n", generatedSourceModel.copyOfComponent("test.Test").get().comment());
     }
 
     @Test
@@ -57,7 +57,7 @@ public class CommentsParsingTest {
         assertEquals("/**\n" +
                 " * A\n" +
                 " *  comment\n" +
-                " */\n", generatedSourceModel.getComponent("test.Test").get().comment());
+                " */\n", generatedSourceModel.copyOfComponent("test.Test").get().comment());
     }
 
     @Test
@@ -70,7 +70,7 @@ public class CommentsParsingTest {
         assertEquals("/**\n" +
                 " * A\n" +
                 " *  comment\n" +
-                " */\n", generatedSourceModel.getComponent("test.Test.Base").get().comment());
+                " */\n", generatedSourceModel.copyOfComponent("test.Test.Base").get().comment());
     }
 
     @Test
@@ -82,7 +82,7 @@ public class CommentsParsingTest {
         final OOPSourceCodeModel generatedSourceModel = parseService.result().model();
         assertEquals("/**\n" +
                 " * lolcakes\n" +
-                " */\n", generatedSourceModel.getComponent("Test.test()").get().comment());
+                " */\n", generatedSourceModel.copyOfComponent("Test.test()").get().comment());
     }
 
     @Test
@@ -94,7 +94,7 @@ public class CommentsParsingTest {
         final OOPSourceCodeModel generatedSourceModel = parseService.result().model();
         assertEquals("/**\n" +
                 " * lol cakes\n" +
-                " */\n", generatedSourceModel.getComponent("Test.test()").get().comment());
+                " */\n", generatedSourceModel.copyOfComponent("Test.test()").get().comment());
     }
 
     @Test
@@ -106,7 +106,7 @@ public class CommentsParsingTest {
         final OOPSourceCodeModel generatedSourceModel = parseService.result().model();
         assertEquals("/**\n" +
                 " * lolcakes\n" +
-                " */\n", generatedSourceModel.getComponent("Test.fieldVar").get().comment());
+                " */\n", generatedSourceModel.copyOfComponent("Test.fieldVar").get().comment());
     }
 
     @Test
@@ -118,6 +118,6 @@ public class CommentsParsingTest {
         final OOPSourceCodeModel generatedSourceModel = parseService.result().model();
         assertEquals("/**\n" +
                 " * lolcakes\n" +
-                " */\n", generatedSourceModel.getComponent("Test.aMethod(String).methodParam").get().comment());
+                " */\n", generatedSourceModel.copyOfComponent("Test.aMethod(String).methodParam").get().comment());
     }
 }

--- a/src/test/java/com/hadi/test/java/ComponentProjectFilePathTest.java
+++ b/src/test/java/com/hadi/test/java/ComponentProjectFilePathTest.java
@@ -54,50 +54,50 @@ public class ComponentProjectFilePathTest {
 
     @Test
     public void testClassAComponentHasCorrectSourceFilePath() {
-        final Component component = sourceCodeModel.getComponent(SOURCEFILE1PACKAGE + ".TestA").get();
+        final Component component = sourceCodeModel.copyOfComponent(SOURCEFILE1PACKAGE + ".TestA").get();
         assertEquals(SOURCEFILE1NAME, component.sourceFile());
     }
 
     @Test
     public void testClassAMethodAComponentHasCorrectSourceFilePath() {
-        final Component component = sourceCodeModel.getComponent(SOURCEFILE1PACKAGE + ".TestA.methodA()").get();
+        final Component component = sourceCodeModel.copyOfComponent(SOURCEFILE1PACKAGE + ".TestA.methodA()").get();
         assertEquals(SOURCEFILE1NAME, component.sourceFile());
     }
 
     @Test
     public void testAbstractClassBComponentHasCorrectSourceFilePath() {
-        final Component component = sourceCodeModel.getComponent(SOURCEFILE1PACKAGE + ".TestB").get();
+        final Component component = sourceCodeModel.copyOfComponent(SOURCEFILE1PACKAGE + ".TestB").get();
         assertEquals(SOURCEFILE1NAME, component.sourceFile());
     }
 
     @Test
     public void testAbstractClassBMethodBComponentHasCorrectSourceFilePath() {
-        final Component component = sourceCodeModel.getComponent(SOURCEFILE1PACKAGE
+        final Component component = sourceCodeModel.copyOfComponent(SOURCEFILE1PACKAGE
                 + ".TestB.methodB()").get();
         assertEquals(SOURCEFILE1NAME, component.sourceFile());
     }
 
     @Test
     public void testClassCComponentHasCorrectSourceFilePath() {
-        final Component component = sourceCodeModel.getComponent(SOURCEFILE2PACKAGE + ".TestC").get();
+        final Component component = sourceCodeModel.copyOfComponent(SOURCEFILE2PACKAGE + ".TestC").get();
         assertEquals(SOURCEFILE2NAME, component.sourceFile());
     }
 
     @Test
     public void testClassCMethodCComponentHasCorrectSourceFilePath() {
-        final Component component = sourceCodeModel.getComponent(SOURCEFILE2PACKAGE + ".TestC.methodC()").get();
+        final Component component = sourceCodeModel.copyOfComponent(SOURCEFILE2PACKAGE + ".TestC.methodC()").get();
         assertEquals(SOURCEFILE2NAME, component.sourceFile());
     }
 
     @Test
     public void testClassCAbstractClassDComponentHasCorrectSourceFilePath() {
-        final Component component = sourceCodeModel.getComponent(SOURCEFILE2PACKAGE + ".TestC.TestD").get();
+        final Component component = sourceCodeModel.copyOfComponent(SOURCEFILE2PACKAGE + ".TestC.TestD").get();
         assertEquals(SOURCEFILE2NAME, component.sourceFile());
     }
 
     @Test
     public void testClassCAbstractClassDMethodDComponentHasCorrectSourceFilePath() {
-        final Component component = sourceCodeModel.getComponent(SOURCEFILE2PACKAGE
+        final Component component = sourceCodeModel.copyOfComponent(SOURCEFILE2PACKAGE
                 + ".TestC.TestD.methodD()").get();
         assertEquals(SOURCEFILE2NAME, component.sourceFile());
     }

--- a/src/test/java/com/hadi/test/java/ComponentTypeTest.java
+++ b/src/test/java/com/hadi/test/java/ComponentTypeTest.java
@@ -107,7 +107,7 @@ public class ComponentTypeTest {
 
     @Test
     public final void testSampleJavaClassMethodParamComponentType() {
-        final Optional<Component> tmp = generatedSourceModel.getComponent(sampleJavaPackageName + "." + sampleJavaClassComponentName + "."
+        final Optional<Component> tmp = generatedSourceModel.copyOfComponent(sampleJavaPackageName + "." + sampleJavaClassComponentName + "."
                         + sampleJavaMethodComponentKeyName + "." + sampleJavaMethodParamComponentName);
         Assert.assertEquals(tmp.get().componentType().toString(),
                             sampleJavaMethodParamComponentNameType.toString());
@@ -115,7 +115,7 @@ public class ComponentTypeTest {
 
     @Test
     public final void testSampleJavaClassMethodParam2ComponentType() {
-        final Optional<Component> tmp = generatedSourceModel.getComponent(sampleJavaPackageName + "." + sampleJavaClassComponentName + "."
+        final Optional<Component> tmp = generatedSourceModel.copyOfComponent(sampleJavaPackageName + "." + sampleJavaClassComponentName + "."
                         + sampleJavaMethodComponentKeyName + "." + sampleJavaMethodParamComponent2Name);
         Assert.assertEquals(tmp.get().componentType().toString(),
                             sampleJavaMethodParamComponent2NameType.toString());
@@ -123,14 +123,14 @@ public class ComponentTypeTest {
 
     @Test
     public final void testSampleJavaClassConstructorComponentType() {
-        final Optional<Component> tmp = generatedSourceModel.getComponent(sampleJavaPackageName + "."
+        final Optional<Component> tmp = generatedSourceModel.copyOfComponent(sampleJavaPackageName + "."
                 + sampleJavaClassComponentName + "." + sampleJavaConstructorComponentKeyName);
         Assert.assertTrue(tmp.get().componentType().toString().equals(sampleJavaConstructorComponentType.toString()));
     }
 
     @Test
     public final void testSampleJavaClassMethodComponentType() {
-        final Optional<Component> tmp = generatedSourceModel.getComponent(sampleJavaPackageName + "."
+        final Optional<Component> tmp = generatedSourceModel.copyOfComponent(sampleJavaPackageName + "."
                 + sampleJavaClassComponentName + "." + sampleJavaMethodComponentKeyName);
         Assert.assertEquals(tmp.get().componentType().toString(),
                             sampleJavaMethodComponentType.toString());
@@ -138,7 +138,7 @@ public class ComponentTypeTest {
 
     @Test
     public final void testSampleJavaClassFieldComponentType() {
-        final Optional<Component> tmp = generatedSourceModel.getComponent(sampleJavaPackageName + "."
+        final Optional<Component> tmp = generatedSourceModel.copyOfComponent(sampleJavaPackageName + "."
                 + sampleJavaClassComponentName + "." + sampleJavaClassFieldComponentName);
         Assert.assertEquals(tmp.get().componentType().toString(),
                             sampleJavaClassFieldComponentType.toString());
@@ -146,14 +146,14 @@ public class ComponentTypeTest {
 
     @Test
     public final void testSampleJavaClassComponentType() {
-        final Optional<Component> tmp = generatedSourceModel.getComponent(sampleJavaPackageName + "." + sampleJavaClassComponentName);
+        final Optional<Component> tmp = generatedSourceModel.copyOfComponent(sampleJavaPackageName + "." + sampleJavaClassComponentName);
         Assert.assertEquals(tmp.get().componentType().toString(),
                             sampleJavaClassComponentType.toString());
     }
 
     @Test
     public final void testSampleJavaInterfaceMethodParamComponentType() {
-        final Optional<Component> tmp = generatedSourceModel.getComponent(sampleJavaPackageName + "." + sampleJavaClassComponentName + "."
+        final Optional<Component> tmp = generatedSourceModel.copyOfComponent(sampleJavaPackageName + "." + sampleJavaClassComponentName + "."
                         + sampleJavaInterfaceComponentName + "." + sampleJavaInterfaceMethodComponentKeyName + "."
                         + sampleJavaInterfaceMethodParamComponentName);
         Assert.assertEquals(tmp.get().componentType().toString(),
@@ -162,7 +162,7 @@ public class ComponentTypeTest {
 
     @Test
     public final void testSampleJavaInterfaceMethodComponentType() {
-        final Optional<Component> tmp = generatedSourceModel.getComponent(sampleJavaPackageName + "." + sampleJavaClassComponentName + "."
+        final Optional<Component> tmp = generatedSourceModel.copyOfComponent(sampleJavaPackageName + "." + sampleJavaClassComponentName + "."
                         + sampleJavaInterfaceComponentName + "." + sampleJavaInterfaceMethodComponentKeyName);
         Assert.assertEquals(tmp.get().componentType().toString(),
                             sampleJavaInterfaceMethodComponentType.toString());
@@ -170,7 +170,7 @@ public class ComponentTypeTest {
 
     @Test
     public final void testSampleJavaInterfaceComponentType() {
-        final Optional<Component> tmp = generatedSourceModel.getComponent(sampleJavaPackageName + "."
+        final Optional<Component> tmp = generatedSourceModel.copyOfComponent(sampleJavaPackageName + "."
                 + sampleJavaClassComponentName + "." + sampleJavaInterfaceComponentName);
         Assert.assertEquals(tmp.get().componentType().toString(),
                             sampleJavaInterfaceComponentType.toString());
@@ -178,7 +178,7 @@ public class ComponentTypeTest {
 
     @Test
     public final void testSampleJavaEnumClassComponentType() {
-        final Optional<Component> tmp = generatedSourceModel.getComponent(sampleJavaPackageName + "."
+        final Optional<Component> tmp = generatedSourceModel.copyOfComponent(sampleJavaPackageName + "."
                 + sampleJavaClassComponentName + "." + sampleJavaEnumComponent);
         Assert.assertEquals(tmp.get().componentType().toString(),
                             sampleJavaEnumComponentType.toString());
@@ -186,7 +186,7 @@ public class ComponentTypeTest {
 
     @Test
     public final void testSampleJavaEnumClassConstantComponentType() {
-        final Optional<Component> tmp = generatedSourceModel.getComponent(sampleJavaPackageName + "."
+        final Optional<Component> tmp = generatedSourceModel.copyOfComponent(sampleJavaPackageName + "."
                 + sampleJavaClassComponentName + "." + sampleJavaEnumComponent + "." + sampleJavaEnumClassConstant);
         Assert.assertEquals(tmp.get().componentType().toString(),
                             sampleJavaEnumClassConstantType.toString());
@@ -194,7 +194,7 @@ public class ComponentTypeTest {
 
     @Test
     public final void testSampleJavaEnumClassMethodComponentType() {
-        final Optional<Component> tmp = generatedSourceModel.getComponent(sampleJavaPackageName + "." + sampleJavaClassComponentName + "."
+        final Optional<Component> tmp = generatedSourceModel.copyOfComponent(sampleJavaPackageName + "." + sampleJavaClassComponentName + "."
                         + sampleJavaEnumComponent + "." + sampleJavaEnumClassConstructorKey);
         Assert.assertEquals(tmp.get().componentType().toString(),
                             sampleJavaEnumClassConstructorType.toString());
@@ -202,7 +202,7 @@ public class ComponentTypeTest {
 
     @Test
     public final void testSampleJavaEnumClassMethodParamComponentType() {
-        final Optional<Component> tmp = generatedSourceModel.getComponent(sampleJavaPackageName + "." + sampleJavaClassComponentName + "."
+        final Optional<Component> tmp = generatedSourceModel.copyOfComponent(sampleJavaPackageName + "." + sampleJavaClassComponentName + "."
                         + sampleJavaEnumComponent + "." + sampleJavaEnumClassConstructorKey + "."
                         + sampleJavaEnumMethodParam);
         Assert.assertEquals(tmp.get().componentType().toString(),

--- a/src/test/java/com/hadi/test/java/CycloTest.java
+++ b/src/test/java/com/hadi/test/java/CycloTest.java
@@ -34,7 +34,7 @@ public class CycloTest {
         rawData.insertFile(new ProjectFile("/file2.java", code));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         final OOPSourceCodeModel generatedSourceModel = parseService.result().model();
-        assertEquals(6, generatedSourceModel.getComponent("Test.Test()").get().cyclo());
+        assertEquals(6, generatedSourceModel.copyOfComponent("Test.Test()").get().cyclo());
     }
 
 
@@ -53,7 +53,7 @@ public class CycloTest {
         rawData.insertFile(new ProjectFile("/file2.java", code));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         final OOPSourceCodeModel generatedSourceModel = parseService.result().model();
-        assertEquals(3, generatedSourceModel.getComponent("Test.Test()").get().cyclo());
+        assertEquals(3, generatedSourceModel.copyOfComponent("Test.Test()").get().cyclo());
     }
 
     @Test
@@ -73,7 +73,7 @@ public class CycloTest {
         rawData.insertFile(new ProjectFile("/file2.java", code));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         final OOPSourceCodeModel generatedSourceModel = parseService.result().model();
-        assertEquals(6, generatedSourceModel.getComponent("test.aMethod()").get().cyclo());
+        assertEquals(6, generatedSourceModel.copyOfComponent("test.aMethod()").get().cyclo());
     }
 
     @Test
@@ -90,7 +90,7 @@ public class CycloTest {
         rawData.insertFile(new ProjectFile("/file2.java", code));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         final OOPSourceCodeModel generatedSourceModel = parseService.result().model();
-        assertEquals(2, generatedSourceModel.getComponent("test.aMethod()").get().cyclo());
+        assertEquals(2, generatedSourceModel.copyOfComponent("test.aMethod()").get().cyclo());
     }
 
 
@@ -103,7 +103,7 @@ public class CycloTest {
         rawData.insertFile(new ProjectFile("/file2.java", code));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         final OOPSourceCodeModel generatedSourceModel = parseService.result().model();
-        assertEquals(0, generatedSourceModel.getComponent("test.aMethod()").get().cyclo());
+        assertEquals(0, generatedSourceModel.copyOfComponent("test.aMethod()").get().cyclo());
     }
 
 
@@ -132,7 +132,7 @@ public class CycloTest {
         rawData.insertFile(new ProjectFile("/file2.java", code));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         final OOPSourceCodeModel generatedSourceModel = parseService.result().model();
-        assertEquals(5, generatedSourceModel.getComponent("test").get().cyclo());
+        assertEquals(5, generatedSourceModel.copyOfComponent("test").get().cyclo());
     }
 
     @Test
@@ -144,6 +144,6 @@ public class CycloTest {
         rawData.insertFile(new ProjectFile("/file2.java", code));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         final OOPSourceCodeModel generatedSourceModel = parseService.result().model();
-        assertEquals(0, generatedSourceModel.getComponent("test").get().cyclo());
+        assertEquals(0, generatedSourceModel.copyOfComponent("test").get().cyclo());
     }
 }

--- a/src/test/java/com/hadi/test/java/JavaConstructorAssignedFieldsTest.java
+++ b/src/test/java/com/hadi/test/java/JavaConstructorAssignedFieldsTest.java
@@ -26,17 +26,17 @@ public class JavaConstructorAssignedFieldsTest {
     @Test
     public void constructorAssignmentPreservesDeclaredField() {
         Assert.assertEquals(OOPSourceModelConstants.ComponentType.FIELD,
-                model.getComponent("Service.owner").orElseThrow().componentType());
+                model.copyOfComponent("Service.owner").orElseThrow().componentType());
     }
 
     @Test
     public void constructorLocalVariableIsNotModeledAsField() {
-        Assert.assertFalse(model.getComponent("Service.temporary").isPresent());
+        Assert.assertFalse(model.copyOfComponent("Service.temporary").isPresent());
     }
 
     @Test
     public void constructorParameterIsStillModeled() {
         Assert.assertEquals(OOPSourceModelConstants.ComponentType.CONSTRUCTOR_PARAMETER_COMPONENT,
-                model.getComponent("Service.Service(User).owner").orElseThrow().componentType());
+                model.copyOfComponent("Service.Service(User).owner").orElseThrow().componentType());
     }
 }

--- a/src/test/java/com/hadi/test/java/JavaRecordTest.java
+++ b/src/test/java/com/hadi/test/java/JavaRecordTest.java
@@ -145,7 +145,7 @@ public class JavaRecordTest {
     }
 
     private static Component component(final String uniqueName) {
-        return model.getComponent(uniqueName).orElseThrow(
+        return model.copyOfComponent(uniqueName).orElseThrow(
                 () -> new AssertionError("no component named " + uniqueName));
     }
 

--- a/src/test/java/com/hadi/test/java/JavaTypeResolutionScopeTest.java
+++ b/src/test/java/com/hadi/test/java/JavaTypeResolutionScopeTest.java
@@ -33,7 +33,7 @@ public class JavaTypeResolutionScopeTest {
     }
 
     private static Set<String> refs(final OOPSourceCodeModel model, final String component) {
-        final Component cmp = model.getComponent(component).orElseThrow(
+        final Component cmp = model.copyOfComponent(component).orElseThrow(
                 () -> new AssertionError("no component " + component + " in "
                         + model.components().map(Component::uniqueName).collect(Collectors.toList())));
         return cmp.references().stream().map(r -> r.invokedComponent()).collect(Collectors.toSet());

--- a/src/test/java/com/hadi/test/java/MethodCallReferenceTest.java
+++ b/src/test/java/com/hadi/test/java/MethodCallReferenceTest.java
@@ -19,7 +19,7 @@ public class MethodCallReferenceTest {
         final ProjectFiles rawData = new ProjectFiles();
         rawData.insertFile(new ProjectFile("/Test.java", code));
         final OOPSourceCodeModel generatedSourceModel = new ClarpseProject(rawData, Lang.JAVA).result().model();
-        assertTrue(generatedSourceModel.getComponent("Test.m()").get()
+        assertTrue(generatedSourceModel.copyOfComponent("Test.m()").get()
                 .references(TypeReferences.SIMPLE).contains(new SimpleTypeReference("java.util.List")));
     }
 }

--- a/src/test/java/com/hadi/test/java/ModuleAttributeTest.java
+++ b/src/test/java/com/hadi/test/java/ModuleAttributeTest.java
@@ -24,15 +24,15 @@ public class ModuleAttributeTest {
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         OOPSourceCodeModel generatedSourceModel = parseService.result().model();
 
-        final Component classCmp = generatedSourceModel.getComponent("com.clarity.test.SampleJavaClass").get();
+        final Component classCmp = generatedSourceModel.copyOfComponent("com.clarity.test.SampleJavaClass").get();
         Assert.assertEquals("SampleFile", classCmp.module());
 
         final Component fieldCmp = generatedSourceModel
-                .getComponent("com.clarity.test.SampleJavaClass.sampleClassField").get();
+                .copyOfComponent("com.clarity.test.SampleJavaClass.sampleClassField").get();
         Assert.assertEquals("SampleFile", fieldCmp.module());
 
         final Component methodCmp = generatedSourceModel
-                .getComponent("com.clarity.test.SampleJavaClass.method()").get();
+                .copyOfComponent("com.clarity.test.SampleJavaClass.method()").get();
         Assert.assertEquals("SampleFile", methodCmp.module());
     }
 }

--- a/src/test/java/com/hadi/test/java/MultiVariableDeclarationTest.java
+++ b/src/test/java/com/hadi/test/java/MultiVariableDeclarationTest.java
@@ -24,14 +24,14 @@ public class MultiVariableDeclarationTest {
         final SimpleTypeReference fooRef = new SimpleTypeReference("Foo");
         final SimpleTypeReference barRef = new SimpleTypeReference("Bar");
 
-        assertTrue(generatedSourceModel.getComponent("Test.m().a").get()
+        assertTrue(generatedSourceModel.copyOfComponent("Test.m().a").get()
                 .references(TypeReferences.SIMPLE).contains(fooRef));
-        assertFalse(generatedSourceModel.getComponent("Test.m().a").get()
+        assertFalse(generatedSourceModel.copyOfComponent("Test.m().a").get()
                 .references(TypeReferences.SIMPLE).contains(barRef));
 
-        assertTrue(generatedSourceModel.getComponent("Test.m().b").get()
+        assertTrue(generatedSourceModel.copyOfComponent("Test.m().b").get()
                 .references(TypeReferences.SIMPLE).contains(barRef));
-        assertFalse(generatedSourceModel.getComponent("Test.m().b").get()
+        assertFalse(generatedSourceModel.copyOfComponent("Test.m().b").get()
                 .references(TypeReferences.SIMPLE).contains(fooRef));
     }
 }

--- a/src/test/java/com/hadi/test/java/PackageAttributeTest.java
+++ b/src/test/java/com/hadi/test/java/PackageAttributeTest.java
@@ -23,7 +23,7 @@ public class PackageAttributeTest {
         rawData.insertFile(new ProjectFile("/file1.java", codeString));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         OOPSourceCodeModel generatedSourceModel = parseService.result().model();
-        final Component cmp = generatedSourceModel.getComponent("com.clarity.test.SampleJavaClass").get();
+        final Component cmp = generatedSourceModel.copyOfComponent("com.clarity.test.SampleJavaClass").get();
         Assert.assertTrue(cmp.pkg().path().equals(pkgName));
     }
 
@@ -36,7 +36,7 @@ public class PackageAttributeTest {
         rawData.insertFile(new ProjectFile("/file1.java", codeString));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         OOPSourceCodeModel generatedSourceModel = parseService.result().model();
-        final Component cmp = generatedSourceModel.getComponent("com.clarity.test.SampleJavaClass.sampleClassField").get();
+        final Component cmp = generatedSourceModel.copyOfComponent("com.clarity.test.SampleJavaClass.sampleClassField").get();
         Assert.assertTrue(cmp.pkg().path().equals(pkgName));
     }
 
@@ -49,7 +49,7 @@ public class PackageAttributeTest {
         rawData.insertFile(new ProjectFile("/file1.java", codeString));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         OOPSourceCodeModel generatedSourceModel = parseService.result().model();
-        final Component cmp = generatedSourceModel.getComponent("com.clarity.test.SampleJavaClass.method()").get();
+        final Component cmp = generatedSourceModel.copyOfComponent("com.clarity.test.SampleJavaClass.method()").get();
         Assert.assertTrue(cmp.pkg().name().equals(pkgName));
     }
 }

--- a/src/test/java/com/hadi/test/java/ReferenceClassificationTest.java
+++ b/src/test/java/com/hadi/test/java/ReferenceClassificationTest.java
@@ -21,8 +21,8 @@ public class ReferenceClassificationTest {
         rawData.insertFile(new ProjectFile("/Test.java", code));
         final OOPSourceCodeModel generatedSourceModel = new ClarpseProject(rawData, Lang.JAVA).result().model();
 
-        final Component ext = generatedSourceModel.getComponent("Test.ext").get();
-        final Component internal = generatedSourceModel.getComponent("Test.internal").get();
+        final Component ext = generatedSourceModel.copyOfComponent("Test.ext").get();
+        final Component internal = generatedSourceModel.copyOfComponent("Test.internal").get();
 
         final SimpleTypeReference listRef = new SimpleTypeReference("java.util.List");
         final SimpleTypeReference classBRef = new SimpleTypeReference("ClassB");

--- a/src/test/java/com/hadi/test/java/ReferenceInheritanceTest.java
+++ b/src/test/java/com/hadi/test/java/ReferenceInheritanceTest.java
@@ -23,7 +23,7 @@ public class ReferenceInheritanceTest {
         rawData.insertFile(new ProjectFile("/file2.java", code));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         final OOPSourceCodeModel generatedSourceModel = parseService.result().model();
-        assertEquals("java.lang.String", ((ComponentReference) generatedSourceModel.getComponent("Test").get().references().toArray()[0])
+        assertEquals("java.lang.String", ((ComponentReference) generatedSourceModel.copyOfComponent("Test").get().references().toArray()[0])
                 .invokedComponent());
     }
 
@@ -34,7 +34,7 @@ public class ReferenceInheritanceTest {
         rawData.insertFile(new ProjectFile("/Test.java", code));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         final OOPSourceCodeModel generatedSourceModel = parseService.result().model();
-        assertEquals("java.lang.String", ((ComponentReference) generatedSourceModel.getComponent("Test").get().references().toArray()[0])
+        assertEquals("java.lang.String", ((ComponentReference) generatedSourceModel.copyOfComponent("Test").get().references().toArray()[0])
                 .invokedComponent());
     }
 
@@ -45,7 +45,7 @@ public class ReferenceInheritanceTest {
         rawData.insertFile(new ProjectFile("/file2.java", code));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         final OOPSourceCodeModel generatedSourceModel = parseService.result().model();
-        assertEquals("java.lang.String", ((ComponentReference) generatedSourceModel.getComponent("Test").get().references().toArray()[0])
+        assertEquals("java.lang.String", ((ComponentReference) generatedSourceModel.copyOfComponent("Test").get().references().toArray()[0])
                 .invokedComponent());
     }
 
@@ -56,7 +56,7 @@ public class ReferenceInheritanceTest {
         rawData.insertFile(new ProjectFile("/file2.java", code));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         final OOPSourceCodeModel generatedSourceModel = parseService.result().model();
-        assertEquals("java.lang.String", ((ComponentReference) generatedSourceModel.getComponent("Test").get().references().toArray()[0])
+        assertEquals("java.lang.String", ((ComponentReference) generatedSourceModel.copyOfComponent("Test").get().references().toArray()[0])
                 .invokedComponent());
     }
 
@@ -67,7 +67,7 @@ public class ReferenceInheritanceTest {
         rawData.insertFile(new ProjectFile("/file2.java", code));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         final OOPSourceCodeModel generatedSourceModel = parseService.result().model();
-        assertEquals("java.lang.String", ((ComponentReference) generatedSourceModel.getComponent("Test").get().references().toArray()[0])
+        assertEquals("java.lang.String", ((ComponentReference) generatedSourceModel.copyOfComponent("Test").get().references().toArray()[0])
                 .invokedComponent());
     }
 
@@ -78,7 +78,7 @@ public class ReferenceInheritanceTest {
         rawData.insertFile(new ProjectFile("/file2.java", code));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         final OOPSourceCodeModel generatedSourceModel = parseService.result().model();
-        assertTrue(generatedSourceModel.getComponent("Test").get().references().isEmpty());
+        assertTrue(generatedSourceModel.copyOfComponent("Test").get().references().isEmpty());
     }
 
     @Test
@@ -88,7 +88,7 @@ public class ReferenceInheritanceTest {
         rawData.insertFile(new ProjectFile("/file2.java", code));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         final OOPSourceCodeModel generatedSourceModel = parseService.result().model();
-        assertEquals("java.lang.String", ((ComponentReference) generatedSourceModel.getComponent(
+        assertEquals("java.lang.String", ((ComponentReference) generatedSourceModel.copyOfComponent(
             "Test").get().references().toArray()[0])
             .invokedComponent());
     }
@@ -100,7 +100,7 @@ public class ReferenceInheritanceTest {
         rawData.insertFile(new ProjectFile("/file2.java", code));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         final OOPSourceCodeModel generatedSourceModel = parseService.result().model();
-        assertEquals("java.lang.String", ((ComponentReference) generatedSourceModel.getComponent("Test").get().references().toArray()[0])
+        assertEquals("java.lang.String", ((ComponentReference) generatedSourceModel.copyOfComponent("Test").get().references().toArray()[0])
                 .invokedComponent());
     }
 
@@ -111,7 +111,7 @@ public class ReferenceInheritanceTest {
         rawData.insertFile(new ProjectFile("/file2.java", code));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         final OOPSourceCodeModel generatedSourceModel = parseService.result().model();
-        assertEquals("java.lang.String", ((ComponentReference) generatedSourceModel.getComponent("Test").get().references().toArray()[0])
+        assertEquals("java.lang.String", ((ComponentReference) generatedSourceModel.copyOfComponent("Test").get().references().toArray()[0])
                 .invokedComponent());
     }
 
@@ -122,7 +122,7 @@ public class ReferenceInheritanceTest {
         rawData.insertFile(new ProjectFile("/file2.java", code));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         final OOPSourceCodeModel generatedSourceModel = parseService.result().model();
-        assertEquals("java.lang.String", ((ComponentReference) generatedSourceModel.getComponent("Test.aMethod()").get().references().toArray()[0])
+        assertEquals("java.lang.String", ((ComponentReference) generatedSourceModel.copyOfComponent("Test.aMethod()").get().references().toArray()[0])
                 .invokedComponent());
     }
 
@@ -133,7 +133,7 @@ public class ReferenceInheritanceTest {
         rawData.insertFile(new ProjectFile("/file2.java", code));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         final OOPSourceCodeModel generatedSourceModel = parseService.result().model();
-        assertEquals("java.lang.String", ((ComponentReference) generatedSourceModel.getComponent("Test.aMethod(String)")
+        assertEquals("java.lang.String", ((ComponentReference) generatedSourceModel.copyOfComponent("Test.aMethod(String)")
                 .get().references().toArray()[0]).invokedComponent());
     }
 }

--- a/src/test/java/com/hadi/test/java/SimpleTypeReferenceTest.java
+++ b/src/test/java/com/hadi/test/java/SimpleTypeReferenceTest.java
@@ -21,7 +21,7 @@ public class SimpleTypeReferenceTest {
         rawData.insertFile(new ProjectFile("/file2.java", code));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         OOPSourceCodeModel generatedSourceModel = parseService.result().model();
-        final ComponentReference invocation = (generatedSourceModel.getComponent("Test.fieldVar")
+        final ComponentReference invocation = (generatedSourceModel.copyOfComponent("Test.fieldVar")
                 .get().references(TypeReferences.SIMPLE).get(0));
         Assert.assertEquals("java.lang.String", invocation.invokedComponent());
     }
@@ -33,9 +33,9 @@ public class SimpleTypeReferenceTest {
         rawData.insertFile(new ProjectFile("/file2.java", code));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         OOPSourceCodeModel generatedSourceModel = parseService.result().model();
-        Assert.assertEquals(0, generatedSourceModel.getComponent("Test")
+        Assert.assertEquals(0, generatedSourceModel.copyOfComponent("Test")
                 .get().references().size());
-        Assert.assertEquals(0, generatedSourceModel.getComponent("Test.Test()")
+        Assert.assertEquals(0, generatedSourceModel.copyOfComponent("Test.Test()")
                 .get().references().size());
     }
 
@@ -49,7 +49,7 @@ public class SimpleTypeReferenceTest {
         rawData.insertFile(new ProjectFile("/src/main/org/ClassB.java", codeB));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         OOPSourceCodeModel generatedSourceModel = parseService.result().model();
-        final ComponentReference invocation = (generatedSourceModel.getComponent("com.Test" +
+        final ComponentReference invocation = (generatedSourceModel.copyOfComponent("com.Test" +
                 ".fieldVar")
                 .get().references(TypeReferences.SIMPLE).get(0));
         Assert.assertEquals("org.ClassB", invocation.invokedComponent());
@@ -62,7 +62,7 @@ public class SimpleTypeReferenceTest {
         rawData.insertFile(new ProjectFile("/file2.java", code));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         OOPSourceCodeModel generatedSourceModel = parseService.result().model();
-        Assert.assertEquals(1, generatedSourceModel.getComponent("Test.fieldVar")
+        Assert.assertEquals(1, generatedSourceModel.copyOfComponent("Test.fieldVar")
                 .get().references(TypeReferences.SIMPLE).size());
     }
 
@@ -77,7 +77,7 @@ public class SimpleTypeReferenceTest {
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         OOPSourceCodeModel generatedSourceModel = parseService.result().model();
         Assert.assertEquals(
-                1, generatedSourceModel.getComponent("Test.log").get().references(TypeReferences.SIMPLE).size());
+                1, generatedSourceModel.copyOfComponent("Test.log").get().references(TypeReferences.SIMPLE).size());
     }
 
     @Test
@@ -87,7 +87,7 @@ public class SimpleTypeReferenceTest {
         rawData.insertFile(new ProjectFile("/Test.java", code));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         OOPSourceCodeModel generatedSourceModel = parseService.result().model();
-        Assert.assertEquals("java.lang.String", generatedSourceModel.getComponent(
+        Assert.assertEquals("java.lang.String", generatedSourceModel.copyOfComponent(
                 "Test.method(String, int).s1").get().references(TypeReferences.SIMPLE).get(0).invokedComponent());
     }
 
@@ -98,7 +98,7 @@ public class SimpleTypeReferenceTest {
         rawData.insertFile(new ProjectFile("/Test.java", code));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         OOPSourceCodeModel generatedSourceModel = parseService.result().model();
-        Assert.assertEquals("java.lang.Exception", generatedSourceModel.getComponent(
+        Assert.assertEquals("java.lang.Exception", generatedSourceModel.copyOfComponent(
                 "Test.AMethod()").get().references(TypeReferences.SIMPLE).get(0).invokedComponent());
     }
 
@@ -109,9 +109,9 @@ public class SimpleTypeReferenceTest {
         rawData.insertFile(new ProjectFile("/file2.java", code));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         OOPSourceCodeModel generatedSourceModel = parseService.result().model();
-        Assert.assertEquals(1, generatedSourceModel.getComponent("Test.method(String, int).s1")
+        Assert.assertEquals(1, generatedSourceModel.copyOfComponent("Test.method(String, int).s1")
                 .get().references(TypeReferences.SIMPLE).size());
-        Assert.assertEquals(1, generatedSourceModel.getComponent("Test.method(String, int).s2")
+        Assert.assertEquals(1, generatedSourceModel.copyOfComponent("Test.method(String, int).s2")
                 .get().references(TypeReferences.SIMPLE).size());
     }
 
@@ -122,7 +122,7 @@ public class SimpleTypeReferenceTest {
         rawData.insertFile(new ProjectFile("/file2.java", code));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         OOPSourceCodeModel generatedSourceModel = parseService.result().model();
-        Assert.assertEquals("java.lang.String", generatedSourceModel.getComponent(
+        Assert.assertEquals("java.lang.String", generatedSourceModel.copyOfComponent(
                 "Test.method().s").get().references(TypeReferences.SIMPLE).get(0).invokedComponent());
     }
 
@@ -136,9 +136,9 @@ public class SimpleTypeReferenceTest {
         rawData.insertFile(new ProjectFile("/Cake.java", codeD));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         OOPSourceCodeModel generatedSourceModel = parseService.result().model();
-        Assert.assertEquals("Cake", generatedSourceModel.getComponent(
+        Assert.assertEquals("Cake", generatedSourceModel.copyOfComponent(
                 "Test.test()").get().references(TypeReferences.SIMPLE).get(0).invokedComponent());
-        Assert.assertEquals("Cake", generatedSourceModel.getComponent(
+        Assert.assertEquals("Cake", generatedSourceModel.copyOfComponent(
                 "Test.test()").get().references(TypeReferences.SIMPLE).get(0).invokedComponent());
     }
 
@@ -149,7 +149,7 @@ public class SimpleTypeReferenceTest {
         rawData.insertFile(new ProjectFile("/Test.java", code));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         OOPSourceCodeModel generatedSourceModel = parseService.result().model();
-        Assert.assertEquals("java.lang.String", generatedSourceModel.getComponent(
+        Assert.assertEquals("java.lang.String", generatedSourceModel.copyOfComponent(
                 "Test.method()").get().references(TypeReferences.SIMPLE).get(0).invokedComponent());
     }
 
@@ -160,7 +160,7 @@ public class SimpleTypeReferenceTest {
         rawData.insertFile(new ProjectFile("/file2.java", code));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         OOPSourceCodeModel generatedSourceModel = parseService.result().model();
-        Assert.assertEquals(1, generatedSourceModel.getComponent("Test.method().s")
+        Assert.assertEquals(1, generatedSourceModel.copyOfComponent("Test.method().s")
                 .get().references(TypeReferences.SIMPLE).size());
     }
 
@@ -178,9 +178,9 @@ public class SimpleTypeReferenceTest {
         final ArrayList<ProjectFiles> reqCons = new ArrayList<ProjectFiles>();
         reqCons.add(reqCon);
         final OOPSourceCodeModel codeModel = new ClarpseProject(reqCon, Lang.JAVA).result().model();
-        Assert.assertEquals(3, codeModel.getComponent("com.sample.ClassA.b").get()
+        Assert.assertEquals(3, codeModel.copyOfComponent("com.sample.ClassA.b").get()
                 .references().size());
-        Assert.assertEquals(3, codeModel.getComponent("com.sample.ClassA.c").get()
+        Assert.assertEquals(3, codeModel.copyOfComponent("com.sample.ClassA.c").get()
                 .references().size());
     }
 }

--- a/src/test/java/com/hadi/test/java/SmokeTest.java
+++ b/src/test/java/com/hadi/test/java/SmokeTest.java
@@ -30,19 +30,19 @@ public class SmokeTest {
 
     @Test
     public void spotCheckClassExtension() {
-        Assert.assertTrue(junit5Model.getComponent("org.junit.platform.engine.discovery" +
+        Assert.assertTrue(junit5Model.copyOfComponent("org.junit.platform.engine.discovery" +
                                                        ".ExcludeClassNameFilter").get().references(OOPSourceModelConstants.TypeReferences.EXTENSION).contains(new TypeExtensionReference("org.junit.platform.engine.discovery" + ".AbstractClassNameFilter")));
     }
 
     @Test
     public void spotCheckClassDocs() {
-        Assert.assertEquals("/**\n" + " * Register a concrete " + "implementation of this interface " + "with a\n" + " * {@link org.junit.platform" + ".launcher.core" + ".LauncherDiscoveryRequestBuilder} " + "or\n" + " * {@link Launcher} to be notified" + " of events that occur during test " + "discovery.\n" + " *\n" + " * <p>All methods in this " + "interface have empty " + "<em>default</em> implementations" + ".\n" + " * Concrete implementations may " + "therefore override one or more of " + "these methods\n" + " * to be notified of the selected " + "events.\n" + " *\n" + " * <p>JUnit provides default " + "implementations that are created " + "via the factory\n" + " * methods in\n" + " * {@link org.junit.platform" + ".launcher.listeners.discovery" + ".LauncherDiscoveryListeners}.\n" + " *\n" + " * <p>The methods declared in this" + " interface are called by the " + "{@link Launcher}\n" + " * created via the {@link org" + ".junit.platform.launcher.core" + ".LauncherFactory}\n" + " * during test discovery.\n" + " *\n" + " * @see org.junit.platform" + ".launcher.listeners.discovery" + ".LauncherDiscoveryListeners\n" + " * @see LauncherDiscoveryRequest" + "#getDiscoveryListener()\n" + " * @see org.junit.platform" + ".launcher.core.LauncherConfig" + ".Builder" + "#addLauncherDiscoveryListeners\n" + " * @since 1.6\n" + " */\n", junit5Model.getComponent("org.junit.platform.launcher" +
+        Assert.assertEquals("/**\n" + " * Register a concrete " + "implementation of this interface " + "with a\n" + " * {@link org.junit.platform" + ".launcher.core" + ".LauncherDiscoveryRequestBuilder} " + "or\n" + " * {@link Launcher} to be notified" + " of events that occur during test " + "discovery.\n" + " *\n" + " * <p>All methods in this " + "interface have empty " + "<em>default</em> implementations" + ".\n" + " * Concrete implementations may " + "therefore override one or more of " + "these methods\n" + " * to be notified of the selected " + "events.\n" + " *\n" + " * <p>JUnit provides default " + "implementations that are created " + "via the factory\n" + " * methods in\n" + " * {@link org.junit.platform" + ".launcher.listeners.discovery" + ".LauncherDiscoveryListeners}.\n" + " *\n" + " * <p>The methods declared in this" + " interface are called by the " + "{@link Launcher}\n" + " * created via the {@link org" + ".junit.platform.launcher.core" + ".LauncherFactory}\n" + " * during test discovery.\n" + " *\n" + " * @see org.junit.platform" + ".launcher.listeners.discovery" + ".LauncherDiscoveryListeners\n" + " * @see LauncherDiscoveryRequest" + "#getDiscoveryListener()\n" + " * @see org.junit.platform" + ".launcher.core.LauncherConfig" + ".Builder" + "#addLauncherDiscoveryListeners\n" + " * @since 1.6\n" + " */\n", junit5Model.copyOfComponent("org.junit.platform.launcher" +
                 ".LauncherDiscoveryListener").get().comment());
     }
 
     @Test
     public void spotCheckClassImplementation() {
-        Assert.assertTrue(junit5Model.getComponent("org.junit.platform.engine.discovery" +
+        Assert.assertTrue(junit5Model.copyOfComponent("org.junit.platform.engine.discovery" +
                                                        ".ExcludePackageNameFilter").get().references(OOPSourceModelConstants.TypeReferences.IMPLEMENTATION).contains(new TypeImplementationReference("org.junit.platform.engine.discovery" + ".PackageNameFilter")));
     }
 
@@ -54,12 +54,12 @@ public class SmokeTest {
 
     @Test
     public void spotCheckSingletonListOriginalClassTypeReference() {
-        Assert.assertTrue(junit5Model.getComponent("example.util.ListWriter").get().references(OOPSourceModelConstants.TypeReferences.SIMPLE).contains(new SimpleTypeReference("java.util.Collections")));
+        Assert.assertTrue(junit5Model.copyOfComponent("example.util.ListWriter").get().references(OOPSourceModelConstants.TypeReferences.SIMPLE).contains(new SimpleTypeReference("java.util.Collections")));
     }
 
     @Test
     public void spotCheckClarpseClassExtension() {
-        Assert.assertEquals("com.hadi.clarpse.reference" + ".ComponentReference", clarpseCodeModel.getComponent("com.hadi.clarpse.reference" +
+        Assert.assertEquals("com.hadi.clarpse.reference" + ".ComponentReference", clarpseCodeModel.copyOfComponent("com.hadi.clarpse.reference" +
                 ".SimpleTypeReference").get().references(OOPSourceModelConstants.TypeReferences.EXTENSION).get(0).invokedComponent());
     }
 
@@ -76,7 +76,7 @@ public class SmokeTest {
                 "java.util.LinkedHashSet",
                 "java.io.Serializable",
                 "java.util.ArrayList"
-        ), clarpseCodeModel.getComponent("com.hadi.clarpse.sourcemodel.Component").get().imports());
+        ), clarpseCodeModel.copyOfComponent("com.hadi.clarpse.sourcemodel.Component").get().imports());
     }
 
 

--- a/src/test/java/com/hadi/test/java/TypeExtensionReferenceTest.java
+++ b/src/test/java/com/hadi/test/java/TypeExtensionReferenceTest.java
@@ -24,7 +24,7 @@ public class TypeExtensionReferenceTest {
         rawData.insertFile(new ProjectFile("/com/ClassD.java", codeD));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         generatedSourceModel = parseService.result().model();
-        Assert.assertEquals("com.ClassD", ((ComponentReference) generatedSourceModel.getComponent("com.ClassA").get().references()
+        Assert.assertEquals("com.ClassD", ((ComponentReference) generatedSourceModel.copyOfComponent("com.ClassA").get().references()
                 .toArray()[0]).invokedComponent());
     }
 
@@ -38,7 +38,7 @@ public class TypeExtensionReferenceTest {
         rawData.insertFile(new ProjectFile("/com/ClassD.java", codeD));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         generatedSourceModel = parseService.result().model();
-        Assert.assertEquals(1, generatedSourceModel.getComponent("com.ClassA").get().references().size());
+        Assert.assertEquals(1, generatedSourceModel.copyOfComponent("com.ClassA").get().references().size());
     }
 
     @Test
@@ -51,10 +51,10 @@ public class TypeExtensionReferenceTest {
         rawData.insertFile(new ProjectFile("/com/ClassD.java", codeD));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         generatedSourceModel = parseService.result().model();
-        Assert.assertEquals("com.ClassD", ((ComponentReference) generatedSourceModel.getComponent("com.ClassA.ClassB")
+        Assert.assertEquals("com.ClassD", ((ComponentReference) generatedSourceModel.copyOfComponent("com.ClassA.ClassB")
                 .get().references().toArray()[0]).invokedComponent());
 
-        Assert.assertEquals(1, generatedSourceModel.getComponent("com.ClassA.ClassB").get().references().size());
+        Assert.assertEquals(1, generatedSourceModel.copyOfComponent("com.ClassA.ClassB").get().references().size());
     }
 
     @Test
@@ -67,6 +67,6 @@ public class TypeExtensionReferenceTest {
         rawData.insertFile(new ProjectFile("/com/ClassD.java", codeD));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         generatedSourceModel = parseService.result().model();
-        Assert.assertEquals(1, generatedSourceModel.getComponent("com.ClassA.ClassB").get().references().size());
+        Assert.assertEquals(1, generatedSourceModel.copyOfComponent("com.ClassA.ClassB").get().references().size());
     }
 }

--- a/src/test/java/com/hadi/test/java/TypeImplementationReferenceTest.java
+++ b/src/test/java/com/hadi/test/java/TypeImplementationReferenceTest.java
@@ -28,9 +28,9 @@ public class TypeImplementationReferenceTest {
         rawData.insertFile(new ProjectFile("/com/ClassD.java", codeD));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         generatedSourceModel = parseService.result().model();
-        assertEquals("com.ClassD", ((ComponentReference) generatedSourceModel.getComponent("com.ClassA").get().references()
+        assertEquals("com.ClassD", ((ComponentReference) generatedSourceModel.copyOfComponent("com.ClassA").get().references()
                 .toArray()[0]).invokedComponent());
-        assertEquals(1, generatedSourceModel.getComponent("com.ClassA").get().references().size());
+        assertEquals(1, generatedSourceModel.copyOfComponent("com.ClassA").get().references().size());
     }
 
     @Test
@@ -45,12 +45,12 @@ public class TypeImplementationReferenceTest {
         rawData.insertFile(new ProjectFile("/com/ClassE.java", codeE));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         generatedSourceModel = parseService.result().model();
-        assertTrue(generatedSourceModel.getComponent(
+        assertTrue(generatedSourceModel.copyOfComponent(
             "com.ClassA")
                                        .get().references(
                 TypeReferences.IMPLEMENTATION)
                                        .contains(new TypeImplementationReference("com.ClassD")));
-        assertTrue(generatedSourceModel.getComponent("com.ClassA")
+        assertTrue(generatedSourceModel.copyOfComponent("com.ClassA")
                                        .get().references(
                 TypeReferences.IMPLEMENTATION)
                                        .contains(
@@ -68,7 +68,7 @@ public class TypeImplementationReferenceTest {
         rawData.insertFile(new ProjectFile("/com/ClassD.java", codeD));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         generatedSourceModel = parseService.result().model();
-        assertEquals(1, generatedSourceModel.getComponent("com.ClassA").get().references().size());
+        assertEquals(1, generatedSourceModel.copyOfComponent("com.ClassA").get().references().size());
     }
 
     @Test
@@ -83,7 +83,7 @@ public class TypeImplementationReferenceTest {
         rawData.insertFile(new ProjectFile("/com/ClassE.java", codeE));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         generatedSourceModel = parseService.result().model();
-        assertEquals(2, generatedSourceModel.getComponent("com.ClassA").get().references().size());
+        assertEquals(2, generatedSourceModel.copyOfComponent("com.ClassA").get().references().size());
     }
 
     @Test
@@ -97,10 +97,10 @@ public class TypeImplementationReferenceTest {
         rawData.insertFile(new ProjectFile("/com/ClassD.java", codeD));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         generatedSourceModel = parseService.result().model();
-        assertEquals("com.ClassD", ((ComponentReference) generatedSourceModel.getComponent("com.ClassA.ClassB")
+        assertEquals("com.ClassD", ((ComponentReference) generatedSourceModel.copyOfComponent("com.ClassA.ClassB")
                 .get().references().toArray()[0]).invokedComponent());
 
-        assertEquals(1, generatedSourceModel.getComponent("com.ClassA.ClassB").get().references().size());
+        assertEquals(1, generatedSourceModel.copyOfComponent("com.ClassA.ClassB").get().references().size());
     }
 
     @Test
@@ -114,6 +114,6 @@ public class TypeImplementationReferenceTest {
         rawData.insertFile(new ProjectFile("/com/ClassD.java", codeD));
         final ClarpseProject parseService = new ClarpseProject(rawData, Lang.JAVA);
         generatedSourceModel = parseService.result().model();
-        assertEquals(1, generatedSourceModel.getComponent("com.ClassA.ClassB").get().references().size());
+        assertEquals(1, generatedSourceModel.copyOfComponent("com.ClassA.ClassB").get().references().size());
     }
 }

--- a/src/test/java/com/hadi/test/perf/CrossRevisionPoolCensus.java
+++ b/src/test/java/com/hadi/test/perf/CrossRevisionPoolCensus.java
@@ -1,0 +1,218 @@
+package com.hadi.test.perf;
+
+import com.hadi.clarpse.compiler.ClarpseProject;
+import com.hadi.clarpse.compiler.Lang;
+import com.hadi.clarpse.compiler.ProjectFile;
+import com.hadi.clarpse.compiler.ProjectFiles;
+import com.hadi.clarpse.sourcemodel.Component;
+import com.hadi.clarpse.sourcemodel.OOPSourceCodeModel;
+
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Stream;
+
+/**
+ * Measures how much of a two-revision analysis's string footprint is the same string held twice,
+ * once per revision.
+ *
+ * <p>This is the question a shared pool answers and a per-model pool cannot. A differential analysis
+ * parses the whole repository at base and at head and holds both models for its whole duration, and
+ * a pull request touching three files out of 452 leaves the two models naming almost entirely the
+ * same packages, types and members. Whether that is worth a map is a matter of measurement, so this
+ * reports the recoverable bytes both within one revision and across the pair.
+ *
+ * <p>Both revisions are the same source tree parsed twice, which is the honest worst case for a pool
+ * -- a real pull request differs slightly more -- and it is deterministic, which a checked-out pair
+ * of real revisions would not be.
+ *
+ * <p>Retained readings are used-heap after repeated collection, so they are approximate; the string
+ * counts beside them are exact.
+ */
+public final class CrossRevisionPoolCensus {
+
+    private static final double MEBIBYTE = 1024.0 * 1024.0;
+
+    private CrossRevisionPoolCensus() {
+    }
+
+    /**
+     * Parses the given trees twice and prints the census.
+     *
+     * @param args Source directories. Defaults to clarpse's own main sources.
+     * @throws Exception If a tree cannot be read or parsed.
+     */
+    public static void main(final String[] args) throws Exception {
+        List<String> roots = args.length == 0 ? List.of("src/main/java") : List.of(args);
+        OOPSourceCodeModel base = parse(roots);
+        OOPSourceCodeModel head = parse(roots);
+        System.out.printf(Locale.ROOT, "base=%d components, head=%d components%n",
+                base.size(), head.size());
+        System.out.printf(Locale.ROOT, "retained (both models reachable): %.1f MiB%n",
+                retainedMib(base, head));
+
+        List<String> baseStrings = strings(base);
+        List<String> headStrings = strings(head);
+        System.out.printf(Locale.ROOT, "%nstring mentions: base=%d head=%d%n",
+                baseStrings.size(), headStrings.size());
+
+        System.out.printf(Locale.ROOT, "within base:  %d objects -> %d values, recoverable %s%n",
+                objects(baseStrings), values(baseStrings),
+                mib(recoverable(baseStrings)));
+
+        List<String> both = new ArrayList<>(baseStrings);
+        both.addAll(headStrings);
+        long objectsBoth = objects(both);
+        long valuesBoth = values(both);
+        System.out.printf(Locale.ROOT, "base+head:    %d objects -> %d values, recoverable %s%n",
+                objectsBoth, valuesBoth, mib(recoverable(both)));
+
+        perField(base, head);
+
+        long withinEach = recoverable(baseStrings) + recoverable(headStrings);
+        long crossOnly = recoverable(both) - withinEach;
+        System.out.printf(Locale.ROOT,
+                "%nof which within a single revision: %s%nattributable to holding two revisions: %s%n",
+                mib(withinEach), mib(crossOnly));
+    }
+
+    /** Reports, per field, what a pool spanning both revisions would recover. */
+    private static void perField(final OOPSourceCodeModel base, final OOPSourceCodeModel head) {
+        java.util.Map<String, java.util.function.Function<Component, Stream<String>>> fields =
+                new java.util.LinkedHashMap<>();
+        fields.put("componentName", c -> Stream.of(c.componentName()));
+        fields.put("name", c -> Stream.of(c.name()));
+        fields.put("value", c -> Stream.of(c.value()));
+        fields.put("sourceFile", c -> Stream.of(c.sourceFile()));
+        fields.put("module", c -> Stream.of(c.module()));
+        fields.put("comment", c -> Stream.of(c.comment()));
+        fields.put("codeFragment", c -> Stream.of(c.codeFragment()));
+        fields.put("pkg (3 strings)", c -> c.pkg() == null ? Stream.of()
+                : Stream.of(c.pkg().name(), c.pkg().path(), c.pkg().ellipsisSeparatedPkgPath()));
+        fields.put("children", c -> c.children().stream());
+        fields.put("imports", c -> c.imports().stream());
+        fields.put("modifiers", c -> c.modifiers().stream());
+        fields.put("refs.invokedComponent", c -> c.references().stream()
+                .map(r -> r.invokedComponent()));
+
+        System.out.printf(Locale.ROOT, "%n%-24s %9s %9s %9s %9s %16s%n", "field",
+                "mentions", "objects", "values", "ratio", "recoverable");
+        System.out.println("-".repeat(82));
+        long total = 0;
+        for (var field : fields.entrySet()) {
+            List<String> all = new ArrayList<>();
+            Stream.concat(base.components(), head.components())
+                    .forEach(c -> field.getValue().apply(c).filter(x -> x != null).forEach(all::add));
+            long objects = objects(all);
+            long values = values(all);
+            long bytes = recoverable(all);
+            total += bytes;
+            System.out.printf(Locale.ROOT, "%-24s %9d %9d %9d %8.1fx %,10d bytes%n",
+                    field.getKey(), all.size(), objects, values,
+                    values == 0 ? 0 : (double) objects / values, bytes);
+        }
+        System.out.println("-".repeat(82));
+        System.out.printf(Locale.ROOT, "%-24s %49s %,10d bytes%n", "total", "", total);
+    }
+
+    private static List<String> strings(final OOPSourceCodeModel model) {
+        List<String> all = new ArrayList<>();
+        model.components().forEach(c -> {
+            add(all, c.componentName());
+            add(all, c.name());
+            add(all, c.value());
+            add(all, c.sourceFile());
+            add(all, c.module());
+            add(all, c.comment());
+            add(all, c.codeFragment());
+            if (c.pkg() != null) {
+                add(all, c.pkg().name());
+                add(all, c.pkg().path());
+                add(all, c.pkg().ellipsisSeparatedPkgPath());
+            }
+            c.children().forEach(s -> add(all, s));
+            c.imports().forEach(s -> add(all, s));
+            c.modifiers().forEach(s -> add(all, s));
+            c.references().forEach(r -> add(all, r.invokedComponent()));
+        });
+        return all;
+    }
+
+    private static void add(final List<String> all, final String s) {
+        if (s != null) {
+            all.add(s);
+        }
+    }
+
+    private static long objects(final List<String> all) {
+        Set<String> identities = Collections.newSetFromMap(new IdentityHashMap<>());
+        return all.stream().filter(identities::add).count();
+    }
+
+    private static long values(final List<String> all) {
+        return all.stream().distinct().count();
+    }
+
+    /** Bytes that would be freed by collapsing distinct objects onto distinct values. */
+    private static long recoverable(final List<String> all) {
+        Set<String> seenObjects = Collections.newSetFromMap(new IdentityHashMap<>());
+        Set<String> seenValues = new HashSet<>();
+        long bytes = 0;
+        for (String s : all) {
+            if (!seenObjects.add(s)) {
+                continue;
+            }
+            if (!seenValues.add(s)) {
+                bytes += 32 + ((s.length() + 7) / 8) * 8L;
+            }
+        }
+        return bytes;
+    }
+
+    private static String mib(final long bytes) {
+        return String.format(Locale.ROOT, "%,d bytes (%.2f MiB)", bytes, bytes / MEBIBYTE);
+    }
+
+    private static OOPSourceCodeModel parse(final List<String> roots) throws Exception {
+        ProjectFiles files = new ProjectFiles();
+        for (String root : roots) {
+            load(files, Path.of(root));
+        }
+        return new ClarpseProject(files, Lang.JAVA).result().model();
+    }
+
+    private static void load(final ProjectFiles files, final Path root) throws IOException {
+        try (Stream<Path> walk = Files.walk(root)) {
+            for (Path p : walk.filter(p -> p.toString().endsWith(".java")).sorted().toList()) {
+                files.insertFile(new ProjectFile("/" + root.relativize(p),
+                        Files.readString(p, StandardCharsets.UTF_8)));
+            }
+        }
+    }
+
+    private static double retainedMib(final Object... keep) {
+        for (int i = 0; i < 6; i++) {
+            System.gc();
+            try {
+                Thread.sleep(60);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException(e);
+            }
+        }
+        long used = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed();
+        if (keep.length == 0) {
+            throw new IllegalStateException("unreachable");
+        }
+        return used / MEBIBYTE;
+    }
+}

--- a/src/test/java/com/hadi/test/perf/StringDuplicationCensus.java
+++ b/src/test/java/com/hadi/test/perf/StringDuplicationCensus.java
@@ -1,0 +1,170 @@
+package com.hadi.test.perf;
+
+import com.hadi.clarpse.compiler.ClarpseProject;
+import com.hadi.clarpse.compiler.Lang;
+import com.hadi.clarpse.compiler.ProjectFile;
+import com.hadi.clarpse.compiler.ProjectFiles;
+import com.hadi.clarpse.sourcemodel.Component;
+import com.hadi.clarpse.sourcemodel.OOPSourceCodeModel;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+/**
+ * Counts, per field of {@link Component}, how many string instances a parsed model holds, how many
+ * distinct values those instances carry, and how many bytes the duplicates cost.
+ *
+ * <p>This exists because a string pool is only worth its own map entry where the values actually
+ * repeat, and which fields repeat is not obvious from reading the parser. A fully-qualified
+ * component name is unique by construction and pooling it can only lose; a package or a declared
+ * type name recurs on nearly every component. The census settles it per field rather than by
+ * argument.
+ *
+ * <p>Three columns are reported. <b>instances</b> counts distinct string <em>objects</em> by identity,
+ * which is what occupies the heap. <b>values</b> counts distinct string <em>contents</em>, which is
+ * what would survive pooling. <b>duplicate bytes</b> is the difference, charged at the JVM's
+ * shallow cost for a latin1 String -- a 16-byte header plus the byte array's 16-byte header and
+ * contents, rounded to 8. It undercounts, because it ignores the reference slots that stay either
+ * way, so treat it as a floor.
+ *
+ * <p>Run it against a real source tree: {@code StringDuplicationCensus <dir> [<dir>...]}. With no
+ * argument it censuses clarpse's own main sources.
+ */
+public final class StringDuplicationCensus {
+
+    private StringDuplicationCensus() {
+    }
+
+    /**
+     * Parses the given trees and prints the census.
+     *
+     * @param args Source directories to parse. Defaults to clarpse's own main sources.
+     * @throws Exception If a tree cannot be read or parsed.
+     */
+    public static void main(final String[] args) throws Exception {
+        List<String> roots = args.length == 0
+                ? List.of("src/main/java")
+                : List.of(args);
+        ProjectFiles files = new ProjectFiles();
+        int count = 0;
+        for (String root : roots) {
+            count += load(files, Path.of(root));
+        }
+        System.out.printf(Locale.ROOT, "parsed input: %d java files from %s%n", count, roots);
+
+        OOPSourceCodeModel model = new ClarpseProject(files, Lang.JAVA).result().model();
+        System.out.printf(Locale.ROOT, "model: %d components%n%n", model.size());
+        census(model);
+    }
+
+    private static int load(final ProjectFiles files, final Path root) throws IOException {
+        try (Stream<Path> walk = Files.walk(root)) {
+            List<Path> javaFiles = walk.filter(p -> p.toString().endsWith(".java")).sorted().toList();
+            for (Path p : javaFiles) {
+                files.insertFile(new ProjectFile("/" + root.relativize(p),
+                        Files.readString(p, StandardCharsets.UTF_8)));
+            }
+            return javaFiles.size();
+        }
+    }
+
+    private static void census(final OOPSourceCodeModel model) {
+        Map<String, Function<Component, Stream<String>>> fields = new LinkedHashMap<>();
+        fields.put("componentName", c -> Stream.of(c.componentName()));
+        fields.put("name", c -> Stream.of(c.name()));
+        fields.put("value", c -> Stream.of(c.value()));
+        fields.put("sourceFile", c -> Stream.of(c.sourceFile()));
+        fields.put("module", c -> Stream.of(c.module()));
+        fields.put("comment", c -> Stream.of(c.comment()));
+        fields.put("codeFragment", c -> Stream.of(c.codeFragment()));
+        fields.put("pkg.name", c -> Stream.of(c.pkg() == null ? null : c.pkg().name()));
+        fields.put("pkg.path", c -> Stream.of(c.pkg() == null ? null : c.pkg().path()));
+        fields.put("pkg.ellipsis", c -> Stream.of(
+                c.pkg() == null ? null : c.pkg().ellipsisSeparatedPkgPath()));
+        fields.put("children (elements)", c -> c.children().stream());
+        fields.put("imports (elements)", c -> c.imports().stream());
+        fields.put("modifiers (elements)", c -> c.modifiers().stream());
+        fields.put("refs.invokedComponent",
+                c -> c.references().stream().map(r -> r.invokedComponent()));
+
+        System.out.printf(Locale.ROOT, "%-24s %9s %10s %8s %9s %14s%n",
+                "field", "mentions", "instances", "values", "dup ratio", "dup bytes");
+        System.out.println("-".repeat(80));
+        long totalDup = 0;
+        for (Map.Entry<String, Function<Component, Stream<String>>> field : fields.entrySet()) {
+            List<String> all = new ArrayList<>();
+            model.components().forEach(c -> field.getValue().apply(c)
+                    .filter(s -> s != null)
+                    .forEach(all::add));
+            Set<String> identities = java.util.Collections.newSetFromMap(new IdentityHashMap<>());
+            long distinctObjects = all.stream().filter(identities::add).count();
+            long distinctValues = all.stream().distinct().count();
+            long dupBytes = 0;
+            Set<String> seenValues = new java.util.HashSet<>();
+            Set<String> seenObjects = java.util.Collections.newSetFromMap(new IdentityHashMap<>());
+            for (String s : all) {
+                if (!seenObjects.add(s)) {
+                    continue;
+                }
+                if (!seenValues.add(s)) {
+                    dupBytes += shallowBytes(s);
+                }
+            }
+            totalDup += dupBytes;
+            System.out.printf(Locale.ROOT, "%-24s %9d %10d %8d %8.1fx %,14d%n",
+                    field.getKey(), all.size(), distinctObjects, distinctValues,
+                    distinctValues == 0 ? 0 : (double) distinctObjects / distinctValues, dupBytes);
+        }
+        System.out.println("-".repeat(80));
+        System.out.printf(Locale.ROOT, "%-24s %49s%,14d%n", "recoverable total", "", totalDup);
+        System.out.printf(Locale.ROOT, "model retained: %,d bytes (%.1f MiB)%n",
+                retainedBytes(model), retainedBytes(model) / (1024.0 * 1024.0));
+        System.out.printf(Locale.ROOT, "%nPackage objects: %d instances, %d distinct values%n",
+                distinctPackageObjects(model), distinctPackageValues(model));
+    }
+
+    private static long retainedBytes(final OOPSourceCodeModel model) {
+        java.lang.management.MemoryMXBean memory = java.lang.management.ManagementFactory.getMemoryMXBean();
+        for (int i = 0; i < 6; i++) {
+            System.gc();
+            try {
+                Thread.sleep(60);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException(e);
+            }
+        }
+        long used = memory.getHeapMemoryUsage().getUsed();
+        if (model.size() < 0) {
+            throw new IllegalStateException("unreachable");
+        }
+        return used;
+    }
+
+    private static long shallowBytes(final String s) {
+        // 16-byte String header (compressed oops) + byte[] header 16 + contents, each rounded to 8.
+        long contents = ((s.length() + 7) / 8) * 8L;
+        return 16 + 16 + contents;
+    }
+
+    private static long distinctPackageObjects(final OOPSourceCodeModel model) {
+        Set<Object> identities = java.util.Collections.newSetFromMap(new IdentityHashMap<>());
+        model.components().map(Component::pkg).filter(p -> p != null).forEach(identities::add);
+        return identities.size();
+    }
+
+    private static long distinctPackageValues(final OOPSourceCodeModel model) {
+        return model.components().map(Component::pkg).filter(p -> p != null).distinct().count();
+    }
+}

--- a/src/test/java/com/hadi/test/python/PythonAccessModifiersTest.java
+++ b/src/test/java/com/hadi/test/python/PythonAccessModifiersTest.java
@@ -23,21 +23,21 @@ public class PythonAccessModifiersTest {
 
     @Test
     public void doubleUnderscoreMethodIsPrivate() {
-        Component method = model.getComponent(name("Service."
+        Component method = model.copyOfComponent(name("Service."
                 + PythonTestUtil.signature("__hidden", "str"))).orElseThrow();
         Assert.assertTrue(method.modifiers().contains("private"));
     }
 
     @Test
     public void singleUnderscoreMethodIsProtected() {
-        Component method = model.getComponent(name("Service."
+        Component method = model.copyOfComponent(name("Service."
                 + PythonTestUtil.signature("_helper", "str"))).orElseThrow();
         Assert.assertTrue(method.modifiers().contains("protected"));
     }
 
     @Test
     public void dunderMethodIsNotMarkedPrivate() {
-        Component method = model.getComponent(name("Service."
+        Component method = model.copyOfComponent(name("Service."
                 + PythonTestUtil.signature("__str__", "str"))).orElseThrow();
         Assert.assertFalse(method.modifiers().contains("private"));
         Assert.assertFalse(method.modifiers().contains("protected"));

--- a/src/test/java/com/hadi/test/python/PythonAliasImportTest.java
+++ b/src/test/java/com/hadi/test/python/PythonAliasImportTest.java
@@ -24,7 +24,7 @@ public class PythonAliasImportTest {
     @Test
     public void testAliasBaseResolvesInternal() {
         String childName = PythonTestUtil.uniqueName(PACKAGE_PATH, "child", "Child");
-        ComponentReference ref = model.getComponent(childName).orElseThrow()
+        ComponentReference ref = model.copyOfComponent(childName).orElseThrow()
                 .references(TypeReferences.EXTENSION).get(0);
         String baseName = PythonTestUtil.uniqueName(PACKAGE_PATH, "base", "Base");
         Assert.assertEquals(baseName, ref.invokedComponent());
@@ -33,7 +33,7 @@ public class PythonAliasImportTest {
     @Test
     public void testAliasFieldResolvesInternal() {
         String fieldName = PythonTestUtil.uniqueName(PACKAGE_PATH, "child", "Child.value");
-        ComponentReference ref = model.getComponent(fieldName).orElseThrow()
+        ComponentReference ref = model.copyOfComponent(fieldName).orElseThrow()
                 .references(TypeReferences.SIMPLE).get(0);
         String baseName = PythonTestUtil.uniqueName(PACKAGE_PATH, "base", "Base");
         Assert.assertEquals(baseName, ref.invokedComponent());

--- a/src/test/java/com/hadi/test/python/PythonBackslashImportTest.java
+++ b/src/test/java/com/hadi/test/python/PythonBackslashImportTest.java
@@ -24,14 +24,14 @@ public class PythonBackslashImportTest {
     @Test
     public void testBackslashImportPrimaryNameResolvesInternal() {
         String fieldName = PythonTestUtil.uniqueName("src", "service", "Service.main");
-        Component field = model.getComponent(fieldName).orElseThrow();
+        Component field = model.copyOfComponent(fieldName).orElseThrow();
         Assert.assertTrue(hasSimpleRef(field, PythonTestUtil.uniqueName("src", "types", "User")));
     }
 
     @Test
     public void testBackslashImportAliasNameResolvesInternal() {
         String fieldName = PythonTestUtil.uniqueName("src", "service", "Service.alt");
-        Component field = model.getComponent(fieldName).orElseThrow();
+        Component field = model.copyOfComponent(fieldName).orElseThrow();
         Assert.assertTrue(hasSimpleRef(field, PythonTestUtil.uniqueName("src", "types", "User")));
     }
 

--- a/src/test/java/com/hadi/test/python/PythonCodeFragmentTest.java
+++ b/src/test/java/com/hadi/test/python/PythonCodeFragmentTest.java
@@ -24,21 +24,21 @@ public class PythonCodeFragmentTest {
 
     @Test
     public void fieldCodeFragmentTest() {
-        Component field = model.getComponent(name("Service.owner")).orElseThrow();
+        Component field = model.copyOfComponent(name("Service.owner")).orElseThrow();
         Assert.assertEquals("owner : User", field.codeFragment());
     }
 
     @Test
     public void constructorCodeFragmentTest() {
         String ctorName = name("Service." + PythonTestUtil.signature("__init__", "None", "user: User"));
-        Component ctor = model.getComponent(ctorName).orElseThrow();
+        Component ctor = model.copyOfComponent(ctorName).orElseThrow();
         Assert.assertEquals("__init__(user: User) : None", ctor.codeFragment());
     }
 
     @Test
     public void methodCodeFragmentTest() {
         String methodName = name("Service." + PythonTestUtil.signature("update", "User", "user: User"));
-        Component method = model.getComponent(methodName).orElseThrow();
+        Component method = model.copyOfComponent(methodName).orElseThrow();
         Assert.assertEquals("update(user: User) : User", method.codeFragment());
     }
 
@@ -46,7 +46,7 @@ public class PythonCodeFragmentTest {
     public void methodParamCodeFragmentTest() {
         String methodSig = PythonTestUtil.signature("update", "User", "user: User");
         String paramName = name("Service." + methodSig + ".user");
-        Component param = model.getComponent(paramName).orElseThrow();
+        Component param = model.copyOfComponent(paramName).orElseThrow();
         Assert.assertEquals("User", param.codeFragment());
     }
 

--- a/src/test/java/com/hadi/test/python/PythonCommentsParsingTest.java
+++ b/src/test/java/com/hadi/test/python/PythonCommentsParsingTest.java
@@ -26,28 +26,28 @@ public class PythonCommentsParsingTest {
     @Test
     public void classLevelCommentIsCaptured() {
         String className = name("Test");
-        Component cmp = model.getComponent(className).orElseThrow();
+        Component cmp = model.copyOfComponent(className).orElseThrow();
         Assert.assertTrue(cmp.comment().contains("Class doc for Test."));
     }
 
     @Test
     public void classWithNoDocstringHasNoComment() {
         String className = name("NoComment");
-        Component cmp = model.getComponent(className).orElseThrow();
+        Component cmp = model.copyOfComponent(className).orElseThrow();
         Assert.assertEquals("", cmp.comment());
     }
 
     @Test
     public void methodLevelDocstringIsCaptured() {
         String methodName = name("Test." + PythonTestUtil.signature("test", "str", "method_param: str"));
-        Component cmp = model.getComponent(methodName).orElseThrow();
+        Component cmp = model.copyOfComponent(methodName).orElseThrow();
         Assert.assertTrue(cmp.comment().contains("method doc for test."));
     }
 
     @Test
     public void classmethodIsParsedAndSkipsClsParameter() {
         String methodName = name("Factory." + PythonTestUtil.signature("build", "None", "name: str"));
-        Component cmp = model.getComponent(methodName).orElseThrow();
+        Component cmp = model.copyOfComponent(methodName).orElseThrow();
         Assert.assertEquals(OOPSourceModelConstants.ComponentType.METHOD, cmp.componentType());
         Assert.assertTrue(cmp.comment().contains("classmethod doc for build."));
         Assert.assertFalse(cmp.codeFragment().contains("cls:"));

--- a/src/test/java/com/hadi/test/python/PythonComponentTypeTest.java
+++ b/src/test/java/com/hadi/test/python/PythonComponentTypeTest.java
@@ -27,66 +27,66 @@ public class PythonComponentTypeTest {
     @Test
     public void testClassComponentType() {
         Assert.assertEquals(OOPSourceModelConstants.ComponentType.CLASS,
-                model.getComponent(name("Service")).orElseThrow().componentType());
+                model.copyOfComponent(name("Service")).orElseThrow().componentType());
     }
 
     @Test
     public void testFieldComponentType() {
         Assert.assertEquals(OOPSourceModelConstants.ComponentType.FIELD,
-                model.getComponent(name("Service.owner")).orElseThrow().componentType());
+                model.copyOfComponent(name("Service.owner")).orElseThrow().componentType());
     }
 
     @Test
     public void testConstructorComponentType() {
         Assert.assertEquals(OOPSourceModelConstants.ComponentType.CONSTRUCTOR,
-                model.getComponent(name(ctorSignaturePath())).orElseThrow().componentType());
+                model.copyOfComponent(name(ctorSignaturePath())).orElseThrow().componentType());
     }
 
     @Test
     public void testConstructorParamComponentType() {
         Assert.assertEquals(OOPSourceModelConstants.ComponentType.CONSTRUCTOR_PARAMETER_COMPONENT,
-                model.getComponent(name(ctorSignaturePath() + ".user")).orElseThrow().componentType());
+                model.copyOfComponent(name(ctorSignaturePath() + ".user")).orElseThrow().componentType());
     }
 
     @Test
     public void testMethodComponentType() {
         Assert.assertEquals(OOPSourceModelConstants.ComponentType.METHOD,
-                model.getComponent(name(methodSignaturePath())).orElseThrow().componentType());
+                model.copyOfComponent(name(methodSignaturePath())).orElseThrow().componentType());
     }
 
     @Test
     public void testMethodParamComponentType() {
         Assert.assertEquals(OOPSourceModelConstants.ComponentType.METHOD_PARAMETER_COMPONENT,
-                model.getComponent(name(methodSignaturePath() + ".user")).orElseThrow().componentType());
+                model.copyOfComponent(name(methodSignaturePath() + ".user")).orElseThrow().componentType());
     }
 
     @Test
     public void testFunctionComponentType() {
         Assert.assertEquals(OOPSourceModelConstants.ComponentType.FUNCTION,
-                model.getComponent(name(functionSignature())).orElseThrow().componentType());
+                model.copyOfComponent(name(functionSignature())).orElseThrow().componentType());
     }
 
     @Test
     public void testFunctionParamComponentType() {
         Assert.assertEquals(OOPSourceModelConstants.ComponentType.METHOD_PARAMETER_COMPONENT,
-                model.getComponent(name(functionSignature() + ".user")).orElseThrow().componentType());
+                model.copyOfComponent(name(functionSignature() + ".user")).orElseThrow().componentType());
     }
 
     @Test
     public void testModuleFieldComponentType() {
         Assert.assertEquals(OOPSourceModelConstants.ComponentType.MODULE_FIELD,
-                model.getComponent(name("DEFAULT_USER")).orElseThrow().componentType());
+                model.copyOfComponent(name("DEFAULT_USER")).orElseThrow().componentType());
     }
 
     @Test
     public void testFunctionReturnReferenceResolvesInternal() {
-        Component function = model.getComponent(name(functionSignature())).orElseThrow();
+        Component function = model.copyOfComponent(name(functionSignature())).orElseThrow();
         Assert.assertTrue(hasSimpleRef(function, userTypeName()));
     }
 
     @Test
     public void testModuleFieldReferenceResolvesInternal() {
-        Component field = model.getComponent(name("DEFAULT_USER")).orElseThrow();
+        Component field = model.copyOfComponent(name("DEFAULT_USER")).orElseThrow();
         Assert.assertTrue(hasSimpleRef(field, userTypeName()));
     }
 

--- a/src/test/java/com/hadi/test/python/PythonConstructorAssignedFieldsTest.java
+++ b/src/test/java/com/hadi/test/python/PythonConstructorAssignedFieldsTest.java
@@ -25,14 +25,14 @@ public class PythonConstructorAssignedFieldsTest {
     @Test
     public void constructorAssignmentsAreModeledAsFields() {
         Assert.assertEquals(OOPSourceModelConstants.ComponentType.FIELD,
-                model.getComponent(name("Service.owner")).orElseThrow().componentType());
+                model.copyOfComponent(name("Service.owner")).orElseThrow().componentType());
         Assert.assertEquals(OOPSourceModelConstants.ComponentType.FIELD,
-                model.getComponent(name("Service.team")).orElseThrow().componentType());
+                model.copyOfComponent(name("Service.team")).orElseThrow().componentType());
     }
 
     @Test
     public void nonSelfLocalVariablesAreNotModeledAsFields() {
-        Assert.assertFalse(model.getComponent(name("Service.temporary")).isPresent());
+        Assert.assertFalse(model.copyOfComponent(name("Service.temporary")).isPresent());
     }
 
     @Test
@@ -46,7 +46,7 @@ public class PythonConstructorAssignedFieldsTest {
     @Test
     public void nestedClassConstructorAssignmentsAreModeledAsFields() {
         Assert.assertEquals(OOPSourceModelConstants.ComponentType.FIELD,
-                model.getComponent(name("Outer.Inner.inner_owner")).orElseThrow().componentType());
+                model.copyOfComponent(name("Outer.Inner.inner_owner")).orElseThrow().componentType());
     }
 
     /**
@@ -68,13 +68,13 @@ public class PythonConstructorAssignedFieldsTest {
     @Test
     public void annotatedAssignmentsAreStillModeledAsFields() {
         Assert.assertEquals(OOPSourceModelConstants.ComponentType.FIELD,
-                model.getComponent(name("Annotated.owner")).orElseThrow().componentType());
+                model.copyOfComponent(name("Annotated.owner")).orElseThrow().componentType());
         Assert.assertEquals(OOPSourceModelConstants.ComponentType.FIELD,
-                model.getComponent(name("Annotated.tag")).orElseThrow().componentType());
+                model.copyOfComponent(name("Annotated.tag")).orElseThrow().componentType());
     }
 
     private static boolean containsInvoked(final String fieldName, final String targetName) {
-        return model.getComponent(fieldName).orElseThrow().internalDependencies().stream()
+        return model.copyOfComponent(fieldName).orElseThrow().internalDependencies().stream()
                 .anyMatch(ref -> targetName.equals(ref.invokedComponent()));
     }
 

--- a/src/test/java/com/hadi/test/python/PythonCycloTest.java
+++ b/src/test/java/com/hadi/test/python/PythonCycloTest.java
@@ -23,19 +23,19 @@ public class PythonCycloTest {
     @Test
     public void constructorCycloIncludesBranchAndBooleanOperator() {
         String ctorName = name("Metrics." + PythonTestUtil.signature("__init__", "None", "value: int"));
-        Assert.assertEquals(3, model.getComponent(ctorName).orElseThrow().cyclo());
+        Assert.assertEquals(3, model.copyOfComponent(ctorName).orElseThrow().cyclo());
     }
 
     @Test
     public void methodCycloIncludesIfAndElif() {
         String methodName = name("Metrics." + PythonTestUtil.signature("evaluate", "int", "limit: int"));
-        Assert.assertEquals(3, model.getComponent(methodName).orElseThrow().cyclo());
+        Assert.assertEquals(3, model.copyOfComponent(methodName).orElseThrow().cyclo());
     }
 
     @Test
     public void functionCycloIncludesLoopAndBooleanOperator() {
         String functionName = name(PythonTestUtil.signature("compute", "int", "total: int"));
-        Assert.assertEquals(3, model.getComponent(functionName).orElseThrow().cyclo());
+        Assert.assertEquals(3, model.copyOfComponent(functionName).orElseThrow().cyclo());
     }
 
     private static String name(final String symbolPath) {

--- a/src/test/java/com/hadi/test/python/PythonExternalTypesTest.java
+++ b/src/test/java/com/hadi/test/python/PythonExternalTypesTest.java
@@ -23,7 +23,7 @@ public class PythonExternalTypesTest {
     @Test
     public void testExternalBaseLabel() {
         String userName = PythonTestUtil.uniqueName(PACKAGE_PATH, "models", "User");
-        ComponentReference ref = model.getComponent(userName).orElseThrow()
+        ComponentReference ref = model.copyOfComponent(userName).orElseThrow()
                 .references(TypeReferences.EXTENSION).get(0);
         Assert.assertEquals("pydantic.BaseModel", ref.invokedComponent());
     }
@@ -31,7 +31,7 @@ public class PythonExternalTypesTest {
     @Test
     public void testExternalFieldLabel() {
         String fieldName = PythonTestUtil.uniqueName(PACKAGE_PATH, "models", "User.id");
-        ComponentReference ref = model.getComponent(fieldName).orElseThrow()
+        ComponentReference ref = model.copyOfComponent(fieldName).orElseThrow()
                 .references(TypeReferences.SIMPLE).get(0);
         Assert.assertEquals("uuid.UUID", ref.invokedComponent());
     }

--- a/src/test/java/com/hadi/test/python/PythonGenericAnnotationTest.java
+++ b/src/test/java/com/hadi/test/python/PythonGenericAnnotationTest.java
@@ -24,28 +24,28 @@ public class PythonGenericAnnotationTest {
     @Test
     public void testOptionalAnnotationResolvesInternalType() {
         String fieldName = PythonTestUtil.uniqueName("src", "models", "Example.user");
-        Component field = model.getComponent(fieldName).orElseThrow();
+        Component field = model.copyOfComponent(fieldName).orElseThrow();
         Assert.assertTrue(hasSimpleRef(field, PythonTestUtil.uniqueName("src", "types", "User")));
     }
 
     @Test
     public void testListAnnotationResolvesInternalType() {
         String fieldName = PythonTestUtil.uniqueName("src", "models", "Example.users");
-        Component field = model.getComponent(fieldName).orElseThrow();
+        Component field = model.copyOfComponent(fieldName).orElseThrow();
         Assert.assertTrue(hasSimpleRef(field, PythonTestUtil.uniqueName("src", "types", "User")));
     }
 
     @Test
     public void testDictAnnotationResolvesInternalType() {
         String fieldName = PythonTestUtil.uniqueName("src", "models", "Example.mapping");
-        Component field = model.getComponent(fieldName).orElseThrow();
+        Component field = model.copyOfComponent(fieldName).orElseThrow();
         Assert.assertTrue(hasSimpleRef(field, PythonTestUtil.uniqueName("src", "types", "Group")));
     }
 
     @Test
     public void testRawGenericTypeStoredInCodeFragment() {
         String fieldName = PythonTestUtil.uniqueName("src", "models", "Example.mapping");
-        Component field = model.getComponent(fieldName).orElseThrow();
+        Component field = model.copyOfComponent(fieldName).orElseThrow();
         Assert.assertEquals("mapping : Dict[str, Group]", field.codeFragment());
     }
 

--- a/src/test/java/com/hadi/test/python/PythonInitModuleTest.java
+++ b/src/test/java/com/hadi/test/python/PythonInitModuleTest.java
@@ -30,7 +30,7 @@ public class PythonInitModuleTest {
     @Test
     public void testInitPyClassModuleAttribute() {
         String className = PythonTestUtil.uniqueName("src/pkg", "__init__", "Root");
-        Component component = model.getComponent(className).orElseThrow();
+        Component component = model.copyOfComponent(className).orElseThrow();
         Assert.assertEquals("__init__", component.module());
     }
 
@@ -49,7 +49,7 @@ public class PythonInitModuleTest {
     public void testClassInInitPyIsImportableFromThePackage() {
         String childName = PythonTestUtil.uniqueName("src/pkg", "child", "Child");
         String rootName = PythonTestUtil.uniqueName("src/pkg", "__init__", "Root");
-        Component child = model.getComponent(childName).orElseThrow();
+        Component child = model.copyOfComponent(childName).orElseThrow();
 
         Assert.assertFalse(child.references(TypeReferences.EXTENSION).isEmpty());
         ComponentReference ref = child.references(TypeReferences.EXTENSION).get(0);
@@ -62,7 +62,7 @@ public class PythonInitModuleTest {
     public void testFieldTypeFromInitPyResolvesToTheDeclaringClass() {
         String fieldName = PythonTestUtil.uniqueName("src/pkg", "holder", "Holder.root");
         String rootName = PythonTestUtil.uniqueName("src/pkg", "__init__", "Root");
-        Component field = model.getComponent(fieldName).orElseThrow();
+        Component field = model.copyOfComponent(fieldName).orElseThrow();
 
         Assert.assertTrue(containsInvokedName(field.internalDependencies(), rootName));
     }

--- a/src/test/java/com/hadi/test/python/PythonInternalInheritanceTest.java
+++ b/src/test/java/com/hadi/test/python/PythonInternalInheritanceTest.java
@@ -25,7 +25,7 @@ public class PythonInternalInheritanceTest {
     public void testChildExtendsBase() {
         String baseName = PythonTestUtil.uniqueName(PACKAGE_PATH, "base", "Base");
         String childName = PythonTestUtil.uniqueName(PACKAGE_PATH, "child", "Child");
-        ComponentReference ref = model.getComponent(childName).orElseThrow()
+        ComponentReference ref = model.copyOfComponent(childName).orElseThrow()
                 .references(TypeReferences.EXTENSION).get(0);
         Assert.assertEquals(new TypeExtensionReference(baseName), ref);
     }

--- a/src/test/java/com/hadi/test/python/PythonLiteralReturnTypeTest.java
+++ b/src/test/java/com/hadi/test/python/PythonLiteralReturnTypeTest.java
@@ -25,21 +25,21 @@ public class PythonLiteralReturnTypeTest {
     @Test
     public void literalStringReturnTypeIsNormalizedToStr() {
         String methodName = name("LiteralTypes." + PythonTestUtil.signature("text", "str"));
-        Component method = model.getComponent(methodName).orElseThrow();
+        Component method = model.copyOfComponent(methodName).orElseThrow();
         Assert.assertEquals("text() : str", method.codeFragment());
     }
 
     @Test
     public void literalIntegerReturnTypeIsNormalizedToInt() {
         String methodName = name("LiteralTypes." + PythonTestUtil.signature("count", "int"));
-        Component method = model.getComponent(methodName).orElseThrow();
+        Component method = model.copyOfComponent(methodName).orElseThrow();
         Assert.assertEquals("count() : int", method.codeFragment());
     }
 
     @Test
     public void literalBooleanReturnTypeIsNormalizedToBool() {
         String methodName = name("LiteralTypes." + PythonTestUtil.signature("flag", "bool"));
-        Component method = model.getComponent(methodName).orElseThrow();
+        Component method = model.copyOfComponent(methodName).orElseThrow();
         Assert.assertEquals("flag() : bool", method.codeFragment());
     }
 

--- a/src/test/java/com/hadi/test/python/PythonMethodBodyRefsTest.java
+++ b/src/test/java/com/hadi/test/python/PythonMethodBodyRefsTest.java
@@ -61,7 +61,7 @@ public class PythonMethodBodyRefsTest {
     }
 
     private static Component getMethod(String symbolPath) {
-        return model.getComponent(PythonTestUtil.uniqueName(PACKAGE_PATH, "service", symbolPath))
+        return model.copyOfComponent(PythonTestUtil.uniqueName(PACKAGE_PATH, "service", symbolPath))
                 .orElseThrow();
     }
 

--- a/src/test/java/com/hadi/test/python/PythonMethodComponentsTest.java
+++ b/src/test/java/com/hadi/test/python/PythonMethodComponentsTest.java
@@ -27,7 +27,7 @@ public class PythonMethodComponentsTest {
     @Test
     public void testFieldComponentTypeAndReference() {
         String fieldName = PythonTestUtil.uniqueName(PACKAGE_PATH, MODULE, "Service.owner");
-        Component field = model.getComponent(fieldName).orElseThrow();
+        Component field = model.copyOfComponent(fieldName).orElseThrow();
         Assert.assertEquals(OOPSourceModelConstants.ComponentType.FIELD, field.componentType());
         Assert.assertTrue(hasSimpleRef(field, userTypeName()));
     }
@@ -36,11 +36,11 @@ public class PythonMethodComponentsTest {
     public void testConstructorComponentTypeAndParamReference() {
         String ctorSignature = PythonTestUtil.signature("__init__", "None", "user: User");
         String ctorName = PythonTestUtil.uniqueName(PACKAGE_PATH, MODULE, "Service." + ctorSignature);
-        Component ctor = model.getComponent(ctorName).orElseThrow();
+        Component ctor = model.copyOfComponent(ctorName).orElseThrow();
         Assert.assertEquals(OOPSourceModelConstants.ComponentType.CONSTRUCTOR, ctor.componentType());
 
         String paramName = PythonTestUtil.uniqueName(PACKAGE_PATH, MODULE, "Service." + ctorSignature + ".user");
-        Component param = model.getComponent(paramName).orElseThrow();
+        Component param = model.copyOfComponent(paramName).orElseThrow();
         Assert.assertEquals(OOPSourceModelConstants.ComponentType.CONSTRUCTOR_PARAMETER_COMPONENT,
                 param.componentType());
         Assert.assertTrue(hasSimpleRef(param, userTypeName()));
@@ -50,12 +50,12 @@ public class PythonMethodComponentsTest {
     public void testMethodComponentTypeAndParamReference() {
         String methodSignature = PythonTestUtil.signature("update", "User", "user: User");
         String methodName = PythonTestUtil.uniqueName(PACKAGE_PATH, MODULE, "Service." + methodSignature);
-        Component method = model.getComponent(methodName).orElseThrow();
+        Component method = model.copyOfComponent(methodName).orElseThrow();
         Assert.assertEquals(OOPSourceModelConstants.ComponentType.METHOD, method.componentType());
         Assert.assertTrue(hasSimpleRef(method, userTypeName()));
 
         String paramName = PythonTestUtil.uniqueName(PACKAGE_PATH, MODULE, "Service." + methodSignature + ".user");
-        Component param = model.getComponent(paramName).orElseThrow();
+        Component param = model.copyOfComponent(paramName).orElseThrow();
         Assert.assertEquals(OOPSourceModelConstants.ComponentType.METHOD_PARAMETER_COMPONENT, param.componentType());
         Assert.assertTrue(hasSimpleRef(param, userTypeName()));
     }

--- a/src/test/java/com/hadi/test/python/PythonModuleAliasDottedTest.java
+++ b/src/test/java/com/hadi/test/python/PythonModuleAliasDottedTest.java
@@ -26,7 +26,7 @@ public class PythonModuleAliasDottedTest {
     @Test
     public void testModuleAliasDottedFieldResolvesInternal() {
         String fieldName = PythonTestUtil.uniqueName(PACKAGE_PATH, MODULE, "Service.current");
-        Component field = model.getComponent(fieldName).orElseThrow();
+        Component field = model.copyOfComponent(fieldName).orElseThrow();
         Assert.assertTrue(hasSimpleRef(field, userTypeName()));
     }
 
@@ -34,11 +34,11 @@ public class PythonModuleAliasDottedTest {
     public void testModuleAliasDottedMethodAndParamResolveInternal() {
         String signature = PythonTestUtil.signature("set_current", "model_types.User", "user: model_types.User");
         String methodName = PythonTestUtil.uniqueName(PACKAGE_PATH, MODULE, "Service." + signature);
-        Component method = model.getComponent(methodName).orElseThrow();
+        Component method = model.copyOfComponent(methodName).orElseThrow();
         Assert.assertTrue(hasSimpleRef(method, userTypeName()));
 
         String paramName = PythonTestUtil.uniqueName(PACKAGE_PATH, MODULE, "Service." + signature + ".user");
-        Component param = model.getComponent(paramName).orElseThrow();
+        Component param = model.copyOfComponent(paramName).orElseThrow();
         Assert.assertTrue(hasSimpleRef(param, userTypeName()));
     }
 

--- a/src/test/java/com/hadi/test/python/PythonModuleDeclarationsTest.java
+++ b/src/test/java/com/hadi/test/python/PythonModuleDeclarationsTest.java
@@ -27,7 +27,7 @@ public class PythonModuleDeclarationsTest {
     @Test
     public void testTopLevelFunctionEmitted() {
         String fnName = name(PythonTestUtil.signature("build", "LocalFoo", "foo: LocalFoo"));
-        Component fn = model.getComponent(fnName).orElseThrow();
+        Component fn = model.copyOfComponent(fnName).orElseThrow();
         Assert.assertEquals(OOPSourceModelConstants.ComponentType.FUNCTION, fn.componentType());
         Assert.assertEquals(MODULE, fn.module());
     }
@@ -35,7 +35,7 @@ public class PythonModuleDeclarationsTest {
     @Test
     public void testTopLevelFunctionInternalTypeReference() {
         String fnName = name(PythonTestUtil.signature("build", "LocalFoo", "foo: LocalFoo"));
-        Component fn = model.getComponent(fnName).orElseThrow();
+        Component fn = model.copyOfComponent(fnName).orElseThrow();
         String expected = PythonTestUtil.uniqueName(PACKAGE_PATH, "types", "Foo");
         Assert.assertTrue(hasSimpleRef(fn, expected));
     }
@@ -43,7 +43,7 @@ public class PythonModuleDeclarationsTest {
     @Test
     public void testTopLevelModuleFieldEmittedAndResolved() {
         String fieldName = name("DEFAULT_FOO");
-        Component field = model.getComponent(fieldName).orElseThrow();
+        Component field = model.copyOfComponent(fieldName).orElseThrow();
         Assert.assertEquals(OOPSourceModelConstants.ComponentType.MODULE_FIELD, field.componentType());
         Assert.assertEquals(MODULE, field.module());
         String expected = PythonTestUtil.uniqueName(PACKAGE_PATH, "types", "Foo");
@@ -53,14 +53,14 @@ public class PythonModuleDeclarationsTest {
     @Test
     public void testUnannotatedModuleFieldIsCaptured() {
         String fieldName = name("counter");
-        Component field = model.getComponent(fieldName).orElseThrow();
+        Component field = model.copyOfComponent(fieldName).orElseThrow();
         Assert.assertEquals(OOPSourceModelConstants.ComponentType.MODULE_FIELD, field.componentType());
     }
 
     @Test
     public void testExternalTypeLabelOnTopLevelFunction() {
         String fnName = name(PythonTestUtil.signature("parse_id", "UUID", "value: UUID"));
-        Component fn = model.getComponent(fnName).orElseThrow();
+        Component fn = model.copyOfComponent(fnName).orElseThrow();
         Assert.assertTrue(hasSimpleRef(fn, "uuid.UUID"));
     }
 

--- a/src/test/java/com/hadi/test/python/PythonMultilineImportTest.java
+++ b/src/test/java/com/hadi/test/python/PythonMultilineImportTest.java
@@ -25,7 +25,7 @@ public class PythonMultilineImportTest {
     @Test
     public void testMultilineBaseImportResolvesInternal() {
         String className = PythonTestUtil.uniqueName(PACKAGE_PATH, "models", "Example");
-        ComponentReference ref = model.getComponent(className).orElseThrow()
+        ComponentReference ref = model.copyOfComponent(className).orElseThrow()
                 .references(TypeReferences.EXTENSION).get(0);
         String fooName = PythonTestUtil.uniqueName(PACKAGE_PATH, "types", "Foo");
         Assert.assertEquals(fooName, ref.invokedComponent());
@@ -34,7 +34,7 @@ public class PythonMultilineImportTest {
     @Test
     public void testMultilineAliasImportResolvesInternal() {
         String fieldName = PythonTestUtil.uniqueName(PACKAGE_PATH, "models", "Example.second");
-        Component field = model.getComponent(fieldName).orElseThrow();
+        Component field = model.copyOfComponent(fieldName).orElseThrow();
         String barName = PythonTestUtil.uniqueName(PACKAGE_PATH, "types", "Bar");
         Assert.assertTrue(hasSimpleRef(field, barName));
     }

--- a/src/test/java/com/hadi/test/python/PythonNestedClassTest.java
+++ b/src/test/java/com/hadi/test/python/PythonNestedClassTest.java
@@ -25,23 +25,23 @@ public class PythonNestedClassTest {
     @Test
     public void testNestedClassComponentNames() {
         Assert.assertEquals(OOPSourceModelConstants.ComponentType.CLASS,
-                model.getComponent(name("Outer")).orElseThrow().componentType());
+                model.copyOfComponent(name("Outer")).orElseThrow().componentType());
         Assert.assertEquals(OOPSourceModelConstants.ComponentType.CLASS,
-                model.getComponent(name("Outer.Inner")).orElseThrow().componentType());
+                model.copyOfComponent(name("Outer.Inner")).orElseThrow().componentType());
         Assert.assertEquals(OOPSourceModelConstants.ComponentType.CLASS,
-                model.getComponent(name("Outer.Inner.Deep")).orElseThrow().componentType());
+                model.copyOfComponent(name("Outer.Inner.Deep")).orElseThrow().componentType());
     }
 
     @Test
     public void testNestedMethodNamesUseNestedClassPath() {
         Assert.assertEquals(OOPSourceModelConstants.ComponentType.METHOD,
-                model.getComponent(name("Outer." + PythonTestUtil.signature("top", "None")))
+                model.copyOfComponent(name("Outer." + PythonTestUtil.signature("top", "None")))
                         .orElseThrow().componentType());
         Assert.assertEquals(OOPSourceModelConstants.ComponentType.METHOD,
-                model.getComponent(name("Outer.Inner." + PythonTestUtil.signature("build", "None")))
+                model.copyOfComponent(name("Outer.Inner." + PythonTestUtil.signature("build", "None")))
                         .orElseThrow().componentType());
         Assert.assertEquals(OOPSourceModelConstants.ComponentType.METHOD,
-                model.getComponent(name("Outer.Inner.Deep." + PythonTestUtil.signature("ping", "int")))
+                model.copyOfComponent(name("Outer.Inner.Deep." + PythonTestUtil.signature("ping", "int")))
                         .orElseThrow().componentType());
     }
 
@@ -53,9 +53,9 @@ public class PythonNestedClassTest {
         String innerMethod = name("Outer.Inner." + PythonTestUtil.signature("build", "None"));
         String deepMethod = name("Outer.Inner.Deep." + PythonTestUtil.signature("ping", "int"));
 
-        Component outer = model.getComponent(outerName).orElseThrow();
-        Component inner = model.getComponent(innerName).orElseThrow();
-        Component deep = model.getComponent(deepName).orElseThrow();
+        Component outer = model.copyOfComponent(outerName).orElseThrow();
+        Component inner = model.copyOfComponent(innerName).orElseThrow();
+        Component deep = model.copyOfComponent(deepName).orElseThrow();
 
         Assert.assertTrue(outer.children().contains(innerName));
         Assert.assertEquals(outerName, inner.parentUniqueName());

--- a/src/test/java/com/hadi/test/python/PythonPyprojectExtraPathsTest.java
+++ b/src/test/java/com/hadi/test/python/PythonPyprojectExtraPathsTest.java
@@ -24,7 +24,7 @@ public class PythonPyprojectExtraPathsTest {
     @Test
     public void testMultilineExtraPathsResolveInternalType() {
         String fieldName = PythonTestUtil.uniqueName("src", "service", "Service.current");
-        Component field = model.getComponent(fieldName).orElseThrow();
+        Component field = model.copyOfComponent(fieldName).orElseThrow();
         String expectedUser = PythonTestUtil.uniqueName("libs/domain", "models", "User");
         Assert.assertTrue(hasSimpleRef(field, expectedUser));
     }

--- a/src/test/java/com/hadi/test/python/PythonPyrightConfigExtraPathsTest.java
+++ b/src/test/java/com/hadi/test/python/PythonPyrightConfigExtraPathsTest.java
@@ -24,7 +24,7 @@ public class PythonPyrightConfigExtraPathsTest {
     @Test
     public void testPyrightConfigExtraPathsResolveInternalType() {
         String fieldName = PythonTestUtil.uniqueName("src", "service", "Service.current");
-        Component field = model.getComponent(fieldName).orElseThrow();
+        Component field = model.copyOfComponent(fieldName).orElseThrow();
         String expectedUser = PythonTestUtil.uniqueName("libs/domain", "models", "User");
         Assert.assertTrue(hasSimpleRef(field, expectedUser));
     }

--- a/src/test/java/com/hadi/test/python/PythonReferenceClassificationTest.java
+++ b/src/test/java/com/hadi/test/python/PythonReferenceClassificationTest.java
@@ -25,7 +25,7 @@ public class PythonReferenceClassificationTest {
     @Test
     public void testClassExtensionReferenceIsInternal() {
         String childName = PythonTestUtil.uniqueName(PACKAGE_PATH, "models", "Child");
-        Component child = model.getComponent(childName).orElseThrow();
+        Component child = model.copyOfComponent(childName).orElseThrow();
         ComponentReference ref = child.references(TypeReferences.EXTENSION).get(0);
         Assert.assertFalse(ref.isExternal());
         Assert.assertTrue(containsInvokedName(child.internalDependencies(),
@@ -35,7 +35,7 @@ public class PythonReferenceClassificationTest {
     @Test
     public void testExternalFieldReferenceIsExternal() {
         String fieldName = PythonTestUtil.uniqueName(PACKAGE_PATH, "models", "Child.id");
-        Component field = model.getComponent(fieldName).orElseThrow();
+        Component field = model.copyOfComponent(fieldName).orElseThrow();
         ComponentReference ref = field.references(TypeReferences.SIMPLE).get(0);
         Assert.assertTrue(ref.isExternal());
         Assert.assertTrue(containsInvokedName(field.externalDependencies(), "uuid.UUID"));
@@ -44,7 +44,7 @@ public class PythonReferenceClassificationTest {
     @Test
     public void testInternalFieldReferenceIsInternal() {
         String fieldName = PythonTestUtil.uniqueName(PACKAGE_PATH, "models", "Child.parent");
-        Component field = model.getComponent(fieldName).orElseThrow();
+        Component field = model.copyOfComponent(fieldName).orElseThrow();
         ComponentReference ref = field.references(TypeReferences.SIMPLE).get(0);
         Assert.assertFalse(ref.isExternal());
         Assert.assertTrue(containsInvokedName(field.internalDependencies(),
@@ -55,7 +55,7 @@ public class PythonReferenceClassificationTest {
     public void testFunctionReturnReferenceIsInternal() {
         String fnName = PythonTestUtil.uniqueName(PACKAGE_PATH, "models",
                 PythonTestUtil.signature("load", "Base", "value: UUID", "parent: Base"));
-        Component fn = model.getComponent(fnName).orElseThrow();
+        Component fn = model.copyOfComponent(fnName).orElseThrow();
         Assert.assertTrue(containsInvokedName(fn.internalDependencies(),
                 PythonTestUtil.uniqueName(PACKAGE_PATH, "base", "Base")));
     }
@@ -64,7 +64,7 @@ public class PythonReferenceClassificationTest {
     public void testFunctionExternalParamReferenceIsExternal() {
         String fnParamName = PythonTestUtil.uniqueName(PACKAGE_PATH, "models",
                 PythonTestUtil.signature("load", "Base", "value: UUID", "parent: Base") + ".value");
-        Component param = model.getComponent(fnParamName).orElseThrow();
+        Component param = model.copyOfComponent(fnParamName).orElseThrow();
         Assert.assertTrue(containsInvokedName(param.externalDependencies(), "uuid.UUID"));
     }
 
@@ -72,7 +72,7 @@ public class PythonReferenceClassificationTest {
     public void testFunctionInternalParamReferenceIsInternal() {
         String fnParamName = PythonTestUtil.uniqueName(PACKAGE_PATH, "models",
                 PythonTestUtil.signature("load", "Base", "value: UUID", "parent: Base") + ".parent");
-        Component param = model.getComponent(fnParamName).orElseThrow();
+        Component param = model.copyOfComponent(fnParamName).orElseThrow();
         Assert.assertTrue(containsInvokedName(param.internalDependencies(),
                 PythonTestUtil.uniqueName(PACKAGE_PATH, "base", "Base")));
     }

--- a/src/test/java/com/hadi/test/python/PythonRelativeImportTest.java
+++ b/src/test/java/com/hadi/test/python/PythonRelativeImportTest.java
@@ -24,7 +24,7 @@ public class PythonRelativeImportTest {
     @Test
     public void testParentRelativeImportResolvesClassExtension() {
         String childName = PythonTestUtil.uniqueName("src/pkg/sub", "child", "Child");
-        ComponentReference ref = model.getComponent(childName).orElseThrow()
+        ComponentReference ref = model.copyOfComponent(childName).orElseThrow()
                 .references(TypeReferences.EXTENSION).get(0);
         String baseName = PythonTestUtil.uniqueName("src/pkg", "base", "Base");
         Assert.assertEquals(baseName, ref.invokedComponent());
@@ -33,7 +33,7 @@ public class PythonRelativeImportTest {
     @Test
     public void testParentRelativeImportResolvesFieldType() {
         String fieldName = PythonTestUtil.uniqueName("src/pkg/sub", "child", "Child.value");
-        Component field = model.getComponent(fieldName).orElseThrow();
+        Component field = model.copyOfComponent(fieldName).orElseThrow();
         String baseName = PythonTestUtil.uniqueName("src/pkg", "base", "Base");
         Assert.assertTrue(hasSimpleRef(field, baseName));
     }

--- a/src/test/java/com/hadi/test/python/PythonRelativeImportVariantsTest.java
+++ b/src/test/java/com/hadi/test/python/PythonRelativeImportVariantsTest.java
@@ -24,21 +24,21 @@ public class PythonRelativeImportVariantsTest {
     @Test
     public void testFromDotImportModuleAliasResolvesInternal() {
         String fieldName = PythonTestUtil.uniqueName("src/pkg", "service", "Service.current");
-        Component field = model.getComponent(fieldName).orElseThrow();
+        Component field = model.copyOfComponent(fieldName).orElseThrow();
         Assert.assertTrue(hasSimpleRef(field, PythonTestUtil.uniqueName("src/pkg", "types", "User")));
     }
 
     @Test
     public void testFromParentImportModuleAliasResolvesInternal() {
         String fieldName = PythonTestUtil.uniqueName("src/pkg/sub", "handler", "Handler.first");
-        Component field = model.getComponent(fieldName).orElseThrow();
+        Component field = model.copyOfComponent(fieldName).orElseThrow();
         Assert.assertTrue(hasSimpleRef(field, PythonTestUtil.uniqueName("src/pkg", "types", "User")));
     }
 
     @Test
     public void testFromParentDirectSymbolImportResolvesInternal() {
         String fieldName = PythonTestUtil.uniqueName("src/pkg/sub", "handler", "Handler.second");
-        Component field = model.getComponent(fieldName).orElseThrow();
+        Component field = model.copyOfComponent(fieldName).orElseThrow();
         Assert.assertTrue(hasSimpleRef(field, PythonTestUtil.uniqueName("src/pkg", "types", "User")));
     }
 

--- a/src/test/java/com/hadi/test/python/PythonSourceFilePathTest.java
+++ b/src/test/java/com/hadi/test/python/PythonSourceFilePathTest.java
@@ -22,7 +22,7 @@ public class PythonSourceFilePathTest {
 
     @Test
     public void testClassSourceFilePath() {
-        Component component = model.getComponent(PythonTestUtil.uniqueName(PACKAGE_PATH, "sample", "Service"))
+        Component component = model.copyOfComponent(PythonTestUtil.uniqueName(PACKAGE_PATH, "sample", "Service"))
                 .orElseThrow();
         assertEndsWith(component.sourceFile(), "/src/sample.py");
     }
@@ -30,7 +30,7 @@ public class PythonSourceFilePathTest {
     @Test
     public void testMethodSourceFilePath() {
         String signature = PythonTestUtil.signature("update", "User", "user: User");
-        Component component = model.getComponent(PythonTestUtil.uniqueName(PACKAGE_PATH, "sample",
+        Component component = model.copyOfComponent(PythonTestUtil.uniqueName(PACKAGE_PATH, "sample",
                         "Service." + signature))
                 .orElseThrow();
         assertEndsWith(component.sourceFile(), "/src/sample.py");
@@ -38,21 +38,21 @@ public class PythonSourceFilePathTest {
 
     @Test
     public void testFieldSourceFilePath() {
-        Component component = model.getComponent(PythonTestUtil.uniqueName(PACKAGE_PATH, "sample", "Service.owner"))
+        Component component = model.copyOfComponent(PythonTestUtil.uniqueName(PACKAGE_PATH, "sample", "Service.owner"))
                 .orElseThrow();
         assertEndsWith(component.sourceFile(), "/src/sample.py");
     }
 
     @Test
     public void testModuleFieldSourceFilePath() {
-        Component component = model.getComponent(PythonTestUtil.uniqueName(PACKAGE_PATH, "sample", "DEFAULT_USER"))
+        Component component = model.copyOfComponent(PythonTestUtil.uniqueName(PACKAGE_PATH, "sample", "DEFAULT_USER"))
                 .orElseThrow();
         assertEndsWith(component.sourceFile(), "/src/sample.py");
     }
 
     @Test
     public void testImportedClassSourceFilePath() {
-        Component component = model.getComponent(PythonTestUtil.uniqueName(PACKAGE_PATH, "types", "User"))
+        Component component = model.copyOfComponent(PythonTestUtil.uniqueName(PACKAGE_PATH, "types", "User"))
                 .orElseThrow();
         assertEndsWith(component.sourceFile(), "/src/types.py");
     }

--- a/src/test/java/com/hadi/test/python/PythonSyntheticModulePackageAttributeTest.java
+++ b/src/test/java/com/hadi/test/python/PythonSyntheticModulePackageAttributeTest.java
@@ -24,35 +24,35 @@ public class PythonSyntheticModulePackageAttributeTest {
 
     @Test
     public void testModuleFieldHasCorrectPackagePath() {
-        Component cmp = model.getComponent(name("DEFAULT_FOO")).orElseThrow();
+        Component cmp = model.copyOfComponent(name("DEFAULT_FOO")).orElseThrow();
         Assert.assertEquals(OOPSourceModelConstants.ComponentType.MODULE_FIELD, cmp.componentType());
         Assert.assertEquals(PACKAGE_PATH, cmp.pkg().path());
     }
 
     @Test
     public void testModuleFieldHasCorrectPackageName() {
-        Component cmp = model.getComponent(name("DEFAULT_FOO")).orElseThrow();
+        Component cmp = model.copyOfComponent(name("DEFAULT_FOO")).orElseThrow();
         Assert.assertEquals(OOPSourceModelConstants.ComponentType.MODULE_FIELD, cmp.componentType());
         Assert.assertEquals(PACKAGE_PATH, cmp.pkg().name());
     }
 
     @Test
     public void testModuleFieldUnannotatedHasCorrectPackagePath() {
-        Component cmp = model.getComponent(name("counter")).orElseThrow();
+        Component cmp = model.copyOfComponent(name("counter")).orElseThrow();
         Assert.assertEquals(OOPSourceModelConstants.ComponentType.MODULE_FIELD, cmp.componentType());
         Assert.assertEquals(PACKAGE_PATH, cmp.pkg().path());
     }
 
     @Test
     public void testModuleFieldUnannotatedHasCorrectPackageName() {
-        Component cmp = model.getComponent(name("counter")).orElseThrow();
+        Component cmp = model.copyOfComponent(name("counter")).orElseThrow();
         Assert.assertEquals(OOPSourceModelConstants.ComponentType.MODULE_FIELD, cmp.componentType());
         Assert.assertEquals(PACKAGE_PATH, cmp.pkg().name());
     }
 
     @Test
     public void testModuleFunctionHasCorrectPackagePath() {
-        Component cmp = model.getComponent(name(PythonTestUtil.signature("build", "LocalFoo", "foo: LocalFoo")))
+        Component cmp = model.copyOfComponent(name(PythonTestUtil.signature("build", "LocalFoo", "foo: LocalFoo")))
                 .orElseThrow();
         Assert.assertEquals(OOPSourceModelConstants.ComponentType.FUNCTION, cmp.componentType());
         Assert.assertEquals(PACKAGE_PATH, cmp.pkg().path());
@@ -60,7 +60,7 @@ public class PythonSyntheticModulePackageAttributeTest {
 
     @Test
     public void testModuleFunctionHasCorrectPackageName() {
-        Component cmp = model.getComponent(name(PythonTestUtil.signature("build", "LocalFoo", "foo: LocalFoo")))
+        Component cmp = model.copyOfComponent(name(PythonTestUtil.signature("build", "LocalFoo", "foo: LocalFoo")))
                 .orElseThrow();
         Assert.assertEquals(OOPSourceModelConstants.ComponentType.FUNCTION, cmp.componentType());
         Assert.assertEquals(PACKAGE_PATH, cmp.pkg().name());
@@ -68,7 +68,7 @@ public class PythonSyntheticModulePackageAttributeTest {
 
     @Test
     public void testModuleFunctionExternalTypeHasCorrectPackagePath() {
-        Component cmp = model.getComponent(name(PythonTestUtil.signature("parse_id", "UUID", "value: UUID")))
+        Component cmp = model.copyOfComponent(name(PythonTestUtil.signature("parse_id", "UUID", "value: UUID")))
                 .orElseThrow();
         Assert.assertEquals(OOPSourceModelConstants.ComponentType.FUNCTION, cmp.componentType());
         Assert.assertEquals(PACKAGE_PATH, cmp.pkg().path());
@@ -76,7 +76,7 @@ public class PythonSyntheticModulePackageAttributeTest {
 
     @Test
     public void testModuleFunctionExternalTypeHasCorrectPackageName() {
-        Component cmp = model.getComponent(name(PythonTestUtil.signature("parse_id", "UUID", "value: UUID")))
+        Component cmp = model.copyOfComponent(name(PythonTestUtil.signature("parse_id", "UUID", "value: UUID")))
                 .orElseThrow();
         Assert.assertEquals(OOPSourceModelConstants.ComponentType.FUNCTION, cmp.componentType());
         Assert.assertEquals(PACKAGE_PATH, cmp.pkg().name());

--- a/src/test/java/com/hadi/test/python/PythonTypeCheckingImportTest.java
+++ b/src/test/java/com/hadi/test/python/PythonTypeCheckingImportTest.java
@@ -26,7 +26,7 @@ public class PythonTypeCheckingImportTest {
     @Test
     public void testTypeCheckingFieldResolvesInternal() {
         String fieldName = PythonTestUtil.uniqueName(PACKAGE_PATH, MODULE, "Service.user");
-        Component field = model.getComponent(fieldName).orElseThrow();
+        Component field = model.copyOfComponent(fieldName).orElseThrow();
         String userName = PythonTestUtil.uniqueName(PACKAGE_PATH, "types", "User");
         Assert.assertTrue(hasSimpleRef(field, userName));
     }
@@ -35,12 +35,12 @@ public class PythonTypeCheckingImportTest {
     public void testTypeCheckingMethodAndParamResolveInternal() {
         String signature = PythonTestUtil.signature("set_user", "User", "user: User");
         String methodName = PythonTestUtil.uniqueName(PACKAGE_PATH, MODULE, "Service." + signature);
-        Component method = model.getComponent(methodName).orElseThrow();
+        Component method = model.copyOfComponent(methodName).orElseThrow();
         String userName = PythonTestUtil.uniqueName(PACKAGE_PATH, "types", "User");
         Assert.assertTrue(hasSimpleRef(method, userName));
 
         String paramName = PythonTestUtil.uniqueName(PACKAGE_PATH, MODULE, "Service." + signature + ".user");
-        Component param = model.getComponent(paramName).orElseThrow();
+        Component param = model.copyOfComponent(paramName).orElseThrow();
         Assert.assertTrue(hasSimpleRef(param, userName));
     }
 

--- a/src/test/java/com/hadi/test/python/PythonTypeCheckingQualifiedTest.java
+++ b/src/test/java/com/hadi/test/python/PythonTypeCheckingQualifiedTest.java
@@ -24,7 +24,7 @@ public class PythonTypeCheckingQualifiedTest {
     @Test
     public void testQualifiedTypeCheckingImportResolvesInternal() {
         String fieldName = PythonTestUtil.uniqueName("src", "service", "Service.user");
-        Component field = model.getComponent(fieldName).orElseThrow();
+        Component field = model.copyOfComponent(fieldName).orElseThrow();
         String expectedUser = PythonTestUtil.uniqueName("src", "types", "User");
         Assert.assertTrue(hasSimpleRef(field, expectedUser));
     }

--- a/src/test/java/com/hadi/test/python/PythonTypePlaceholderReferenceTest.java
+++ b/src/test/java/com/hadi/test/python/PythonTypePlaceholderReferenceTest.java
@@ -90,7 +90,7 @@ public class PythonTypePlaceholderReferenceTest {
     }
 
     private static Component component(final String symbolPath) {
-        return model.getComponent(name(symbolPath)).orElseThrow(
+        return model.copyOfComponent(name(symbolPath)).orElseThrow(
                 () -> new AssertionError("no component named " + name(symbolPath)));
     }
 

--- a/src/test/java/com/hadi/test/python/PythonUnionSyntaxTest.java
+++ b/src/test/java/com/hadi/test/python/PythonUnionSyntaxTest.java
@@ -24,7 +24,7 @@ public class PythonUnionSyntaxTest {
     @Test
     public void testUnionTypeResolvesInternal() {
         String fieldName = PythonTestUtil.uniqueName(PACKAGE_PATH, "union", "Example.value");
-        ComponentReference ref = model.getComponent(fieldName).orElseThrow()
+        ComponentReference ref = model.copyOfComponent(fieldName).orElseThrow()
                 .references(TypeReferences.SIMPLE).get(0);
         String fooName = PythonTestUtil.uniqueName(PACKAGE_PATH, "types", "Foo");
         Assert.assertEquals(fooName, ref.invokedComponent());

--- a/src/test/java/com/hadi/test/sourcemodel/ComponentAccessorsTest.java
+++ b/src/test/java/com/hadi/test/sourcemodel/ComponentAccessorsTest.java
@@ -18,14 +18,14 @@ import static org.junit.Assert.assertTrue;
 
 /**
  * Pins the difference between the copying and the non-copying component accessors, in both
- * directions: that {@code getComponent} still isolates its caller, and that {@code liveComponent}
+ * directions: that {@code copyOfComponent} still isolates its caller, and that {@code component}
  * deliberately does not.
  *
  * <p>The isolation half matters more than the speed half. A caller that mutates what
- * {@code getComponent} hands it must go on being unable to reach the model, or this optimisation
+ * {@code copyOfComponent} hands it must go on being unable to reach the model, or this optimisation
  * becomes a class of mutation bug that no test would catch.
  */
-public class LiveComponentAccessTest {
+public class ComponentAccessorsTest {
 
     private static OOPSourceCodeModel modelWithOneClass() {
         OOPSourceCodeModel model = new OOPSourceCodeModel();
@@ -47,12 +47,12 @@ public class LiveComponentAccessTest {
     }
 
     @Test
-    public void getComponentStillHandsBackAnIsolatedCopy() {
+    public void copyOfComponentStillHandsBackAnIsolatedCopy() {
         OOPSourceCodeModel model = modelWithOneClass();
 
         Component first = model.copyOfComponent("app.Widget").orElseThrow();
         Component second = model.copyOfComponent("app.Widget").orElseThrow();
-        assertNotSame("getComponent must not hand out the model's own instance", first, second);
+        assertNotSame("copyOfComponent must not hand out the model's own instance", first, second);
 
         first.insertChildComponent("app.Widget.mutated");
         assertFalse("mutating a copy must not reach the model",
@@ -61,12 +61,12 @@ public class LiveComponentAccessTest {
     }
 
     @Test
-    public void liveComponentHandsBackTheModelsOwnInstance() {
+    public void componentHandsBackTheModelsOwnInstance() {
         OOPSourceCodeModel model = modelWithOneClass();
 
         Component first = model.component("app.Widget").orElseThrow();
         Component second = model.component("app.Widget").orElseThrow();
-        assertSame("liveComponent must not copy", first, second);
+        assertSame("component() must not copy", first, second);
 
         first.insertChildComponent("app.Widget.added");
         assertTrue("mutating a live component must reach the model",
@@ -75,13 +75,13 @@ public class LiveComponentAccessTest {
     }
 
     @Test
-    public void liveComponentIsEmptyForAnAbsentName() {
+    public void componentIsEmptyForAnAbsentName() {
         assertTrue(modelWithOneClass().component("app.Missing").isEmpty());
         assertTrue(modelWithOneClass().copyOfComponent("app.Missing").isEmpty());
     }
 
     @Test
-    public void liveParentBaseCmpFindsTheSameComponentAsTheCopyingWalk() {
+    public void parentBaseComponentFindsTheSameComponentAsTheCopyingWalk() {
         OOPSourceCodeModel model = modelWithOneClass();
 
         Component live = model.parentBaseComponent("app.Widget.field");
@@ -96,7 +96,7 @@ public class LiveComponentAccessTest {
     }
 
     @Test
-    public void parentBaseCmpStillThrowsForAnUnrootedName() {
+    public void copyOfParentBaseComponentStillThrowsForAnUnrootedName() {
         OOPSourceCodeModel model = modelWithOneClass();
         assertThrows(IllegalArgumentException.class, () -> model.copyOfParentBaseComponent("nothing.Here"));
         assertThrows(IllegalArgumentException.class, () -> model.parentBaseComponent("nothing.Here"));

--- a/src/test/java/com/hadi/test/sourcemodel/LiveComponentAccessTest.java
+++ b/src/test/java/com/hadi/test/sourcemodel/LiveComponentAccessTest.java
@@ -50,13 +50,13 @@ public class LiveComponentAccessTest {
     public void getComponentStillHandsBackAnIsolatedCopy() {
         OOPSourceCodeModel model = modelWithOneClass();
 
-        Component first = model.getComponent("app.Widget").orElseThrow();
-        Component second = model.getComponent("app.Widget").orElseThrow();
+        Component first = model.copyOfComponent("app.Widget").orElseThrow();
+        Component second = model.copyOfComponent("app.Widget").orElseThrow();
         assertNotSame("getComponent must not hand out the model's own instance", first, second);
 
         first.insertChildComponent("app.Widget.mutated");
         assertFalse("mutating a copy must not reach the model",
-                model.getComponent("app.Widget").orElseThrow().children()
+                model.copyOfComponent("app.Widget").orElseThrow().children()
                         .contains("app.Widget.mutated"));
     }
 
@@ -64,48 +64,48 @@ public class LiveComponentAccessTest {
     public void liveComponentHandsBackTheModelsOwnInstance() {
         OOPSourceCodeModel model = modelWithOneClass();
 
-        Component first = model.liveComponent("app.Widget").orElseThrow();
-        Component second = model.liveComponent("app.Widget").orElseThrow();
+        Component first = model.component("app.Widget").orElseThrow();
+        Component second = model.component("app.Widget").orElseThrow();
         assertSame("liveComponent must not copy", first, second);
 
         first.insertChildComponent("app.Widget.added");
         assertTrue("mutating a live component must reach the model",
-                model.getComponent("app.Widget").orElseThrow().children()
+                model.copyOfComponent("app.Widget").orElseThrow().children()
                         .contains("app.Widget.added"));
     }
 
     @Test
     public void liveComponentIsEmptyForAnAbsentName() {
-        assertTrue(modelWithOneClass().liveComponent("app.Missing").isEmpty());
-        assertTrue(modelWithOneClass().getComponent("app.Missing").isEmpty());
+        assertTrue(modelWithOneClass().component("app.Missing").isEmpty());
+        assertTrue(modelWithOneClass().copyOfComponent("app.Missing").isEmpty());
     }
 
     @Test
     public void liveParentBaseCmpFindsTheSameComponentAsTheCopyingWalk() {
         OOPSourceCodeModel model = modelWithOneClass();
 
-        Component live = model.liveParentBaseCmp("app.Widget.field");
-        Component copied = model.parentBaseCmp("app.Widget.field");
+        Component live = model.parentBaseComponent("app.Widget.field");
+        Component copied = model.copyOfParentBaseComponent("app.Widget.field");
 
         assertEquals("app.Widget", live.uniqueName());
         assertEquals(copied.uniqueName(), live.uniqueName());
         assertSame("the live walk returns the model's own instance",
-                model.liveComponent("app.Widget").orElseThrow(), live);
+                model.component("app.Widget").orElseThrow(), live);
         assertNotSame("the copying walk still copies",
-                model.liveComponent("app.Widget").orElseThrow(), copied);
+                model.component("app.Widget").orElseThrow(), copied);
     }
 
     @Test
     public void parentBaseCmpStillThrowsForAnUnrootedName() {
         OOPSourceCodeModel model = modelWithOneClass();
-        assertThrows(IllegalArgumentException.class, () -> model.parentBaseCmp("nothing.Here"));
-        assertThrows(IllegalArgumentException.class, () -> model.liveParentBaseCmp("nothing.Here"));
+        assertThrows(IllegalArgumentException.class, () -> model.copyOfParentBaseComponent("nothing.Here"));
+        assertThrows(IllegalArgumentException.class, () -> model.parentBaseComponent("nothing.Here"));
     }
 
     @Test
     public void childrenIsAViewAndRefusesMutationThroughIt() {
         OOPSourceCodeModel model = modelWithOneClass();
-        Component live = model.liveComponent("app.Widget").orElseThrow();
+        Component live = model.component("app.Widget").orElseThrow();
 
         List<String> view = live.children();
         assertThrows(UnsupportedOperationException.class, () -> view.add("app.Widget.sneaked"));
@@ -118,7 +118,7 @@ public class LiveComponentAccessTest {
     @Test
     public void iteratingChildrenWhileInsertingFailsLoudly() {
         OOPSourceCodeModel model = modelWithOneClass();
-        Component live = model.liveComponent("app.Widget").orElseThrow();
+        Component live = model.component("app.Widget").orElseThrow();
 
         assertThrows(ConcurrentModificationException.class, () -> {
             for (String child : live.children()) {
@@ -130,7 +130,7 @@ public class LiveComponentAccessTest {
     @Test
     public void dependencyAndModifierAccessorsAreUnmodifiableViews() {
         OOPSourceCodeModel model = modelWithOneClass();
-        Component live = model.liveComponent("app.Widget").orElseThrow();
+        Component live = model.component("app.Widget").orElseThrow();
 
         assertThrows(UnsupportedOperationException.class, () -> live.imports().add("java.util.List"));
         assertThrows(UnsupportedOperationException.class, () -> live.modifiers().add("public"));

--- a/src/test/java/com/hadi/test/sourcemodel/LiveComponentAccessTest.java
+++ b/src/test/java/com/hadi/test/sourcemodel/LiveComponentAccessTest.java
@@ -1,0 +1,142 @@
+package com.hadi.test.sourcemodel;
+
+import com.hadi.clarpse.sourcemodel.Component;
+import com.hadi.clarpse.sourcemodel.OOPSourceCodeModel;
+import com.hadi.clarpse.sourcemodel.OOPSourceModelConstants.ComponentType;
+import com.hadi.clarpse.sourcemodel.Package;
+import org.junit.Test;
+
+import java.util.ConcurrentModificationException;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Pins the difference between the copying and the non-copying component accessors, in both
+ * directions: that {@code getComponent} still isolates its caller, and that {@code liveComponent}
+ * deliberately does not.
+ *
+ * <p>The isolation half matters more than the speed half. A caller that mutates what
+ * {@code getComponent} hands it must go on being unable to reach the model, or this optimisation
+ * becomes a class of mutation bug that no test would catch.
+ */
+public class LiveComponentAccessTest {
+
+    private static OOPSourceCodeModel modelWithOneClass() {
+        OOPSourceCodeModel model = new OOPSourceCodeModel();
+        Component cls = new Component();
+        cls.setComponentType(ComponentType.CLASS);
+        cls.setComponentName("Widget");
+        cls.setName("Widget");
+        cls.setPkg(new Package("app", "app"));
+        cls.insertChildComponent("app.Widget.field");
+        model.insertComponent(cls);
+
+        Component field = new Component();
+        field.setComponentType(ComponentType.FIELD);
+        field.setComponentName("Widget.field");
+        field.setName("field");
+        field.setPkg(new Package("app", "app"));
+        model.insertComponent(field);
+        return model;
+    }
+
+    @Test
+    public void getComponentStillHandsBackAnIsolatedCopy() {
+        OOPSourceCodeModel model = modelWithOneClass();
+
+        Component first = model.getComponent("app.Widget").orElseThrow();
+        Component second = model.getComponent("app.Widget").orElseThrow();
+        assertNotSame("getComponent must not hand out the model's own instance", first, second);
+
+        first.insertChildComponent("app.Widget.mutated");
+        assertFalse("mutating a copy must not reach the model",
+                model.getComponent("app.Widget").orElseThrow().children()
+                        .contains("app.Widget.mutated"));
+    }
+
+    @Test
+    public void liveComponentHandsBackTheModelsOwnInstance() {
+        OOPSourceCodeModel model = modelWithOneClass();
+
+        Component first = model.liveComponent("app.Widget").orElseThrow();
+        Component second = model.liveComponent("app.Widget").orElseThrow();
+        assertSame("liveComponent must not copy", first, second);
+
+        first.insertChildComponent("app.Widget.added");
+        assertTrue("mutating a live component must reach the model",
+                model.getComponent("app.Widget").orElseThrow().children()
+                        .contains("app.Widget.added"));
+    }
+
+    @Test
+    public void liveComponentIsEmptyForAnAbsentName() {
+        assertTrue(modelWithOneClass().liveComponent("app.Missing").isEmpty());
+        assertTrue(modelWithOneClass().getComponent("app.Missing").isEmpty());
+    }
+
+    @Test
+    public void liveParentBaseCmpFindsTheSameComponentAsTheCopyingWalk() {
+        OOPSourceCodeModel model = modelWithOneClass();
+
+        Component live = model.liveParentBaseCmp("app.Widget.field");
+        Component copied = model.parentBaseCmp("app.Widget.field");
+
+        assertEquals("app.Widget", live.uniqueName());
+        assertEquals(copied.uniqueName(), live.uniqueName());
+        assertSame("the live walk returns the model's own instance",
+                model.liveComponent("app.Widget").orElseThrow(), live);
+        assertNotSame("the copying walk still copies",
+                model.liveComponent("app.Widget").orElseThrow(), copied);
+    }
+
+    @Test
+    public void parentBaseCmpStillThrowsForAnUnrootedName() {
+        OOPSourceCodeModel model = modelWithOneClass();
+        assertThrows(IllegalArgumentException.class, () -> model.parentBaseCmp("nothing.Here"));
+        assertThrows(IllegalArgumentException.class, () -> model.liveParentBaseCmp("nothing.Here"));
+    }
+
+    @Test
+    public void childrenIsAViewAndRefusesMutationThroughIt() {
+        OOPSourceCodeModel model = modelWithOneClass();
+        Component live = model.liveComponent("app.Widget").orElseThrow();
+
+        List<String> view = live.children();
+        assertThrows(UnsupportedOperationException.class, () -> view.add("app.Widget.sneaked"));
+
+        live.insertChildComponent("app.Widget.second");
+        assertTrue("the view reflects the component it came from",
+                view.contains("app.Widget.second"));
+    }
+
+    @Test
+    public void iteratingChildrenWhileInsertingFailsLoudly() {
+        OOPSourceCodeModel model = modelWithOneClass();
+        Component live = model.liveComponent("app.Widget").orElseThrow();
+
+        assertThrows(ConcurrentModificationException.class, () -> {
+            for (String child : live.children()) {
+                live.insertChildComponent(child + ".copy");
+            }
+        });
+    }
+
+    @Test
+    public void dependencyAndModifierAccessorsAreUnmodifiableViews() {
+        OOPSourceCodeModel model = modelWithOneClass();
+        Component live = model.liveComponent("app.Widget").orElseThrow();
+
+        assertThrows(UnsupportedOperationException.class, () -> live.imports().add("java.util.List"));
+        assertThrows(UnsupportedOperationException.class, () -> live.modifiers().add("public"));
+        assertThrows(UnsupportedOperationException.class,
+                () -> live.internalDependencies().clear());
+        assertThrows(UnsupportedOperationException.class,
+                () -> live.externalDependencies().clear());
+    }
+}

--- a/src/test/java/com/hadi/test/sourcemodel/StringPoolTest.java
+++ b/src/test/java/com/hadi/test/sourcemodel/StringPoolTest.java
@@ -59,8 +59,8 @@ public class StringPoolTest {
         base.insertComponent(freshlyBuilt("Widget", "app"));
         head.insertComponent(freshlyBuilt("Widget", "app"));
 
-        Component fromBase = base.liveComponent("app.Widget").orElseThrow();
-        Component fromHead = head.liveComponent("app.Widget").orElseThrow();
+        Component fromBase = base.component("app.Widget").orElseThrow();
+        Component fromHead = head.component("app.Widget").orElseThrow();
 
         assertSame("componentName", fromBase.componentName(), fromHead.componentName());
         assertSame("name", fromBase.name(), fromHead.name());
@@ -83,8 +83,8 @@ public class StringPoolTest {
         base.insertComponent(freshlyBuilt("Widget", "app"));
         head.insertComponent(freshlyBuilt("Widget", "app"));
 
-        assertEquals(base.liveComponent("app.Widget").orElseThrow().name(),
-                head.liveComponent("app.Widget").orElseThrow().name());
+        assertEquals(base.component("app.Widget").orElseThrow().name(),
+                head.component("app.Widget").orElseThrow().name());
         assertTrue("a model given no pool still shares within itself",
                 base.stringPool().size() > 0);
     }
@@ -98,8 +98,8 @@ public class StringPoolTest {
         pooled.insertComponent(classComponent("Widget", "app"));
         plain.insertComponent(classComponent("Widget", "app"));
 
-        Component a = pooled.liveComponent("app.Widget").orElseThrow();
-        Component b = plain.liveComponent("app.Widget").orElseThrow();
+        Component a = pooled.component("app.Widget").orElseThrow();
+        Component b = plain.component("app.Widget").orElseThrow();
         assertEquals(b.componentName(), a.componentName());
         assertEquals(b.uniqueName(), a.uniqueName());
         assertEquals(b.name(), a.name());
@@ -122,8 +122,8 @@ public class StringPoolTest {
         OOPSourceCodeModel copy = base.copy();
         assertSame("a copy shares its source's pool", pool, copy.stringPool());
         assertSame("so a copied component shares the original's text",
-                base.liveComponent("app.Widget").orElseThrow().name(),
-                copy.liveComponent("app.Widget").orElseThrow().name());
+                base.component("app.Widget").orElseThrow().name(),
+                copy.component("app.Widget").orElseThrow().name());
     }
 
     @Test

--- a/src/test/java/com/hadi/test/sourcemodel/StringPoolTest.java
+++ b/src/test/java/com/hadi/test/sourcemodel/StringPoolTest.java
@@ -1,0 +1,175 @@
+package com.hadi.test.sourcemodel;
+
+import com.hadi.clarpse.sourcemodel.Component;
+import com.hadi.clarpse.sourcemodel.OOPSourceCodeModel;
+import com.hadi.clarpse.sourcemodel.OOPSourceModelConstants;
+import com.hadi.clarpse.sourcemodel.OOPSourceModelConstants.ComponentType;
+import com.hadi.clarpse.sourcemodel.Package;
+import com.hadi.clarpse.sourcemodel.StringPool;
+import org.junit.Test;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Pins that a shared pool makes two models share their text, and that sharing text changes nothing a
+ * caller can observe about the models.
+ *
+ * <p>Identity assertions are the point here: {@code assertEquals} on a string would pass whether or
+ * not the pool did anything at all, so every assertion that matters below is {@code assertSame}.
+ */
+public class StringPoolTest {
+
+    private static Component classComponent(final String name, final String pkg) {
+        Component cls = new Component();
+        cls.setComponentType(ComponentType.CLASS);
+        cls.setComponentName(name);
+        cls.setName(name);
+        cls.setPkg(new Package(pkg, pkg));
+        cls.setModule("core");
+        cls.setComment("A comment repeated across revisions.");
+        cls.setCodeFragment("class " + name);
+        cls.setSourceFilePath("/" + pkg + "/" + name + ".java");
+        cls.insertChildComponent(pkg + "." + name + ".field");
+        cls.insertAccessModifier("public");
+        Set<String> imports = new LinkedHashSet<>();
+        imports.add("java.util.List");
+        cls.setImports(imports);
+        return cls;
+    }
+
+    /** Fresh strings with equal contents, as two separate parses of the same file would produce. */
+    private static Component freshlyBuilt(final String name, final String pkg) {
+        return classComponent(new String(name.toCharArray()), new String(pkg.toCharArray()));
+    }
+
+    @Test
+    public void twoModelsSharingAPoolShareTheirStrings() {
+        StringPool pool = new StringPool();
+        OOPSourceCodeModel base = new OOPSourceCodeModel(pool);
+        OOPSourceCodeModel head = new OOPSourceCodeModel(pool);
+
+        base.insertComponent(freshlyBuilt("Widget", "app"));
+        head.insertComponent(freshlyBuilt("Widget", "app"));
+
+        Component fromBase = base.liveComponent("app.Widget").orElseThrow();
+        Component fromHead = head.liveComponent("app.Widget").orElseThrow();
+
+        assertSame("componentName", fromBase.componentName(), fromHead.componentName());
+        assertSame("name", fromBase.name(), fromHead.name());
+        assertSame("module", fromBase.module(), fromHead.module());
+        assertSame("comment", fromBase.comment(), fromHead.comment());
+        assertSame("codeFragment", fromBase.codeFragment(), fromHead.codeFragment());
+        assertSame("sourceFile", fromBase.sourceFile(), fromHead.sourceFile());
+        assertSame("pkg", fromBase.pkg(), fromHead.pkg());
+        assertSame("children element",
+                fromBase.children().get(0), fromHead.children().get(0));
+        assertSame("imports element",
+                fromBase.imports().iterator().next(), fromHead.imports().iterator().next());
+    }
+
+    @Test
+    public void twoModelsWithSeparatePoolsDoNotShare() {
+        OOPSourceCodeModel base = new OOPSourceCodeModel();
+        OOPSourceCodeModel head = new OOPSourceCodeModel();
+
+        base.insertComponent(freshlyBuilt("Widget", "app"));
+        head.insertComponent(freshlyBuilt("Widget", "app"));
+
+        assertEquals(base.liveComponent("app.Widget").orElseThrow().name(),
+                head.liveComponent("app.Widget").orElseThrow().name());
+        assertTrue("a model given no pool still shares within itself",
+                base.stringPool().size() > 0);
+    }
+
+    @Test
+    public void poolingLeavesEveryValueUnchanged() {
+        StringPool pool = new StringPool();
+        OOPSourceCodeModel pooled = new OOPSourceCodeModel(pool);
+        OOPSourceCodeModel plain = new OOPSourceCodeModel();
+
+        pooled.insertComponent(classComponent("Widget", "app"));
+        plain.insertComponent(classComponent("Widget", "app"));
+
+        Component a = pooled.liveComponent("app.Widget").orElseThrow();
+        Component b = plain.liveComponent("app.Widget").orElseThrow();
+        assertEquals(b.componentName(), a.componentName());
+        assertEquals(b.uniqueName(), a.uniqueName());
+        assertEquals(b.name(), a.name());
+        assertEquals(b.module(), a.module());
+        assertEquals(b.comment(), a.comment());
+        assertEquals(b.codeFragment(), a.codeFragment());
+        assertEquals(b.sourceFile(), a.sourceFile());
+        assertEquals(b.pkg(), a.pkg());
+        assertEquals(b.children(), a.children());
+        assertEquals(b.imports(), a.imports());
+        assertEquals(b.modifiers(), a.modifiers());
+    }
+
+    @Test
+    public void copyCarriesThePoolRatherThanStartingAFreshOne() {
+        StringPool pool = new StringPool();
+        OOPSourceCodeModel base = new OOPSourceCodeModel(pool);
+        base.insertComponent(freshlyBuilt("Widget", "app"));
+
+        OOPSourceCodeModel copy = base.copy();
+        assertSame("a copy shares its source's pool", pool, copy.stringPool());
+        assertSame("so a copied component shares the original's text",
+                base.liveComponent("app.Widget").orElseThrow().name(),
+                copy.liveComponent("app.Widget").orElseThrow().name());
+    }
+
+    @Test
+    public void pooledIsNullSafeAndLeavesEmptyStringsAlone() {
+        StringPool pool = new StringPool();
+        assertNull(pool.pooled((String) null));
+        assertNull(pool.pooled((Package) null));
+        assertEquals("", pool.pooled(""));
+        assertTrue(pool.pooledSet(null).isEmpty());
+    }
+
+    @Test
+    public void pooledSetKeepsDeclarationOrder() {
+        StringPool pool = new StringPool();
+        Set<String> in = new LinkedHashSet<>(List.of("zebra", "apple", "mango"));
+        assertEquals(List.copyOf(in), List.copyOf(pool.pooledSet(in)));
+    }
+
+    @Test
+    public void aModelRefusesANullPool() {
+        try {
+            new OOPSourceCodeModel((StringPool) null);
+            throw new AssertionError("expected a rejected null pool");
+        } catch (IllegalArgumentException expected) {
+            assertNotNull(expected.getMessage());
+        }
+    }
+
+    @Test
+    public void modifiersAreStoredAsTheVocabularysOwnInstance() {
+        Component cmp = new Component();
+        cmp.insertAccessModifier("PUBLIC");
+        String canonical = OOPSourceModelConstants.getAccessModifierMap()
+                .get(OOPSourceModelConstants.AccessModifiers.PUBLIC);
+        assertSame("a modifier must not be a fresh lower-cased copy",
+                canonical, cmp.modifiers().iterator().next());
+    }
+
+    @Test
+    public void anInvalidModifierIsStillRefused() {
+        Component cmp = new Component();
+        try {
+            cmp.insertAccessModifier("notamodifier");
+            throw new AssertionError("expected an invalid modifier to be refused");
+        } catch (IllegalArgumentException expected) {
+            assertTrue(expected.getMessage().contains("notamodifier"));
+        }
+    }
+}

--- a/src/test/java/com/hadi/test/typescript/TypeScriptAccessModifiersTest.java
+++ b/src/test/java/com/hadi/test/typescript/TypeScriptAccessModifiersTest.java
@@ -23,63 +23,63 @@ public class TypeScriptAccessModifiersTest {
 
     @Test
     public void testClassLevelModifier() {
-        assertTrue(model.getComponent(name("Test")).orElseThrow().modifiers().contains("export"));
+        assertTrue(model.copyOfComponent(name("Test")).orElseThrow().modifiers().contains("export"));
     }
 
     @Test
     public void testInterfaceLevelModifier() {
-        assertTrue(model.getComponent(name("TestInterface")).orElseThrow().modifiers().contains("export"));
+        assertTrue(model.copyOfComponent(name("TestInterface")).orElseThrow().modifiers().contains("export"));
     }
 
     @Test
     public void testEnumLevelModifier() {
-        assertTrue(model.getComponent(name("TestEnum")).orElseThrow().modifiers().contains("export"));
+        assertTrue(model.copyOfComponent(name("TestEnum")).orElseThrow().modifiers().contains("export"));
     }
 
     @Test
     public void testClassMethodLevelModifier() {
         String methodName = name("Tester." + TypeScriptTestUtil.signature("lolcakes"));
-        assertTrue(model.getComponent(methodName).orElseThrow().modifiers().contains("private"));
-        assertTrue(model.getComponent(methodName).orElseThrow().modifiers().contains("static"));
+        assertTrue(model.copyOfComponent(methodName).orElseThrow().modifiers().contains("private"));
+        assertTrue(model.copyOfComponent(methodName).orElseThrow().modifiers().contains("static"));
     }
 
     @Test
     public void testClassConstructorLevelModifier() {
         String ctorName = name("PrivateCtor." + TypeScriptTestUtil.signature("constructor"));
-        assertTrue(model.getComponent(ctorName).orElseThrow().modifiers().contains("private"));
+        assertTrue(model.copyOfComponent(ctorName).orElseThrow().modifiers().contains("private"));
     }
 
     @Test
     public void testAbstractMethodLevelModifier() {
         String methodName = name("AbstractTester." + TypeScriptTestUtil.signature("doWork"));
-        assertTrue(model.getComponent(methodName).orElseThrow().modifiers().contains("abstract"));
+        assertTrue(model.copyOfComponent(methodName).orElseThrow().modifiers().contains("abstract"));
     }
 
     @Test
     public void testFieldVarLevelModifier() {
         String fieldName = name("Tester.fieldVar");
-        assertTrue(model.getComponent(fieldName).orElseThrow().modifiers().contains("public"));
-        assertTrue(model.getComponent(fieldName).orElseThrow().modifiers().contains("static"));
+        assertTrue(model.copyOfComponent(fieldName).orElseThrow().modifiers().contains("public"));
+        assertTrue(model.copyOfComponent(fieldName).orElseThrow().modifiers().contains("static"));
     }
 
     @Test
     public void testMethodParamLevelModifier() {
         String paramName = name("ParamTest." + TypeScriptTestUtil.signature("constructor", "string") + ".str");
-        assertTrue(model.getComponent(paramName).orElseThrow().modifiers().contains("public"));
-        assertTrue(model.getComponent(paramName).orElseThrow().modifiers().contains("readonly"));
+        assertTrue(model.copyOfComponent(paramName).orElseThrow().modifiers().contains("public"));
+        assertTrue(model.copyOfComponent(paramName).orElseThrow().modifiers().contains("readonly"));
     }
 
     @Test
     public void testMethodLocalVarLevelModifier() {
         String localName = name("Tester." + TypeScriptTestUtil.signature("method") + ".localConst");
-        assertEquals(1, model.getComponent(localName).orElseThrow().modifiers().size());
-        assertTrue(model.getComponent(localName).orElseThrow().modifiers().contains("const"));
+        assertEquals(1, model.copyOfComponent(localName).orElseThrow().modifiers().size());
+        assertTrue(model.copyOfComponent(localName).orElseThrow().modifiers().contains("const"));
     }
 
     @Test
     public void testMethodLocalVarLevelNoModifier() {
         String localName = name("Tester." + TypeScriptTestUtil.signature("method") + ".localVar");
-        assertTrue(model.getComponent(localName).orElseThrow().modifiers().isEmpty());
+        assertTrue(model.copyOfComponent(localName).orElseThrow().modifiers().isEmpty());
     }
 
     private static String name(final String symbolPath) {

--- a/src/test/java/com/hadi/test/typescript/TypeScriptChildComponentsTest.java
+++ b/src/test/java/com/hadi/test/typescript/TypeScriptChildComponentsTest.java
@@ -27,7 +27,7 @@ public class TypeScriptChildComponentsTest {
     public void testClassHasMethodChild() {
         String className = name("Test");
         String methodName = name("Test." + TypeScriptTestUtil.signature("method", "string"));
-        Component parent = model.getComponent(className).orElseThrow();
+        Component parent = model.copyOfComponent(className).orElseThrow();
         assertTrue(parent.children().contains(methodName));
     }
 
@@ -35,28 +35,28 @@ public class TypeScriptChildComponentsTest {
     public void testClassHasFieldVarChild() {
         String className = name("Test");
         String fieldName = name("Test.fieldVar");
-        Component parent = model.getComponent(className).orElseThrow();
+        Component parent = model.copyOfComponent(className).orElseThrow();
         assertTrue(parent.children().contains(fieldName));
     }
 
     @Test
     public void ignoreClassDeclaredWithinMethods() {
         String nested = name("Test." + TypeScriptTestUtil.signature("methodWithLocal") + ".LocalClass");
-        assertFalse(model.getComponent(nested).isPresent());
+        assertFalse(model.copyOfComponent(nested).isPresent());
     }
 
     @Test
     public void testInterfaceHasMethodChild() {
         String ifaceName = name("TestInterface");
         String methodName = name("TestInterface." + TypeScriptTestUtil.signature("method"));
-        Component parent = model.getComponent(ifaceName).orElseThrow();
+        Component parent = model.copyOfComponent(ifaceName).orElseThrow();
         assertTrue(parent.children().contains(methodName));
     }
 
     @Test
     public void testMethodHasMethodParamChild() {
         String methodName = name("Test." + TypeScriptTestUtil.signature("method", "string"));
-        Component method = model.getComponent(methodName).orElseThrow();
+        Component method = model.copyOfComponent(methodName).orElseThrow();
         assertTrue(method.children().contains(methodName + ".str"));
     }
 
@@ -64,7 +64,7 @@ public class TypeScriptChildComponentsTest {
     public void testInterfaceHasFieldChild() {
         String ifaceName = name("TestInterface");
         String fieldName = name("TestInterface.fieldVar");
-        Component parent = model.getComponent(ifaceName).orElseThrow();
+        Component parent = model.copyOfComponent(ifaceName).orElseThrow();
         assertTrue(parent.children().contains(fieldName));
     }
 
@@ -72,20 +72,20 @@ public class TypeScriptChildComponentsTest {
     public void testClassHasGetterChild() {
         String className = name("Test");
         String getterName = name("Test." + TypeScriptTestUtil.signature("value"));
-        assertTrue(model.getComponent(className).orElseThrow().children().contains(getterName));
+        assertTrue(model.copyOfComponent(className).orElseThrow().children().contains(getterName));
     }
 
     @Test
     public void testClassHasSetterChild() {
         String className = name("Test");
         String setterName = name("Test." + TypeScriptTestUtil.signature("value", "number"));
-        assertTrue(model.getComponent(className).orElseThrow().children().contains(setterName));
+        assertTrue(model.copyOfComponent(className).orElseThrow().children().contains(setterName));
     }
 
     @Test
     public void testEnumHasNestedConstantsChild() {
         String enumName = name("TestEnum");
-        Component parent = model.getComponent(enumName).orElseThrow();
+        Component parent = model.copyOfComponent(enumName).orElseThrow();
         assertTrue(parent.children().contains(name("TestEnum.A")));
         assertTrue(parent.children().contains(name("TestEnum.B")));
         assertTrue(parent.children().contains(name("TestEnum.C")));
@@ -94,12 +94,12 @@ public class TypeScriptChildComponentsTest {
     @Test
     public void testFieldVarParent() {
         String fieldName = name("Test.fieldVar");
-        assertEquals(name("Test"), model.getComponent(fieldName).orElseThrow().parentUniqueName());
+        assertEquals(name("Test"), model.copyOfComponent(fieldName).orElseThrow().parentUniqueName());
     }
 
     @Test
     public void testClassWithMultipleChildren() {
-        Component parent = model.getComponent(name("Test")).orElseThrow();
+        Component parent = model.copyOfComponent(name("Test")).orElseThrow();
         assertTrue(parent.children().contains(name("Test.fieldVar")));
         assertTrue(parent.children().contains(name("Test." + TypeScriptTestUtil.signature("method", "string"))));
         assertTrue(parent.children().contains(name("Test." + TypeScriptTestUtil.signature("value"))));

--- a/src/test/java/com/hadi/test/typescript/TypeScriptClaudeMemSpotCheckTest.java
+++ b/src/test/java/com/hadi/test/typescript/TypeScriptClaudeMemSpotCheckTest.java
@@ -109,16 +109,16 @@ public class TypeScriptClaudeMemSpotCheckTest {
         String hybrid = name("src/services/worker/search/strategies", "HybridSearchStrategy", "HybridSearchStrategy");
         String baseStrategy = name("src/services/worker/search/strategies", "SearchStrategy", "BaseSearchStrategy");
         String strategy = name("src/services/worker/search/strategies", "SearchStrategy", "SearchStrategy");
-        assertTrue(model.getComponent(hybrid).orElseThrow()
+        assertTrue(model.copyOfComponent(hybrid).orElseThrow()
                 .references(OOPSourceModelConstants.TypeReferences.EXTENSION)
                 .contains(new TypeExtensionReference(baseStrategy)));
-        assertTrue(model.getComponent(hybrid).orElseThrow()
+        assertTrue(model.copyOfComponent(hybrid).orElseThrow()
                 .references(OOPSourceModelConstants.TypeReferences.IMPLEMENTATION)
                 .contains(new TypeImplementationReference(strategy)));
 
         String searchRoutes = name("src/services/worker/http/routes", "SearchRoutes", "SearchRoutes");
         String baseRouteHandler = name("src/services/worker/http", "BaseRouteHandler", "BaseRouteHandler");
-        assertTrue(model.getComponent(searchRoutes).orElseThrow()
+        assertTrue(model.copyOfComponent(searchRoutes).orElseThrow()
                 .references(OOPSourceModelConstants.TypeReferences.EXTENSION)
                 .contains(new TypeExtensionReference(baseRouteHandler)));
 
@@ -130,11 +130,11 @@ public class TypeScriptClaudeMemSpotCheckTest {
     }
 
     private static void assertPresent(final String uniqueName) {
-        assertTrue("Missing component: " + uniqueName, model.getComponent(uniqueName).isPresent());
+        assertTrue("Missing component: " + uniqueName, model.copyOfComponent(uniqueName).isPresent());
     }
 
     private static void assertSimpleReference(final String owner, final String target) {
-        assertTrue(model.getComponent(owner).orElseThrow()
+        assertTrue(model.copyOfComponent(owner).orElseThrow()
                 .references(OOPSourceModelConstants.TypeReferences.SIMPLE)
                 .contains(new SimpleTypeReference(target)));
         assertTrue("Missing referenced component: " + target, model.containsComponent(target));

--- a/src/test/java/com/hadi/test/typescript/TypeScriptCodeFragmentTest.java
+++ b/src/test/java/com/hadi/test/typescript/TypeScriptCodeFragmentTest.java
@@ -22,62 +22,62 @@ public class TypeScriptCodeFragmentTest {
 
     @Test
     public void classGenericsCodeFragmentTest() {
-        assertEquals("<T>", model.getComponent(name("GenericTest")).orElseThrow().codeFragment());
+        assertEquals("<T>", model.copyOfComponent(name("GenericTest")).orElseThrow().codeFragment());
     }
 
     @Test
     public void classGenericsCodeFragmentTestv2() {
         assertEquals("<T extends List>",
-                model.getComponent(name("GenericTest2")).orElseThrow().codeFragment());
+                model.copyOfComponent(name("GenericTest2")).orElseThrow().codeFragment());
     }
 
     @Test
     public void fieldVarCodeFragmentTest() {
-        assertEquals("fieldVar : List", model.getComponent(name("FieldTest.fieldVar")).orElseThrow().codeFragment());
-        assertEquals("x : List", model.getComponent(name("FieldTest.x")).orElseThrow().codeFragment());
+        assertEquals("fieldVar : List", model.copyOfComponent(name("FieldTest.fieldVar")).orElseThrow().codeFragment());
+        assertEquals("x : List", model.copyOfComponent(name("FieldTest.x")).orElseThrow().codeFragment());
     }
 
     @Test
     public void fieldVarCodeFragmentTestComplex() {
         assertEquals("complexField : Map<string, List>",
-                model.getComponent(name("FieldTest.complexField")).orElseThrow().codeFragment());
+                model.copyOfComponent(name("FieldTest.complexField")).orElseThrow().codeFragment());
     }
 
     @Test
     public void simpleMethodCodeFragmentTest() {
         String methodName = name("MethodTest." + TypeScriptTestUtil.signature("sMethod"));
-        assertEquals("sMethod() : Map<string, List>", model.getComponent(methodName).orElseThrow().codeFragment());
+        assertEquals("sMethod() : Map<string, List>", model.copyOfComponent(methodName).orElseThrow().codeFragment());
     }
 
     @Test
     public void interfaceMethodCodeFragmentTest() {
         String methodName = name("InterfaceTest." + TypeScriptTestUtil.signature("sMethod"));
-        assertEquals("sMethod() : Map<string, List>", model.getComponent(methodName).orElseThrow().codeFragment());
+        assertEquals("sMethod() : Map<string, List>", model.copyOfComponent(methodName).orElseThrow().codeFragment());
     }
 
     @Test
     public void complexMethodCodeFragmentTest() {
         String methodName = name("MethodTest." + TypeScriptTestUtil.signature("complexMethod", "string", "number"));
         assertEquals("complexMethod(string, number) : Map<List, string[]>",
-                model.getComponent(methodName).orElseThrow().codeFragment());
+                model.copyOfComponent(methodName).orElseThrow().codeFragment());
     }
 
     @Test
     public void literalStringReturnTypeIsNormalized() {
         String methodName = name("MethodTest." + TypeScriptTestUtil.signature("literalText"));
-        assertEquals("literalText() : string", model.getComponent(methodName).orElseThrow().codeFragment());
+        assertEquals("literalText() : string", model.copyOfComponent(methodName).orElseThrow().codeFragment());
     }
 
     @Test
     public void literalNumberReturnTypeIsNormalized() {
         String methodName = name("MethodTest." + TypeScriptTestUtil.signature("literalCount"));
-        assertEquals("literalCount() : number", model.getComponent(methodName).orElseThrow().codeFragment());
+        assertEquals("literalCount() : number", model.copyOfComponent(methodName).orElseThrow().codeFragment());
     }
 
     @Test
     public void literalUnionReturnTypeIsNormalized() {
         String methodName = name("MethodTest." + TypeScriptTestUtil.signature("literalSwitch", "boolean"));
-        assertEquals("literalSwitch(boolean) : string", model.getComponent(methodName).orElseThrow().codeFragment());
+        assertEquals("literalSwitch(boolean) : string", model.copyOfComponent(methodName).orElseThrow().codeFragment());
     }
 
     private static String name(final String symbolPath) {

--- a/src/test/java/com/hadi/test/typescript/TypeScriptCommentsParsingTest.java
+++ b/src/test/java/com/hadi/test/typescript/TypeScriptCommentsParsingTest.java
@@ -23,45 +23,45 @@ public class TypeScriptCommentsParsingTest {
 
     @Test
     public void testClassLevelComment() {
-        assertTrue(model.getComponent(name("Test")).orElseThrow().comment().contains("Class doc"));
+        assertTrue(model.copyOfComponent(name("Test")).orElseThrow().comment().contains("Class doc"));
     }
 
     @Test
     public void testClassLevelNoComment() {
-        assertEquals("", model.getComponent(name("NoComment")).orElseThrow().comment());
+        assertEquals("", model.copyOfComponent(name("NoComment")).orElseThrow().comment());
     }
 
     @Test
     public void testInterfaceLevelComment() {
-        assertTrue(model.getComponent(name("TestInterface")).orElseThrow().comment().contains("Interface doc"));
+        assertTrue(model.copyOfComponent(name("TestInterface")).orElseThrow().comment().contains("Interface doc"));
     }
 
     @Test
     public void testEnumLevelComment() {
-        assertTrue(model.getComponent(name("TestEnum")).orElseThrow().comment().contains("Enum doc"));
+        assertTrue(model.copyOfComponent(name("TestEnum")).orElseThrow().comment().contains("Enum doc"));
     }
 
     @Test
     public void testMethodLevelComment() {
         String methodName = name("Test." + TypeScriptTestUtil.signature("test", "string"));
-        assertTrue(model.getComponent(methodName).orElseThrow().comment().contains("method doc"));
+        assertTrue(model.copyOfComponent(methodName).orElseThrow().comment().contains("method doc"));
     }
 
     @Test
     public void testInterfaceMethodLevelComment() {
         String methodName = name("TestInterface." + TypeScriptTestUtil.signature("method"));
-        assertTrue(model.getComponent(methodName).orElseThrow().comment().contains("interface method doc"));
+        assertTrue(model.copyOfComponent(methodName).orElseThrow().comment().contains("interface method doc"));
     }
 
     @Test
     public void testFieldVarLevelComment() {
-        assertTrue(model.getComponent(name("Test.fieldVar")).orElseThrow().comment().contains("field doc"));
+        assertTrue(model.copyOfComponent(name("Test.fieldVar")).orElseThrow().comment().contains("field doc"));
     }
 
     @Test
     public void testMethodParamLevelComment() {
         String paramName = name("Test." + TypeScriptTestUtil.signature("test", "string") + ".methodParam");
-        assertTrue(model.getComponent(paramName).orElseThrow().comment().contains("param doc"));
+        assertTrue(model.copyOfComponent(paramName).orElseThrow().comment().contains("param doc"));
     }
 
     private static String name(final String symbolPath) {

--- a/src/test/java/com/hadi/test/typescript/TypeScriptComponentProjectFilePathTest.java
+++ b/src/test/java/com/hadi/test/typescript/TypeScriptComponentProjectFilePathTest.java
@@ -29,53 +29,53 @@ public class TypeScriptComponentProjectFilePathTest {
 
     @Test
     public void testClassAComponentHasCorrectSourceFilePath() {
-        Component component = model.getComponent(name(PACKAGE_A, MODULE_A, "TestA")).orElseThrow();
+        Component component = model.copyOfComponent(name(PACKAGE_A, MODULE_A, "TestA")).orElseThrow();
         assertEquals(filePath("src/com/foo/TestA.ts"), component.sourceFile());
     }
 
     @Test
     public void testClassAMethodAComponentHasCorrectSourceFilePath() {
         String symbol = "TestA." + TypeScriptTestUtil.signature("methodA");
-        Component component = model.getComponent(name(PACKAGE_A, MODULE_A, symbol)).orElseThrow();
+        Component component = model.copyOfComponent(name(PACKAGE_A, MODULE_A, symbol)).orElseThrow();
         assertEquals(filePath("src/com/foo/TestA.ts"), component.sourceFile());
     }
 
     @Test
     public void testAbstractClassBComponentHasCorrectSourceFilePath() {
-        Component component = model.getComponent(name(PACKAGE_A, MODULE_A, "TestB")).orElseThrow();
+        Component component = model.copyOfComponent(name(PACKAGE_A, MODULE_A, "TestB")).orElseThrow();
         assertEquals(filePath("src/com/foo/TestA.ts"), component.sourceFile());
     }
 
     @Test
     public void testAbstractClassBMethodBComponentHasCorrectSourceFilePath() {
         String symbol = "TestB." + TypeScriptTestUtil.signature("methodB");
-        Component component = model.getComponent(name(PACKAGE_A, MODULE_A, symbol)).orElseThrow();
+        Component component = model.copyOfComponent(name(PACKAGE_A, MODULE_A, symbol)).orElseThrow();
         assertEquals(filePath("src/com/foo/TestA.ts"), component.sourceFile());
     }
 
     @Test
     public void testClassCComponentHasCorrectSourceFilePath() {
-        Component component = model.getComponent(name(PACKAGE_B, MODULE_C, "TestC")).orElseThrow();
+        Component component = model.copyOfComponent(name(PACKAGE_B, MODULE_C, "TestC")).orElseThrow();
         assertEquals(filePath("src/com/foo/lol/TestC.ts"), component.sourceFile());
     }
 
     @Test
     public void testClassCMethodCComponentHasCorrectSourceFilePath() {
         String symbol = "TestC." + TypeScriptTestUtil.signature("methodC");
-        Component component = model.getComponent(name(PACKAGE_B, MODULE_C, symbol)).orElseThrow();
+        Component component = model.copyOfComponent(name(PACKAGE_B, MODULE_C, symbol)).orElseThrow();
         assertEquals(filePath("src/com/foo/lol/TestC.ts"), component.sourceFile());
     }
 
     @Test
     public void testClassDComponentHasCorrectSourceFilePath() {
-        Component component = model.getComponent(name(PACKAGE_B, MODULE_C, "TestD")).orElseThrow();
+        Component component = model.copyOfComponent(name(PACKAGE_B, MODULE_C, "TestD")).orElseThrow();
         assertEquals(filePath("src/com/foo/lol/TestC.ts"), component.sourceFile());
     }
 
     @Test
     public void testClassDMethodDComponentHasCorrectSourceFilePath() {
         String symbol = "TestD." + TypeScriptTestUtil.signature("methodD");
-        Component component = model.getComponent(name(PACKAGE_B, MODULE_C, symbol)).orElseThrow();
+        Component component = model.copyOfComponent(name(PACKAGE_B, MODULE_C, symbol)).orElseThrow();
         assertEquals(filePath("src/com/foo/lol/TestC.ts"), component.sourceFile());
     }
 

--- a/src/test/java/com/hadi/test/typescript/TypeScriptComponentTypeTest.java
+++ b/src/test/java/com/hadi/test/typescript/TypeScriptComponentTypeTest.java
@@ -26,14 +26,14 @@ public class TypeScriptComponentTypeTest {
 
     @Test
     public void testSampleClassComponentType() {
-        Optional<Component> cmp = model.getComponent(name("SampleClass"));
+        Optional<Component> cmp = model.copyOfComponent(name("SampleClass"));
         Assert.assertEquals(OOPSourceModelConstants.ComponentType.CLASS.toString(),
                 cmp.orElseThrow().componentType().toString());
     }
 
     @Test
     public void testSampleClassFieldComponentType() {
-        Optional<Component> cmp = model.getComponent(name("SampleClass.sampleClassField"));
+        Optional<Component> cmp = model.copyOfComponent(name("SampleClass.sampleClassField"));
         Assert.assertEquals(OOPSourceModelConstants.ComponentType.FIELD.toString(),
                 cmp.orElseThrow().componentType().toString());
     }
@@ -41,7 +41,7 @@ public class TypeScriptComponentTypeTest {
     @Test
     public void testSampleClassConstructorComponentType() {
         String ctorName = name("SampleClass." + TypeScriptTestUtil.signature("constructor", "string"));
-        Optional<Component> cmp = model.getComponent(ctorName);
+        Optional<Component> cmp = model.copyOfComponent(ctorName);
         Assert.assertEquals(OOPSourceModelConstants.ComponentType.CONSTRUCTOR.toString(),
                 cmp.orElseThrow().componentType().toString());
     }
@@ -50,7 +50,7 @@ public class TypeScriptComponentTypeTest {
     public void testSampleClassConstructorParamComponentType() {
         String paramName = name("SampleClass." + TypeScriptTestUtil.signature("constructor", "string")
                 + ".sampleConstructorParam");
-        Optional<Component> cmp = model.getComponent(paramName);
+        Optional<Component> cmp = model.copyOfComponent(paramName);
         Assert.assertEquals(OOPSourceModelConstants.ComponentType.CONSTRUCTOR_PARAMETER_COMPONENT.toString(),
                 cmp.orElseThrow().componentType().toString());
     }
@@ -58,7 +58,7 @@ public class TypeScriptComponentTypeTest {
     @Test
     public void testSampleClassMethodComponentType() {
         String methodName = name("SampleClass." + TypeScriptTestUtil.signature("sampleMethod", "string", "object"));
-        Optional<Component> cmp = model.getComponent(methodName);
+        Optional<Component> cmp = model.copyOfComponent(methodName);
         Assert.assertEquals(OOPSourceModelConstants.ComponentType.METHOD.toString(),
                 cmp.orElseThrow().componentType().toString());
     }
@@ -67,7 +67,7 @@ public class TypeScriptComponentTypeTest {
     public void testSampleClassMethodParamComponentType() {
         String paramName = name("SampleClass." + TypeScriptTestUtil.signature("sampleMethod", "string", "object")
                 + ".sampleMethodParam");
-        Optional<Component> cmp = model.getComponent(paramName);
+        Optional<Component> cmp = model.copyOfComponent(paramName);
         Assert.assertEquals(OOPSourceModelConstants.ComponentType.METHOD_PARAMETER_COMPONENT.toString(),
                 cmp.orElseThrow().componentType().toString());
     }
@@ -76,14 +76,14 @@ public class TypeScriptComponentTypeTest {
     public void testSampleClassMethodParam2ComponentType() {
         String paramName = name("SampleClass." + TypeScriptTestUtil.signature("sampleMethod", "string", "object")
                 + ".sampleMethodParam2");
-        Optional<Component> cmp = model.getComponent(paramName);
+        Optional<Component> cmp = model.copyOfComponent(paramName);
         Assert.assertEquals(OOPSourceModelConstants.ComponentType.METHOD_PARAMETER_COMPONENT.toString(),
                 cmp.orElseThrow().componentType().toString());
     }
 
     @Test
     public void testSampleInterfaceComponentType() {
-        Optional<Component> cmp = model.getComponent(name("SampleInterface"));
+        Optional<Component> cmp = model.copyOfComponent(name("SampleInterface"));
         Assert.assertEquals(OOPSourceModelConstants.ComponentType.INTERFACE.toString(),
                 cmp.orElseThrow().componentType().toString());
     }
@@ -91,7 +91,7 @@ public class TypeScriptComponentTypeTest {
     @Test
     public void testSampleInterfaceMethodComponentType() {
         String methodName = name("SampleInterface." + TypeScriptTestUtil.signature("sampleInterfaceMethod", "string"));
-        Optional<Component> cmp = model.getComponent(methodName);
+        Optional<Component> cmp = model.copyOfComponent(methodName);
         Assert.assertEquals(OOPSourceModelConstants.ComponentType.METHOD.toString(),
                 cmp.orElseThrow().componentType().toString());
     }
@@ -100,28 +100,28 @@ public class TypeScriptComponentTypeTest {
     public void testSampleInterfaceMethodParamComponentType() {
         String paramName = name("SampleInterface." + TypeScriptTestUtil.signature("sampleInterfaceMethod", "string")
                 + ".sampleInterfaceMethodParam");
-        Optional<Component> cmp = model.getComponent(paramName);
+        Optional<Component> cmp = model.copyOfComponent(paramName);
         Assert.assertEquals(OOPSourceModelConstants.ComponentType.METHOD_PARAMETER_COMPONENT.toString(),
                 cmp.orElseThrow().componentType().toString());
     }
 
     @Test
     public void testSampleEnumComponentType() {
-        Optional<Component> cmp = model.getComponent(name("SampleEnum"));
+        Optional<Component> cmp = model.copyOfComponent(name("SampleEnum"));
         Assert.assertEquals(OOPSourceModelConstants.ComponentType.ENUM.toString(),
                 cmp.orElseThrow().componentType().toString());
     }
 
     @Test
     public void testSampleEnumConstantComponentType() {
-        Optional<Component> cmp = model.getComponent(name("SampleEnum.SampleEnumConstant"));
+        Optional<Component> cmp = model.copyOfComponent(name("SampleEnum.SampleEnumConstant"));
         Assert.assertEquals(OOPSourceModelConstants.ComponentType.ENUM_CONSTANT.toString(),
                 cmp.orElseThrow().componentType().toString());
     }
 
     @Test
     public void testTopLevelFunctionComponentType() {
-        Optional<Component> cmp = model.getComponent(name("topLevelFunction"));
+        Optional<Component> cmp = model.copyOfComponent(name("topLevelFunction"));
         Assert.assertEquals(OOPSourceModelConstants.ComponentType.FUNCTION.toString(),
                 cmp.orElseThrow().componentType().toString());
     }

--- a/src/test/java/com/hadi/test/typescript/TypeScriptConstructorAssignedFieldsTest.java
+++ b/src/test/java/com/hadi/test/typescript/TypeScriptConstructorAssignedFieldsTest.java
@@ -25,19 +25,19 @@ public class TypeScriptConstructorAssignedFieldsTest {
     @Test
     public void constructorAssignmentPreservesDeclaredField() {
         Assert.assertEquals(OOPSourceModelConstants.ComponentType.FIELD,
-                model.getComponent(name("Service.owner")).orElseThrow().componentType());
+                model.copyOfComponent(name("Service.owner")).orElseThrow().componentType());
     }
 
     @Test
     public void constructorLocalVariableIsNotModeledAsField() {
-        Assert.assertFalse(model.getComponent(name("Service.temporary")).isPresent());
+        Assert.assertFalse(model.copyOfComponent(name("Service.temporary")).isPresent());
     }
 
     @Test
     public void constructorParameterIsStillModeled() {
         String ctor = "Service." + TypeScriptTestUtil.signature("constructor", "User");
         Assert.assertEquals(OOPSourceModelConstants.ComponentType.CONSTRUCTOR_PARAMETER_COMPONENT,
-                model.getComponent(name(ctor + ".owner")).orElseThrow().componentType());
+                model.copyOfComponent(name(ctor + ".owner")).orElseThrow().componentType());
     }
 
     private static String name(final String symbolPath) {

--- a/src/test/java/com/hadi/test/typescript/TypeScriptCycloTest.java
+++ b/src/test/java/com/hadi/test/typescript/TypeScriptCycloTest.java
@@ -23,41 +23,41 @@ public class TypeScriptCycloTest {
     @Test
     public void simpleCycloTest() {
         String ctorName = name("Test." + TypeScriptTestUtil.signature("constructor"));
-        assertEquals(6, model.getComponent(ctorName).orElseThrow().cyclo());
+        assertEquals(6, model.copyOfComponent(ctorName).orElseThrow().cyclo());
     }
 
     @Test
     public void switchStmtCycloTest() {
         String methodName = name("Test." + TypeScriptTestUtil.signature("switcher", "string"));
-        assertEquals(3, model.getComponent(methodName).orElseThrow().cyclo());
+        assertEquals(3, model.copyOfComponent(methodName).orElseThrow().cyclo());
     }
 
     @Test
     public void complexCycloTest() {
         String methodName = name("Test." + TypeScriptTestUtil.signature("complex"));
-        assertEquals(6, model.getComponent(methodName).orElseThrow().cyclo());
+        assertEquals(6, model.copyOfComponent(methodName).orElseThrow().cyclo());
     }
 
     @Test
     public void ignoreOperatorsInComments() {
         String methodName = name("Test." + TypeScriptTestUtil.signature("withComment"));
-        assertEquals(2, model.getComponent(methodName).orElseThrow().cyclo());
+        assertEquals(2, model.copyOfComponent(methodName).orElseThrow().cyclo());
     }
 
     @Test
     public void ignoreInterfaceMethods() {
         String methodName = name("ITest." + TypeScriptTestUtil.signature("aMethod"));
-        assertEquals(0, model.getComponent(methodName).orElseThrow().cyclo());
+        assertEquals(0, model.copyOfComponent(methodName).orElseThrow().cyclo());
     }
 
     @Test
     public void classCycloTest() {
-        assertEquals(5, model.getComponent(name("ClassCyclo")).orElseThrow().cyclo());
+        assertEquals(5, model.copyOfComponent(name("ClassCyclo")).orElseThrow().cyclo());
     }
 
     @Test
     public void emptyClassCycloTest() {
-        assertEquals(0, model.getComponent(name("EmptyClass")).orElseThrow().cyclo());
+        assertEquals(0, model.copyOfComponent(name("EmptyClass")).orElseThrow().cyclo());
     }
 
     private static String name(final String symbolPath) {

--- a/src/test/java/com/hadi/test/typescript/TypeScriptFileNotInProgramTest.java
+++ b/src/test/java/com/hadi/test/typescript/TypeScriptFileNotInProgramTest.java
@@ -23,7 +23,7 @@ public class TypeScriptFileNotInProgramTest {
 
         OOPSourceCodeModel model = result.model();
         String includedName = TypeScriptTestUtil.uniqueName("src", "Included", "Included");
-        assertTrue(model.getComponent(includedName).isPresent());
+        assertTrue(model.copyOfComponent(includedName).isPresent());
 
         assertTrue(result.failures().isEmpty());
     }

--- a/src/test/java/com/hadi/test/typescript/TypeScriptInvalidTsconfigTest.java
+++ b/src/test/java/com/hadi/test/typescript/TypeScriptInvalidTsconfigTest.java
@@ -35,7 +35,7 @@ public class TypeScriptInvalidTsconfigTest {
 
         OOPSourceCodeModel model = result.model();
         String goodName = TypeScriptTestUtil.uniqueName("good/src", "Good", "Good");
-        assertTrue(model.getComponent(goodName).isPresent());
+        assertTrue(model.copyOfComponent(goodName).isPresent());
 
         assertEquals(1, result.failures().size());
         CompileFailure failure = result.failures().iterator().next();

--- a/src/test/java/com/hadi/test/typescript/TypeScriptMethodCallReferenceTest.java
+++ b/src/test/java/com/hadi/test/typescript/TypeScriptMethodCallReferenceTest.java
@@ -26,7 +26,7 @@ public class TypeScriptMethodCallReferenceTest {
     public void testMethodCallTypeReferenceFromReturnType() {
         String methodName = name("Test." + TypeScriptTestUtil.signature("m"));
         String listRef = name("List");
-        assertTrue(model.getComponent(methodName).orElseThrow()
+        assertTrue(model.copyOfComponent(methodName).orElseThrow()
                 .references(OOPSourceModelConstants.TypeReferences.SIMPLE)
                 .contains(new SimpleTypeReference(listRef)));
     }

--- a/src/test/java/com/hadi/test/typescript/TypeScriptModuleVariableTest.java
+++ b/src/test/java/com/hadi/test/typescript/TypeScriptModuleVariableTest.java
@@ -26,7 +26,7 @@ public class TypeScriptModuleVariableTest {
 
     @Test
     public void testTopLevelConstUniqueNameAndType() {
-        Component cmp = model.getComponent(name("API_URL")).orElseThrow();
+        Component cmp = model.copyOfComponent(name("API_URL")).orElseThrow();
         Assert.assertEquals(name("API_URL"), cmp.uniqueName());
         Assert.assertEquals(MODULE, cmp.module());
         Assert.assertEquals(OOPSourceModelConstants.ComponentType.MODULE_FIELD.toString(),
@@ -37,7 +37,7 @@ public class TypeScriptModuleVariableTest {
 
     @Test
     public void testTopLevelLetUniqueNameAndType() {
-        Component cmp = model.getComponent(name("retryCount")).orElseThrow();
+        Component cmp = model.copyOfComponent(name("retryCount")).orElseThrow();
         Assert.assertEquals(name("retryCount"), cmp.uniqueName());
         Assert.assertEquals(MODULE, cmp.module());
         Assert.assertEquals(OOPSourceModelConstants.ComponentType.MODULE_FIELD.toString(),
@@ -47,7 +47,7 @@ public class TypeScriptModuleVariableTest {
 
     @Test
     public void testTopLevelVarUniqueNameAndType() {
-        Component cmp = model.getComponent(name("legacyFlag")).orElseThrow();
+        Component cmp = model.copyOfComponent(name("legacyFlag")).orElseThrow();
         Assert.assertEquals(name("legacyFlag"), cmp.uniqueName());
         Assert.assertEquals(MODULE, cmp.module());
         Assert.assertEquals(OOPSourceModelConstants.ComponentType.MODULE_FIELD.toString(),

--- a/src/test/java/com/hadi/test/typescript/TypeScriptMonorepoTsconfigScopeTest.java
+++ b/src/test/java/com/hadi/test/typescript/TypeScriptMonorepoTsconfigScopeTest.java
@@ -22,8 +22,8 @@ public class TypeScriptMonorepoTsconfigScopeTest {
         CompileResult result = new ClarpseProject(projectFiles, Lang.TYPESCRIPT).result();
 
         OOPSourceCodeModel model = result.model();
-        assertTrue(model.getComponent(TypeScriptTestUtil.uniqueName("apps/backend/src", "service", "Service")).isPresent());
-        assertTrue(model.getComponent(TypeScriptTestUtil.uniqueName("apps/frontend/src", "app", "App")).isPresent());
+        assertTrue(model.copyOfComponent(TypeScriptTestUtil.uniqueName("apps/backend/src", "service", "Service")).isPresent());
+        assertTrue(model.copyOfComponent(TypeScriptTestUtil.uniqueName("apps/frontend/src", "app", "App")).isPresent());
         assertTrue(result.failures().isEmpty());
     }
 }

--- a/src/test/java/com/hadi/test/typescript/TypeScriptMultiVariableDeclarationTest.java
+++ b/src/test/java/com/hadi/test/typescript/TypeScriptMultiVariableDeclarationTest.java
@@ -35,11 +35,11 @@ public class TypeScriptMultiVariableDeclarationTest {
         String aName = methodName + ".a";
         String bName = methodName + ".b";
 
-        assertTrue(model.getComponent(aName).orElseThrow().references(TypeReferences.SIMPLE).contains(foo));
-        assertFalse(model.getComponent(aName).orElseThrow().references(TypeReferences.SIMPLE).contains(bar));
+        assertTrue(model.copyOfComponent(aName).orElseThrow().references(TypeReferences.SIMPLE).contains(foo));
+        assertFalse(model.copyOfComponent(aName).orElseThrow().references(TypeReferences.SIMPLE).contains(bar));
 
-        assertTrue(model.getComponent(bName).orElseThrow().references(TypeReferences.SIMPLE).contains(bar));
-        assertFalse(model.getComponent(bName).orElseThrow().references(TypeReferences.SIMPLE).contains(foo));
+        assertTrue(model.copyOfComponent(bName).orElseThrow().references(TypeReferences.SIMPLE).contains(bar));
+        assertFalse(model.copyOfComponent(bName).orElseThrow().references(TypeReferences.SIMPLE).contains(foo));
     }
 
     private static String name(final String symbolPath) {

--- a/src/test/java/com/hadi/test/typescript/TypeScriptPackageAttributeTest.java
+++ b/src/test/java/com/hadi/test/typescript/TypeScriptPackageAttributeTest.java
@@ -23,19 +23,19 @@ public class TypeScriptPackageAttributeTest {
 
     @Test
     public void testClassAccuratePackageName() {
-        Component cmp = model.getComponent(name("SampleClass")).orElseThrow();
+        Component cmp = model.copyOfComponent(name("SampleClass")).orElseThrow();
         assertTrue(cmp.pkg().path().equals(PACKAGE_PATH));
     }
 
     @Test
     public void testFieldVarAccuratePackageName() {
-        Component cmp = model.getComponent(name("SampleClass.sampleClassField")).orElseThrow();
+        Component cmp = model.copyOfComponent(name("SampleClass.sampleClassField")).orElseThrow();
         assertTrue(cmp.pkg().path().equals(PACKAGE_PATH));
     }
 
     @Test
     public void testMethodAccuratePackageName() {
-        Component cmp = model.getComponent(name("SampleClass." + TypeScriptTestUtil.signature("method")))
+        Component cmp = model.copyOfComponent(name("SampleClass." + TypeScriptTestUtil.signature("method")))
                 .orElseThrow();
         assertTrue(cmp.pkg().name().equals(PACKAGE_PATH));
     }

--- a/src/test/java/com/hadi/test/typescript/TypeScriptPathsHeavyTest.java
+++ b/src/test/java/com/hadi/test/typescript/TypeScriptPathsHeavyTest.java
@@ -30,13 +30,13 @@ public class TypeScriptPathsHeavyTest {
         String profileRef = TypeScriptTestUtil.uniqueName("src/domain/user/profile", "Profile", "Profile");
         String idRef = TypeScriptTestUtil.uniqueName("src/shared", "types", "Id");
 
-        assertTrue(model.getComponent(runName).orElseThrow()
+        assertTrue(model.copyOfComponent(runName).orElseThrow()
                 .references(OOPSourceModelConstants.TypeReferences.SIMPLE)
                 .contains(new SimpleTypeReference(userRef)));
-        assertTrue(model.getComponent(runName).orElseThrow()
+        assertTrue(model.copyOfComponent(runName).orElseThrow()
                 .references(OOPSourceModelConstants.TypeReferences.SIMPLE)
                 .contains(new SimpleTypeReference(profileRef)));
-        assertTrue(model.getComponent(runName).orElseThrow()
+        assertTrue(model.copyOfComponent(runName).orElseThrow()
                 .references(OOPSourceModelConstants.TypeReferences.SIMPLE)
                 .contains(new SimpleTypeReference(idRef)));
     }

--- a/src/test/java/com/hadi/test/typescript/TypeScriptRecursiveTypeTest.java
+++ b/src/test/java/com/hadi/test/typescript/TypeScriptRecursiveTypeTest.java
@@ -36,7 +36,7 @@ public class TypeScriptRecursiveTypeTest {
 
         assertNotNull(result);
         assertTrue("TreeNode class should be resolved",
-                result.model().getComponent("src.index.TreeNode").isPresent());
+                result.model().copyOfComponent("src.index.TreeNode").isPresent());
     }
 
     @Test
@@ -57,7 +57,7 @@ public class TypeScriptRecursiveTypeTest {
 
         assertNotNull(result);
         assertTrue("Container interface should be resolved",
-                result.model().getComponent("src.index.Container").isPresent());
+                result.model().copyOfComponent("src.index.Container").isPresent());
     }
 
     @Test

--- a/src/test/java/com/hadi/test/typescript/TypeScriptReferenceClassificationTest.java
+++ b/src/test/java/com/hadi/test/typescript/TypeScriptReferenceClassificationTest.java
@@ -25,8 +25,8 @@ public class TypeScriptReferenceClassificationTest {
 
     @Test
     public void testInternalAndExternalDependencies() {
-        Component ext = model.getComponent(name("Test.ext")).orElseThrow();
-        Component internal = model.getComponent(name("Test.internal")).orElseThrow();
+        Component ext = model.copyOfComponent(name("Test.ext")).orElseThrow();
+        Component internal = model.copyOfComponent(name("Test.internal")).orElseThrow();
 
         SimpleTypeReference dateRef = new SimpleTypeReference("Date");
         SimpleTypeReference classBRef = new SimpleTypeReference(name("ClassB"));

--- a/src/test/java/com/hadi/test/typescript/TypeScriptReferenceInheritanceTest.java
+++ b/src/test/java/com/hadi/test/typescript/TypeScriptReferenceInheritanceTest.java
@@ -23,49 +23,49 @@ public class TypeScriptReferenceInheritanceTest {
 
     @Test
     public void testClassInheritsFieldReferences() {
-        assertTrue(model.getComponent(name("Test")).orElseThrow().references().contains(new SimpleTypeReference("string")));
+        assertTrue(model.copyOfComponent(name("Test")).orElseThrow().references().contains(new SimpleTypeReference("string")));
     }
 
     @Test
     public void testClassInheritsMethodReferences() {
-        assertTrue(model.getComponent(name("Test")).orElseThrow().references().contains(new SimpleTypeReference("string")));
+        assertTrue(model.copyOfComponent(name("Test")).orElseThrow().references().contains(new SimpleTypeReference("string")));
     }
 
     @Test
     public void testClassInheritsLocalVarsReferences() {
-        assertTrue(model.getComponent(name("Test")).orElseThrow().references().contains(new SimpleTypeReference("string")));
+        assertTrue(model.copyOfComponent(name("Test")).orElseThrow().references().contains(new SimpleTypeReference("string")));
     }
 
     @Test
     public void testClassInheritsMethodParamsReferences() {
-        assertTrue(model.getComponent(name("Test")).orElseThrow().references().contains(new SimpleTypeReference("string")));
+        assertTrue(model.copyOfComponent(name("Test")).orElseThrow().references().contains(new SimpleTypeReference("string")));
     }
 
     @Test
     public void testInterfaceInheritsFieldReferences() {
-        assertTrue(model.getComponent(name("ITest")).orElseThrow().references().contains(new SimpleTypeReference("string")));
+        assertTrue(model.copyOfComponent(name("ITest")).orElseThrow().references().contains(new SimpleTypeReference("string")));
     }
 
     @Test
     public void testInterfaceInheritsMethodReferences() {
-        assertTrue(model.getComponent(name("ITest")).orElseThrow().references().contains(new SimpleTypeReference("string")));
+        assertTrue(model.copyOfComponent(name("ITest")).orElseThrow().references().contains(new SimpleTypeReference("string")));
     }
 
     @Test
     public void testInterfaceInheritsMethodParamsReferences() {
-        assertTrue(model.getComponent(name("ITest")).orElseThrow().references().contains(new SimpleTypeReference("string")));
+        assertTrue(model.copyOfComponent(name("ITest")).orElseThrow().references().contains(new SimpleTypeReference("string")));
     }
 
     @Test
     public void testMethodInheritsLocalVarsReferences() {
         String methodName = name("Test." + TypeScriptTestUtil.signature("methodWithLocal"));
-        assertTrue(model.getComponent(methodName).orElseThrow().references().contains(new SimpleTypeReference("string")));
+        assertTrue(model.copyOfComponent(methodName).orElseThrow().references().contains(new SimpleTypeReference("string")));
     }
 
     @Test
     public void testMethodInheritsMethodParamsReferences() {
         String methodName = name("Test." + TypeScriptTestUtil.signature("methodWithParam", "string"));
-        assertTrue(model.getComponent(methodName).orElseThrow().references().contains(new SimpleTypeReference("string")));
+        assertTrue(model.copyOfComponent(methodName).orElseThrow().references().contains(new SimpleTypeReference("string")));
     }
 
     private static String name(final String symbolPath) {

--- a/src/test/java/com/hadi/test/typescript/TypeScriptResolutionTest.java
+++ b/src/test/java/com/hadi/test/typescript/TypeScriptResolutionTest.java
@@ -19,7 +19,7 @@ public class TypeScriptResolutionTest {
     public void resolvesExtendsImplementsAndTypesThroughPathsAndBarrels() throws Exception {
         CompileResult result = TypeScriptTestUtil.compileFixture("paths");
 
-        Component service = result.model().getComponent("src.app.service.Service").orElseThrow();
+        Component service = result.model().copyOfComponent("src.app.service.Service").orElseThrow();
         Set<Class<? extends ComponentReference>> refTypes = service.references().stream()
                 .map(ComponentReference::getClass)
                 .collect(Collectors.toSet());
@@ -30,7 +30,7 @@ public class TypeScriptResolutionTest {
         assertTrue(service.references().stream().anyMatch(ref ->
                 ref instanceof TypeImplementationReference && ref.invokedComponent().equals("src.app.service.Repo")));
 
-        Component getMethod = result.model().getComponent("src.app.service.Service.get()").orElseThrow();
+        Component getMethod = result.model().copyOfComponent("src.app.service.Service.get()").orElseThrow();
         assertTrue(getMethod.references().stream().anyMatch(ref ->
                 ref instanceof SimpleTypeReference && ref.invokedComponent().equals("src.lib.user.User")));
 

--- a/src/test/java/com/hadi/test/typescript/TypeScriptSimpleTypeReferenceTest.java
+++ b/src/test/java/com/hadi/test/typescript/TypeScriptSimpleTypeReferenceTest.java
@@ -26,78 +26,78 @@ public class TypeScriptSimpleTypeReferenceTest {
 
     @Test
     public void testFieldVarTypeDeclaration() {
-        ComponentReference invocation = model.getComponent(name(MODULE_MAIN, "Test.fieldVar"))
+        ComponentReference invocation = model.copyOfComponent(name(MODULE_MAIN, "Test.fieldVar"))
                 .orElseThrow().references(TypeReferences.SIMPLE).get(0);
         Assert.assertEquals("string", invocation.invokedComponent());
     }
 
     @Test
     public void testSelfReferenceShouldNotExist() {
-        Assert.assertEquals(0, model.getComponent(name(MODULE_MAIN, "SelfRef")).orElseThrow().references().size());
+        Assert.assertEquals(0, model.copyOfComponent(name(MODULE_MAIN, "SelfRef")).orElseThrow().references().size());
         String ctorName = name(MODULE_MAIN, "SelfRef." + TypeScriptTestUtil.signature("constructor"));
-        Assert.assertEquals(0, model.getComponent(ctorName).orElseThrow().references().size());
+        Assert.assertEquals(0, model.copyOfComponent(ctorName).orElseThrow().references().size());
     }
 
     @Test
     public void testFieldVarImportTypeDeclaration() {
-        ComponentReference invocation = model.getComponent(name(MODULE_MAIN, "Test.importedField"))
+        ComponentReference invocation = model.copyOfComponent(name(MODULE_MAIN, "Test.importedField"))
                 .orElseThrow().references(TypeReferences.SIMPLE).get(0);
         Assert.assertEquals(name(MODULE_OTHER, "ClassB"), invocation.invokedComponent());
     }
 
     @Test
     public void testFieldVarTypeDeclarationListSize() {
-        Assert.assertEquals(1, model.getComponent(name(MODULE_MAIN, "Test.fieldVar"))
+        Assert.assertEquals(1, model.copyOfComponent(name(MODULE_MAIN, "Test.fieldVar"))
                 .orElseThrow().references(TypeReferences.SIMPLE).size());
     }
 
     @Test
     public void testResolveImportInFieldType() {
-        Assert.assertEquals(1, model.getComponent(name(MODULE_MAIN, "Test.importedField"))
+        Assert.assertEquals(1, model.copyOfComponent(name(MODULE_MAIN, "Test.importedField"))
                 .orElseThrow().references(TypeReferences.SIMPLE).size());
     }
 
     @Test
     public void testMethodParamTypeDeclaration() {
         String methodName = name(MODULE_MAIN, "Test." + TypeScriptTestUtil.signature("method", "string", "number"));
-        Assert.assertEquals("string", model.getComponent(methodName + ".s1").orElseThrow()
+        Assert.assertEquals("string", model.copyOfComponent(methodName + ".s1").orElseThrow()
                 .references(TypeReferences.SIMPLE).get(0).invokedComponent());
     }
 
     @Test
     public void testMethodParamTypeDeclarationListSize() {
         String methodName = name(MODULE_MAIN, "Test." + TypeScriptTestUtil.signature("method", "string", "number"));
-        Assert.assertEquals(1, model.getComponent(methodName + ".s1").orElseThrow()
+        Assert.assertEquals(1, model.copyOfComponent(methodName + ".s1").orElseThrow()
                 .references(TypeReferences.SIMPLE).size());
-        Assert.assertEquals(1, model.getComponent(methodName + ".s2").orElseThrow()
+        Assert.assertEquals(1, model.copyOfComponent(methodName + ".s2").orElseThrow()
                 .references(TypeReferences.SIMPLE).size());
     }
 
     @Test
     public void testMethodLocalVarTypeDeclaration() {
         String methodName = name(MODULE_MAIN, "Test." + TypeScriptTestUtil.signature("method", "string", "number"));
-        Assert.assertEquals("string", model.getComponent(methodName + ".localVar").orElseThrow()
+        Assert.assertEquals("string", model.copyOfComponent(methodName + ".localVar").orElseThrow()
                 .references(TypeReferences.SIMPLE).get(0).invokedComponent());
     }
 
     @Test
     public void testMethodLocalVarTypeDeclarationListSize() {
         String methodName = name(MODULE_MAIN, "Test." + TypeScriptTestUtil.signature("method", "string", "number"));
-        Assert.assertEquals(1, model.getComponent(methodName + ".localVar").orElseThrow()
+        Assert.assertEquals(1, model.copyOfComponent(methodName + ".localVar").orElseThrow()
                 .references(TypeReferences.SIMPLE).size());
     }
 
     @Test
     public void testMethodCallStaticTypeReference() {
         String methodName = name(MODULE_MAIN, "Test." + TypeScriptTestUtil.signature("testStatic"));
-        Assert.assertTrue(model.getComponent(methodName).orElseThrow().references(TypeReferences.SIMPLE)
+        Assert.assertTrue(model.copyOfComponent(methodName).orElseThrow().references(TypeReferences.SIMPLE)
                 .contains(new SimpleTypeReference(name(MODULE_MAIN, "Foo"))));
     }
 
     @Test
     public void testInstantiateObjectType() {
         String methodName = name(MODULE_MAIN, "Test." + TypeScriptTestUtil.signature("method", "string", "number"));
-        Assert.assertTrue(model.getComponent(methodName).orElseThrow().references(TypeReferences.SIMPLE)
+        Assert.assertTrue(model.copyOfComponent(methodName).orElseThrow().references(TypeReferences.SIMPLE)
                 .contains(new SimpleTypeReference(name(MODULE_MAIN, "Foo"))));
     }
 
@@ -105,8 +105,8 @@ public class TypeScriptSimpleTypeReferenceTest {
     public void typeDeclarationArrayList() {
         String classAFieldB = name(MODULE_COLLECTIONS, "ClassA.b");
         String classAFieldC = name(MODULE_COLLECTIONS, "ClassA.c");
-        Assert.assertEquals(3, model.getComponent(classAFieldB).orElseThrow().references().size());
-        Assert.assertEquals(3, model.getComponent(classAFieldC).orElseThrow().references().size());
+        Assert.assertEquals(3, model.copyOfComponent(classAFieldB).orElseThrow().references().size());
+        Assert.assertEquals(3, model.copyOfComponent(classAFieldC).orElseThrow().references().size());
     }
 
     private static String name(final String moduleName, final String symbolPath) {

--- a/src/test/java/com/hadi/test/typescript/TypeScriptSmokeTest.java
+++ b/src/test/java/com/hadi/test/typescript/TypeScriptSmokeTest.java
@@ -28,7 +28,7 @@ public class TypeScriptSmokeTest {
 
     @Test
     public void spotCheckClassExtension() {
-        Assert.assertTrue(model.getComponent(name("src/core", "Service", "Service"))
+        Assert.assertTrue(model.copyOfComponent(name("src/core", "Service", "Service"))
                 .orElseThrow()
                 .references(OOPSourceModelConstants.TypeReferences.EXTENSION)
                 .contains(new TypeExtensionReference(name("src/core", "Base", "Base"))));
@@ -36,7 +36,7 @@ public class TypeScriptSmokeTest {
 
     @Test
     public void spotCheckClassDocs() {
-        Assert.assertTrue(model.getComponent(name("src/core", "Service", "Service"))
+        Assert.assertTrue(model.copyOfComponent(name("src/core", "Service", "Service"))
                 .orElseThrow()
                 .comment()
                 .contains("Service doc"));
@@ -44,7 +44,7 @@ public class TypeScriptSmokeTest {
 
     @Test
     public void spotCheckClassImplementation() {
-        Assert.assertTrue(model.getComponent(name("src/core", "Service", "Service"))
+        Assert.assertTrue(model.copyOfComponent(name("src/core", "Service", "Service"))
                 .orElseThrow()
                 .references(OOPSourceModelConstants.TypeReferences.IMPLEMENTATION)
                 .contains(new TypeImplementationReference(name("src/core", "Repo", "Repo"))));
@@ -58,7 +58,7 @@ public class TypeScriptSmokeTest {
 
     @Test
     public void spotCheckListWriterReference() {
-        Assert.assertTrue(model.getComponent(name("src/util", "ListWriter", "ListWriter.items"))
+        Assert.assertTrue(model.copyOfComponent(name("src/util", "ListWriter", "ListWriter.items"))
                 .orElseThrow()
                 .references(OOPSourceModelConstants.TypeReferences.SIMPLE)
                 .contains(new SimpleTypeReference(name("src/util", "ListWriter", "List"))));

--- a/src/test/java/com/hadi/test/typescript/TypeScriptStructureTest.java
+++ b/src/test/java/com/hadi/test/typescript/TypeScriptStructureTest.java
@@ -13,15 +13,15 @@ public class TypeScriptStructureTest {
     public void classMembersAndCycloAreModeled() throws Exception {
         CompileResult result = TypeScriptTestUtil.compileFixture("simple");
 
-        Component widget = result.model().getComponent("src.structs.Widget.Widget").orElseThrow();
+        Component widget = result.model().copyOfComponent("src.structs.Widget.Widget").orElseThrow();
         assertTrue(widget.comment().contains("Widget doc"));
         assertTrue(widget.modifiers().contains("export"));
 
-        Component field = result.model().getComponent("src.structs.Widget.Widget.id").orElseThrow();
+        Component field = result.model().copyOfComponent("src.structs.Widget.Widget.id").orElseThrow();
         assertTrue(field.comment().contains("field doc"));
         assertTrue(field.modifiers().contains("readonly"));
 
-        Component method = result.model().getComponent("src.structs.Widget.Widget.compute(boolean)").orElseThrow();
+        Component method = result.model().copyOfComponent("src.structs.Widget.Widget.compute(boolean)").orElseThrow();
         assertTrue(method.comment().contains("method doc"));
         assertEquals(4, method.cyclo());
         assertTrue(method.children().contains("src.structs.Widget.Widget.compute(boolean).flag"));

--- a/src/test/java/com/hadi/test/typescript/TypeScriptSyntheticModuleSourceFileTest.java
+++ b/src/test/java/com/hadi/test/typescript/TypeScriptSyntheticModuleSourceFileTest.java
@@ -30,7 +30,7 @@ public class TypeScriptSyntheticModuleSourceFileTest {
 
     @Test
     public void moduleFieldUsesSourceFilePathFromOwningFile() {
-        Component cmp = model.getComponent(name("API_URL")).orElseThrow();
+        Component cmp = model.copyOfComponent(name("API_URL")).orElseThrow();
         String sourceFile = cmp.sourceFile();
         assertFalse(sourceFile == null || sourceFile.isEmpty());
         assertEquals(filePath("src/foo/bar/Config.ts"), sourceFile);
@@ -38,25 +38,25 @@ public class TypeScriptSyntheticModuleSourceFileTest {
 
     @Test
     public void moduleFieldHasCorrectPackagePath() {
-        Component cmp = model.getComponent(name("API_URL")).orElseThrow();
+        Component cmp = model.copyOfComponent(name("API_URL")).orElseThrow();
         assertEquals(PACKAGE_PATH, cmp.pkg().path());
     }
 
     @Test
     public void moduleFieldHasCorrectPackageName() {
-        Component cmp = model.getComponent(name("API_URL")).orElseThrow();
+        Component cmp = model.copyOfComponent(name("API_URL")).orElseThrow();
         assertEquals(PACKAGE_PATH, cmp.pkg().name());
     }
 
     @Test
     public void moduleFunctionHasCorrectPackagePath() {
-        Component cmp = model.getComponent(name("ping")).orElseThrow();
+        Component cmp = model.copyOfComponent(name("ping")).orElseThrow();
         assertEquals(PACKAGE_PATH, cmp.pkg().path());
     }
 
     @Test
     public void moduleFunctionHasCorrectPackageName() {
-        Component cmp = model.getComponent(name("ping")).orElseThrow();
+        Component cmp = model.copyOfComponent(name("ping")).orElseThrow();
         assertEquals(PACKAGE_PATH, cmp.pkg().name());
     }
 

--- a/src/test/java/com/hadi/test/typescript/TypeScriptTypeExtensionReferenceTest.java
+++ b/src/test/java/com/hadi/test/typescript/TypeScriptTypeExtensionReferenceTest.java
@@ -23,31 +23,31 @@ public class TypeScriptTypeExtensionReferenceTest {
 
     @Test
     public void testAccurateExtendedTypes() {
-        ComponentReference ref = (ComponentReference) model.getComponent(name("ClassA")).orElseThrow().references()
+        ComponentReference ref = (ComponentReference) model.copyOfComponent(name("ClassA")).orElseThrow().references()
                 .toArray()[0];
         Assert.assertEquals(name("ClassD"), ref.invokedComponent());
     }
 
     @Test
     public void testAccurateExtendedTypesSize() {
-        Assert.assertEquals(1, model.getComponent(name("ClassA")).orElseThrow().references().size());
+        Assert.assertEquals(1, model.copyOfComponent(name("ClassA")).orElseThrow().references().size());
     }
 
     @Test
     public void testAccurateExtendedTypesForAnotherClass() {
-        ComponentReference ref = (ComponentReference) model.getComponent(name("ClassE")).orElseThrow().references()
+        ComponentReference ref = (ComponentReference) model.copyOfComponent(name("ClassE")).orElseThrow().references()
                 .toArray()[0];
         Assert.assertEquals(name("ClassD"), ref.invokedComponent());
     }
 
     @Test
     public void testAccurateExtendedTypesSizeForAnotherClass() {
-        Assert.assertEquals(1, model.getComponent(name("ClassE")).orElseThrow().references().size());
+        Assert.assertEquals(1, model.copyOfComponent(name("ClassE")).orElseThrow().references().size());
     }
 
     @Test
     public void testInterfaceExtendsReference() {
-        Assert.assertTrue(model.getComponent(name("InterfaceA")).orElseThrow().references()
+        Assert.assertTrue(model.copyOfComponent(name("InterfaceA")).orElseThrow().references()
                 .contains(new TypeExtensionReference(name("InterfaceD"))));
     }
 

--- a/src/test/java/com/hadi/test/typescript/TypeScriptTypeImplementationReferenceTest.java
+++ b/src/test/java/com/hadi/test/typescript/TypeScriptTypeImplementationReferenceTest.java
@@ -26,28 +26,28 @@ public class TypeScriptTypeImplementationReferenceTest {
 
     @Test
     public void testAccurateImplementedTypes() {
-        ComponentReference ref = (ComponentReference) model.getComponent(name("ClassB")).orElseThrow().references()
+        ComponentReference ref = (ComponentReference) model.copyOfComponent(name("ClassB")).orElseThrow().references()
                 .toArray()[0];
         assertEquals(name("ClassD"), ref.invokedComponent());
-        assertEquals(1, model.getComponent(name("ClassB")).orElseThrow().references().size());
+        assertEquals(1, model.copyOfComponent(name("ClassB")).orElseThrow().references().size());
     }
 
     @Test
     public void testAccurateMultipleImplementedTypes() {
-        assertTrue(model.getComponent(name("ClassA")).orElseThrow().references(TypeReferences.IMPLEMENTATION)
+        assertTrue(model.copyOfComponent(name("ClassA")).orElseThrow().references(TypeReferences.IMPLEMENTATION)
                 .contains(new TypeImplementationReference(name("ClassD"))));
-        assertTrue(model.getComponent(name("ClassA")).orElseThrow().references(TypeReferences.IMPLEMENTATION)
+        assertTrue(model.copyOfComponent(name("ClassA")).orElseThrow().references(TypeReferences.IMPLEMENTATION)
                 .contains(new TypeImplementationReference(name("ClassE"))));
     }
 
     @Test
     public void testAccurateImplementedTypesSize() {
-        assertEquals(1, model.getComponent(name("ClassB")).orElseThrow().references().size());
+        assertEquals(1, model.copyOfComponent(name("ClassB")).orElseThrow().references().size());
     }
 
     @Test
     public void testAccurateMultipleImplementedTypesSize() {
-        assertEquals(2, model.getComponent(name("ClassA")).orElseThrow().references().size());
+        assertEquals(2, model.copyOfComponent(name("ClassA")).orElseThrow().references().size());
     }
 
     private static String name(final String symbolPath) {

--- a/src/test/resources/python/access-modifiers/src/service.py
+++ b/src/test/resources/python/access-modifiers/src/service.py
@@ -7,3 +7,5 @@ class Service:
 
     def __str__(self) -> str:
         return "Service"
+
+


### PR DESCRIPTION
## Why

A consumer comparing **two revisions of a 452-file repository** — ~12,000 components each — exhausted a memory budget several times its configured heap and was killed by the OS, with **no `OutOfMemoryError`**: the excess was native memory outside every `jvm_memory_*` pool. It died during the model comparison, in neither parse. Allocation churn is the leading explanation for a native term that size, and this repository was supplying it.

Two causes, measured separately because they need different metrics: one is **allocation churn**, the other is **retained heap**.

## Breaking: the accessors are named for what they cost

Four renames, and one rule to replace a scheme that could not be learned from either half:

| before | after | returns |
|---|---|---|
| `getComponent(n)` | **`copyOfComponent(n)`** | an isolated deep copy |
| `parentBaseCmp(n)` | **`copyOfParentBaseComponent(n)`** | an isolated deep copy |
| `liveComponent(n)` | **`component(n)`** | the model's own instance |
| `liveParentBaseCmp(n)` | **`parentBaseComponent(n)`** | the model's own instance |

**A plain name aliases; `copyOf` copies.** Behaviour is unchanged in all four — only the names moved.

The previous pair had the emphasis backwards. `getComponent` reads like a map lookup and deep-copies a component, its imports, its children and every one of its references, which is how a hot read path came to allocate 629MiB: nothing at the call site suggested a price. Marking the cheap accessor `live` treated aliasing as the surprise, when the expense was the surprise.

What settles it is `components()`, which has always returned the model's own components — unmarked and uncopied. So the plural aliased silently while the singular copied silently, and no rule covered both. `copyOf` is idiomatic enough to need no javadoc, so the operation that costs something is now the one that says so. `Cmp` also leaves the public surface.

587 call sites, all mechanical.

**What this PR deliberately does not do.** The rename exposes a question it cannot answer: how many of those 554 former `getComponent` callers ever needed a copy. Every one that only reads belongs on `component()`, and that is where the remaining allocation win is — but it is an audit with measurements per call site, not a rename, because a caller that mutates what it is handed would silently start mutating the model. Worth doing next, on top of this.

## 1. The deep copy, and why the read paths are enormous

`copyOfComponent` duplicates a component's imports, its children and every one of its references. Callers rely on that isolation, so **that behaviour is unchanged**. What was missing was a sibling for the paths that only read:

- `component(String)` — the model's own instance
- `parentBaseComponent(String)` — the walk up to an enclosing base component, which was itself the cost: it copied a component at every step to read one field off it

Relationship extraction resolves every reference in the model through these and walks the parent chain once per member, **three times over per two-model comparison**. On a pair of 11,750-component models that path allocated **629MiB** and now allocates **166MiB** (−73%).

`children()`, `imports()`, `modifiers()` and the two dependency accessors returned a fresh copy on every call — `children()` from inside a filter predicate, once per child per component; the dependency sets six times per component during extraction. They are **unmodifiable views** now.

## 2. Two revisions hold the same text twice

Comparing revisions holds both models for the whole operation, and a change touching three files out of 452 leaves them naming almost entirely the same packages, types and members. `StringPool` canonicalises the fields that repeat, and an `OOPSourceCodeModel` can be **handed one so two models share it** — which is the case worth having:

| | retained, two revisions |
|---|---|
| before | 21.55 MiB |
| pool per model | 21.15 MiB (−1.9%) |
| **one shared pool** | **19.31 MiB (−10.4%)** |

### Which fields pay had to be measured, and one model would have got it wrong

`componentName` is a fully-qualified name, unique by construction; a **single-model** census puts it at 1.0x, where pooling is pure loss. Across a **pair** of revisions it is 2.0x and the third largest saving available. Recoverable bytes, both models together:

| field | ratio | recovered |
|---|---|---|
| children | 2.0x | 536,648 |
| module | 64.6x | 442,144 |
| componentName | 2.0x | 413,912 |
| name | 4.8x | 315,672 |
| modifiers | 1090.6x | 305,104 |
| codeFragment | 4.0x | 245,320 |
| imports | 7.2x | 98,392 |
| comment | 2.1x | 66,320 |
| pkg | 12.2x | 15,312 |
| sourceFile | 2.0x | 11,536 |

The census that produced this **ships beside the pool**, so the next person to ask can re-run it rather than argue.

### Not static, and not `String.intern()`

A static map here would be the shape of the leak fixed in 10.1.2, where `JavaParserFacade` kept a registry nothing pruned and each entry pinned a whole AST. An instance owned by the models given it becomes unreachable with them — exactly the scope the saving is wanted over. It retains nothing the models do not already hold, so its only cost above the saving is its own entries: visible in the benchmark as `head.copy()` rising 23.1 → 24.1 MiB, against 227MiB saved beside it.

Pooling happens in the copy constructor, on the path a component already takes into a model, so choosing the canonical instance costs a hash lookup and no extra allocation. Threading a pool through four parsers would have reached the same values having allocated them all first.

## Two smaller things found on the way

- `insertAccessModifier` called `toLowerCase` per declaration, so seven distinct tokens were held as **7,634 instances**. It stores the vocabulary's own constant now, and needs no pool to do it.
- `Package.hashCode` concatenated two fields on every call — a detail until packages started being pooled by value. Computed once, into a `transient` field so adding it cannot change the serialized form.

## Reviewer notes

Two behaviours changed under existing signatures. Neither is source-incompatible, and every caller in this repository and in `striff-lib` was audited for both:

- the five accessors return **views**, so a caller inserting while iterating one is now told (`ConcurrentModificationException`) where it previously got a silently stale snapshot — pinned by a test
- `insertAccessModifier` resolves through `OOPSourceModelConstants.accessModifier`, which trims, so a token differing only by surrounding whitespace is now accepted rather than rejected

## Methodology

Allocation is `ThreadMXBean.getThreadAllocatedBytes`, median of three iterations after one warm-up, spread under 0.3%. Retained is used-heap after repeated collection with only the models reachable — the weaker number, quoted to two significant figures, reproducible to ±0.1MiB over three runs each. The before/after comparison is against a worktree of `master` **carrying the in-flight `ComponentReference` interning**, so these figures isolate this change rather than crediting it with a neighbouring one.

## Reference-name interning, folded in

The in-progress interning of reference target names is included here rather than left to arrive separately, so this release carries **one** story about string identity instead of two adjacent classes with contradictory rationales.

Its argument for `String.intern()` over a pool of our own stands on inspection: since Java 7 the string table lives in the heap and its entries are collectable once unreachable, so it cannot retain a compile's strings after the compile — which is the objection that would otherwise apply. `refs.invokedComponent` is therefore absent from the census table above because that mechanism already covers it: 9,715 mentions collapse to 480 objects.

Its inline conditional is expanded to satisfy Checkstyle; the branch reports **0 violations**.

## Tests

`mvn verify`: **Tests run: 715, Failures: 0, Errors: 0, Skipped: 0** (698 before), Checkstyle 0 violations.

Downstream: `striff-lib` and its consumer are being updated for the rename in their own PRs. Neither can resolve this version until it publishes, so a red build there is expected until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017X3m5Qxtn8KZPM6TqrknGk
