### PR TITLE
fix: a reference names a type, not the expression the source wrote it as

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Add the dependency (check the badge above for the latest version):
 <dependency>
   <groupId>io.github.hadi-technology</groupId>
   <artifactId>clarpse</artifactId>
-  <version>11.0.0</version>
+  <version>11.1.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>io.github.hadi-technology</groupId>
 	<artifactId>clarpse</artifactId>
-	<version>11.0.0</version>
+	<version>11.1.0</version>
 	<packaging>jar</packaging>
 
 	<name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/java/com/hadi/clarpse/TypeNames.java
+++ b/src/main/java/com/hadi/clarpse/TypeNames.java
@@ -1,0 +1,75 @@
+package com.hadi.clarpse;
+
+/**
+ * Reduces a written type expression to the name of the type it refers to.
+ *
+ * <p>Source spells a type as an expression -- {@code DTO<HttpRequest>}, {@code Foo<Bar>[]},
+ * {@code Bar...} -- but a model has one component per type, named {@code DTO}, {@code Foo},
+ * {@code Bar}. A reference recorded under the written form matches no component, so the edge is
+ * present in the model, well formed, and joined to nothing. Nothing downstream can detect that:
+ * the model does not claim the type has no incoming references, it simply has none to offer.
+ *
+ * <p>The reduction is erasure plus the array and varargs suffixes. It is deliberately textual --
+ * it runs on names that a language front end has already resolved, and there is no type system
+ * here to consult.
+ */
+public final class TypeNames {
+
+    private TypeNames() {
+    }
+
+    /**
+     * The name of the type a written type expression refers to.
+     *
+     * <p>Type arguments are written in angle brackets in Java, C# and TypeScript and in square
+     * brackets in Python, and an array is square brackets with nothing in them, so the rule is one
+     * rule: the name ends where the first bracket of either kind opens. {@code DTO<HttpRequest>},
+     * {@code Map<String, List<Foo>>}, {@code Foo<?>}, {@code Foo<? extends Bar>},
+     * {@code Dict[str, int]}, {@code Bar[][]} and {@code Foo<Bar>...} name {@code DTO},
+     * {@code Map}, {@code Foo}, {@code Foo}, {@code Dict}, {@code Bar} and {@code Foo}.
+     *
+     * <p>A name with nothing to strip comes back identical, which is the common case and the one
+     * that must stay exact: a raw {@code Foo} is already the name of a type, and reducing it
+     * further would be inventing. So is a name that opens with a bracket, which is not a
+     * parameterised type at all -- truncating there would leave nothing, and a reference to
+     * nothing is worse than a reference to a name that matches nothing.
+     *
+     * <p>The type arguments are dropped rather than recorded, because a name is a name. Where they
+     * carry a dependency of their own -- {@code HttpRequest} in {@code DTO<HttpRequest>} is a real
+     * one -- it is for the caller to record as a reference in its own right; that is a different
+     * edge from the one being named here, and naming this one after both would describe neither.
+     *
+     * @param typeName a written type expression, or null
+     * @return the erased type name; the input unchanged when there is nothing to erase
+     */
+    public static String erasure(final String typeName) {
+        if (typeName == null) {
+            return null;
+        }
+        String result = typeName;
+        final int arguments = firstBracket(result);
+        if (arguments > 0) {
+            result = result.substring(0, arguments);
+        }
+        result = result.trim();
+        while (result.endsWith("...")) {
+            result = result.substring(0, result.length() - 3).trim();
+        }
+        if (result.isEmpty()) {
+            return typeName;
+        }
+        return result;
+    }
+
+    private static int firstBracket(final String typeName) {
+        final int angle = typeName.indexOf('<');
+        final int square = typeName.indexOf('[');
+        if (angle < 0) {
+            return square;
+        }
+        if (square < 0) {
+            return angle;
+        }
+        return Math.min(angle, square);
+    }
+}

--- a/src/main/java/com/hadi/clarpse/listener/JavaTreeListener.java
+++ b/src/main/java/com/hadi/clarpse/listener/JavaTreeListener.java
@@ -21,6 +21,7 @@ import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.SimpleName;
 import com.github.javaparser.ast.expr.VariableDeclarationExpr;
+import com.github.javaparser.ast.nodeTypes.NodeWithTypeParameters;
 import com.github.javaparser.ast.stmt.CatchClause;
 import com.github.javaparser.ast.stmt.ForEachStmt;
 import com.github.javaparser.ast.stmt.ForStmt;
@@ -30,9 +31,12 @@ import com.github.javaparser.ast.stmt.SwitchEntry;
 import com.github.javaparser.ast.stmt.SwitchStmt;
 import com.github.javaparser.ast.stmt.ThrowStmt;
 import com.github.javaparser.ast.stmt.WhileStmt;
+import com.github.javaparser.ast.type.ArrayType;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.type.ReferenceType;
 import com.github.javaparser.ast.type.Type;
+import com.github.javaparser.ast.type.TypeParameter;
+import com.github.javaparser.ast.type.WildcardType;
 import com.github.javaparser.ast.visitor.VoidVisitorAdapter;
 import com.github.javaparser.resolution.TypeSolver;
 import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
@@ -226,6 +230,7 @@ public class JavaTreeListener extends VoidVisitorAdapter<Object> {
             }
             ParseUtil.pointParentsToGivenChild(cmp, componentStack);
 
+            final Set<String> typeParameters = typeParameterNamesInScope(ctx);
             if (ctx.getExtendedTypes() != null) {
                 for (final ClassOrInterfaceType outerType : ctx.getExtendedTypes()) {
                     final String resolvedType = resolveType(outerType.asString());
@@ -233,6 +238,7 @@ public class JavaTreeListener extends VoidVisitorAdapter<Object> {
                         ParseUtil.insertCmpRef(cmp, new TypeExtensionReference(resolvedType),
                                 this.componentStack);
                     }
+                    insertTypeArgumentRefs(cmp, outerType, typeParameters);
                 }
             }
 
@@ -243,6 +249,7 @@ public class JavaTreeListener extends VoidVisitorAdapter<Object> {
                         ParseUtil.insertCmpRef(cmp, new TypeImplementationReference(resolvedOuterType),
                                 this.componentStack);
                     }
+                    insertTypeArgumentRefs(cmp, outerType, typeParameters);
                 }
             }
 
@@ -301,12 +308,14 @@ public class JavaTreeListener extends VoidVisitorAdapter<Object> {
             }
             ParseUtil.pointParentsToGivenChild(cmp, componentStack);
 
+            final Set<String> typeParameters = typeParameterNamesInScope(ctx);
             for (final ClassOrInterfaceType implementedType : ctx.getImplementedTypes()) {
                 final String resolvedType = resolveType(implementedType.asString());
                 if (resolvedType != null) {
                     ParseUtil.insertCmpRef(cmp, new TypeImplementationReference(resolvedType),
                             this.componentStack);
                 }
+                insertTypeArgumentRefs(cmp, implementedType, typeParameters);
             }
 
             componentStack.push(cmp);
@@ -812,6 +821,78 @@ public class JavaTreeListener extends VoidVisitorAdapter<Object> {
             }
         }
         super.visit(ctx, arg);
+    }
+
+    /**
+     * Records the type arguments of a supertype as dependencies of their own.
+     *
+     * <p>A supertype reference names one type, so {@code implements Repository<Order>} says
+     * {@code Repository} and stops. But the class does depend on {@code Order}: it is written in
+     * the source, it is part of what the class is, and it was recorded nowhere -- the supertype
+     * reference had swallowed it into a name, and the visitors that pick type names out of a class
+     * body deliberately leave the declaration's own supertypes alone. Every other type position in
+     * this listener records its arguments; heritage clauses were the one that did not, and
+     * TypeScript and C# already record them, so Java was the odd language out.
+     *
+     * <p>Recorded as a plain dependency and not with the flavour of the clause it was written in:
+     * a class implementing {@code Repository<Order>} does not implement {@code Order}.
+     */
+    private void insertTypeArgumentRefs(final Component cmp, final ClassOrInterfaceType supertype,
+                                        final Set<String> typeParameters) {
+        if (supertype.getTypeArguments().isEmpty()) {
+            return;
+        }
+        for (final Type argument : supertype.getTypeArguments().get()) {
+            insertTypeArgumentRef(cmp, argument, typeParameters);
+        }
+    }
+
+    private void insertTypeArgumentRef(final Component cmp, final Type argument,
+                                       final Set<String> typeParameters) {
+        if (argument instanceof WildcardType) {
+            // `?` names no type. Its bound does -- `? extends Bar` depends on Bar.
+            final WildcardType wildcard = (WildcardType) argument;
+            wildcard.getExtendedType().ifPresent(bound -> insertTypeArgumentRef(cmp, bound, typeParameters));
+            wildcard.getSuperType().ifPresent(bound -> insertTypeArgumentRef(cmp, bound, typeParameters));
+            return;
+        }
+        if (argument instanceof ArrayType) {
+            insertTypeArgumentRef(cmp, ((ArrayType) argument).getComponentType(), typeParameters);
+            return;
+        }
+        if (!(argument instanceof ClassOrInterfaceType)) {
+            return;
+        }
+        final ClassOrInterfaceType classType = (ClassOrInterfaceType) argument;
+        // A type variable is not a type. `class Box<T> implements Holder<T>` would otherwise
+        // resolve `T` through the current-package fallback and invent a component `<package>.T`
+        // that does not exist -- the failure mode that unresolved names are supposed to avoid by
+        // being omitted rather than guessed.
+        if (!typeParameters.contains(classType.getNameAsString())) {
+            final String resolvedType = resolveType(classType.asString());
+            if (resolvedType != null) {
+                ParseUtil.insertCmpRef(cmp, new SimpleTypeReference(resolvedType), this.componentStack);
+            }
+        }
+        insertTypeArgumentRefs(cmp, classType, typeParameters);
+    }
+
+    /**
+     * The type variables a node may legally mention: its own, and those of every type that
+     * encloses it.
+     */
+    private static Set<String> typeParameterNamesInScope(final Node node) {
+        final Set<String> names = new HashSet<>();
+        Node current = node;
+        while (current != null) {
+            if (current instanceof NodeWithTypeParameters) {
+                for (final TypeParameter typeParameter : ((NodeWithTypeParameters<?>) current).getTypeParameters()) {
+                    names.add(typeParameter.getNameAsString());
+                }
+            }
+            current = current.getParentNode().orElse(null);
+        }
+        return names;
     }
 
     private String resolveType(final String type) {

--- a/src/main/java/com/hadi/clarpse/listener/JavaTreeListener.java
+++ b/src/main/java/com/hadi/clarpse/listener/JavaTreeListener.java
@@ -40,6 +40,7 @@ import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclar
 import com.github.javaparser.resolution.model.SymbolReference;
 import com.github.javaparser.resolution.types.ResolvedType;
 import com.hadi.clarpse.compiler.ProjectFile;
+import com.hadi.clarpse.TypeNames;
 import com.hadi.clarpse.reference.SimpleTypeReference;
 import com.hadi.clarpse.reference.TypeExtensionReference;
 import com.hadi.clarpse.reference.TypeImplementationReference;
@@ -831,7 +832,16 @@ public class JavaTreeListener extends VoidVisitorAdapter<Object> {
      *     Inventing is worse than omitting, because a missing edge reads as a coverage gap while
      *     an invented one reads as a fact.
      */
-    private String resolveType(final String type, final boolean assumeCurrentPackage) {
+    private String resolveType(final String writtenType, final boolean assumeCurrentPackage) {
+        // Resolution is by name, and every lookup below -- the import map, the default classes, the
+        // type solver, the on-demand imports -- is keyed on the name of a type. A written type
+        // expression is not that: `DTO<HttpRequest>` is absent from an import map that holds `DTO`,
+        // and so is `Bar[]` from one that holds `Bar`. Every lookup then misses and the fallback
+        // invents a current-package name out of the expression -- `com.DTO<HttpRequest>` for a
+        // `DTO` that lives in another package entirely. So the type arguments have to come off
+        // before the lookups, not after: erasing only the recorded name would keep the invented
+        // package and merely make the invention look plausible.
+        final String type = TypeNames.erasure(writtenType);
         String resolvedType = "";
         final SymbolReference<ResolvedReferenceTypeDeclaration> symbol = typeSolver.tryToSolveType(type);
         if (currentImportsMap.containsKey(type)) {

--- a/src/main/java/com/hadi/clarpse/reference/ComponentReference.java
+++ b/src/main/java/com/hadi/clarpse/reference/ComponentReference.java
@@ -43,7 +43,8 @@ public abstract class ComponentReference implements Serializable, Cloneable {
      * {@code Bar[] xs} as {@code Bar[]}. The model holds one component per type -- {@code DTO},
      * {@code Bar} -- and matches references to it by name, so such a reference joins to nothing:
      * a type with twenty-six implementers reports no incoming references at all, and
-     * {@code Foo<A>} and {@code Foo<B>} count as two referenced types where the source has one.
+     * {@code Foo<Bar>} and {@code Foo<Baz>} count as two referenced types where the source has
+     * one.
      * Both directions are silent, because a model missing an edge looks exactly like a model whose
      * code has no such edge.
      *

--- a/src/main/java/com/hadi/clarpse/reference/ComponentReference.java
+++ b/src/main/java/com/hadi/clarpse/reference/ComponentReference.java
@@ -1,5 +1,7 @@
 package com.hadi.clarpse.reference;
 
+import com.hadi.clarpse.TypeNames;
+
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
@@ -25,11 +27,34 @@ public abstract class ComponentReference implements Serializable, Cloneable {
     private boolean external = false;
 
     public ComponentReference(final String invocationComponentName) {
-        invokedComponent = pooled(invocationComponentName);
+        invokedComponent = pooled(named(invocationComponentName));
     }
 
     public ComponentReference(final ComponentReference invocation) {
-        invokedComponent = pooled(invocation.invokedComponent());
+        invokedComponent = pooled(named(invocation.invokedComponent()));
+    }
+
+    /**
+     * A reference names a type, so what is stored is a type name and not the type expression the
+     * source happened to write.
+     *
+     * <p>Every language front end here resolves a written type and hands the result on unchanged,
+     * so {@code implements DTO<HttpRequest>} arrives as {@code DTO<HttpRequest>} and
+     * {@code Bar[] xs} as {@code Bar[]}. The model holds one component per type -- {@code DTO},
+     * {@code Bar} -- and matches references to it by name, so such a reference joins to nothing:
+     * a type with twenty-six implementers reports no incoming references at all, and
+     * {@code Foo<A>} and {@code Foo<B>} count as two referenced types where the source has one.
+     * Both directions are silent, because a model missing an edge looks exactly like a model whose
+     * code has no such edge.
+     *
+     * <p>Normalising here rather than at each recording site is deliberate: this is the one place
+     * every reference in every language passes through, and the invariant wanted -- a reference
+     * names a type -- is a property of references, not of any one parser. Front ends still need to
+     * erase before they <em>resolve</em>, since a name carrying its type arguments matches no
+     * import either; this cannot do that for them, only keep the stored name honest.
+     */
+    private static String named(final String invocationComponentName) {
+        return TypeNames.erasure(invocationComponentName);
     }
 
     /**

--- a/src/test/java/com/hadi/test/CrossLanguageGenericReferenceTest.java
+++ b/src/test/java/com/hadi/test/CrossLanguageGenericReferenceTest.java
@@ -1,0 +1,106 @@
+package com.hadi.test;
+
+import com.hadi.clarpse.compiler.ClarpseProject;
+import com.hadi.clarpse.compiler.CompileResult;
+import com.hadi.clarpse.compiler.Lang;
+import com.hadi.clarpse.compiler.ProjectFile;
+import com.hadi.clarpse.compiler.ProjectFiles;
+import com.hadi.clarpse.compiler.typescript.NodeRuntime;
+import com.hadi.clarpse.reference.ComponentReference;
+import com.hadi.clarpse.sourcemodel.OOPSourceCodeModel;
+import com.hadi.clarpse.sourcemodel.OOPSourceModelConstants.TypeReferences;
+import org.junit.Assume;
+import org.junit.Test;
+
+import java.nio.file.Paths;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * The invariant that a reference names a type rather than a type expression holds for every
+ * language, not only the one the defect was found in. Java, C#, TypeScript and Python all write
+ * type arguments, and all four resolve a type and then hand the resolved name on unchanged, so
+ * the shape is available to all of them wherever a resolution misses.
+ */
+public class CrossLanguageGenericReferenceTest {
+
+    private static Set<String> allReferenceNames(final OOPSourceCodeModel model) {
+        return model.components().flatMap(c -> c.references().stream())
+                .map(ComponentReference::invokedComponent).collect(Collectors.toSet());
+    }
+
+    private static Set<String> referenced(final OOPSourceCodeModel model, final String component,
+                                          final TypeReferences kind) {
+        return model.copyOfComponent(component).orElseThrow().references(kind).stream()
+                .map(ComponentReference::invokedComponent).collect(Collectors.toSet());
+    }
+
+    private static void assertNoTypeExpressions(final OOPSourceCodeModel model) {
+        final Set<String> offending = allReferenceNames(model).stream()
+                .filter(name -> name.contains("<") || name.contains("[") || name.endsWith("..."))
+                .collect(Collectors.toSet());
+        assertEquals("references naming a type expression rather than a type",
+                Set.of(), offending);
+    }
+
+    private static OOPSourceCodeModel fixture(final String path, final Lang lang) throws Exception {
+        Assume.assumeTrue(NodeRuntime.isNodeAvailable());
+        final CompileResult result = new ClarpseProject(
+                new ProjectFiles(Paths.get(path).toAbsolutePath().toString()), lang).result();
+        assertTrue(result.failures().isEmpty());
+        return result.model();
+    }
+
+    @Test
+    public void csharpGenericHeritageAndArraysNameTypes() throws Exception {
+        final ProjectFiles files = new ProjectFiles();
+        files.insertFile(new ProjectFile("/Com/IDto.cs", "namespace Com { public interface IDto<T> { } }"));
+        files.insertFile(new ProjectFile("/Com/Base.cs", "namespace Com { public class Base<T> { } }"));
+        files.insertFile(new ProjectFile("/Com/Bar.cs", "namespace Com { public class Bar { } }"));
+        files.insertFile(new ProjectFile("/Com/Foo.cs", "namespace Com { public class Foo<T> { } }"));
+        files.insertFile(new ProjectFile("/Com/Impl.cs",
+                "namespace Com {\n"
+              + " public class Impl : Base<Bar>, IDto<Bar> {\n"
+              + "   private Foo<Bar> parameterised;\n"
+              + "   private Bar raw;\n"
+              + "   private Foo<Bar>[] arr;\n"
+              + " }\n"
+              + "}"));
+        final OOPSourceCodeModel model = new ClarpseProject(files, Lang.CSHARP).result().model();
+
+        assertTrue(referenced(model, "Com.Impl", TypeReferences.EXTENSION).contains("Com.Base"));
+        assertTrue(referenced(model, "Com.Impl", TypeReferences.IMPLEMENTATION).contains("Com.IDto"));
+        assertNoTypeExpressions(model);
+    }
+
+    /**
+     * TypeScript is where the shape survives outside heritage clauses: a heritage clause resolves
+     * to a symbol and is named after it, but an array of a parameterised type has no symbol of its
+     * own that the assembler reaches for, so the reference was named {@code Foo<Bar>[]} -- the type
+     * rendered back as source.
+     */
+    @Test
+    public void typescriptArraysOfParameterisedTypesNameTypes() throws Exception {
+        final OOPSourceCodeModel model =
+                fixture("src/test/resources/typescript/generic-references", Lang.TYPESCRIPT);
+
+        assertTrue(referenced(model, "src.impl.Impl", TypeReferences.EXTENSION).contains("src.types.Base"));
+        assertTrue(referenced(model, "src.impl.Impl", TypeReferences.IMPLEMENTATION).contains("src.types.Dto"));
+        assertTrue(allReferenceNames(model).contains("src.types.Foo"));
+        assertNoTypeExpressions(model);
+    }
+
+    @Test
+    public void pythonSubscriptedBasesNameTypes() throws Exception {
+        final OOPSourceCodeModel model =
+                fixture("src/test/resources/python/generic-references", Lang.PYTHON);
+
+        assertTrue(referenced(model, "src.impl.Impl", TypeReferences.EXTENSION).contains("src.types.Base"));
+        assertTrue(referenced(model, "src.impl.Impl", TypeReferences.EXTENSION).contains("src.types.Dto"));
+        assertTrue(allReferenceNames(model).contains("src.types.Foo"));
+        assertNoTypeExpressions(model);
+    }
+}

--- a/src/test/java/com/hadi/test/TypeNamesTest.java
+++ b/src/test/java/com/hadi/test/TypeNamesTest.java
@@ -1,0 +1,83 @@
+package com.hadi.test;
+
+import com.hadi.clarpse.TypeNames;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * The reduction from a written type expression to the name of the type it refers to.
+ */
+public class TypeNamesTest {
+
+    @Test
+    public void typeArgumentsAreErased() {
+        assertEquals("DTO", TypeNames.erasure("DTO<HttpRequest>"));
+        assertEquals("com.example.model.DTO", TypeNames.erasure("com.example.model.DTO<HttpRequest>"));
+    }
+
+    @Test
+    public void nestedTypeArgumentsEraseToTheOutermostType() {
+        assertEquals("Map", TypeNames.erasure("Map<String, List<Foo>>"));
+        assertEquals("java.util.Map", TypeNames.erasure("java.util.Map<String, java.util.List<Foo>>"));
+    }
+
+    @Test
+    public void wildcardsAreErasedLikeAnyOtherArgument() {
+        assertEquals("Foo", TypeNames.erasure("Foo<?>"));
+        assertEquals("Foo", TypeNames.erasure("Foo<? extends Bar>"));
+        assertEquals("Foo", TypeNames.erasure("Foo<? super Bar>"));
+    }
+
+    @Test
+    public void arraysAndVarargsAreErased() {
+        assertEquals("Bar", TypeNames.erasure("Bar[]"));
+        assertEquals("Bar", TypeNames.erasure("Bar[][]"));
+        assertEquals("Foo", TypeNames.erasure("Foo<Bar>[]"));
+        assertEquals("Bar", TypeNames.erasure("Bar..."));
+        assertEquals("Foo", TypeNames.erasure("Foo<Bar>..."));
+    }
+
+    @Test
+    public void pythonSubscriptsAreErased() {
+        assertEquals("Dict", TypeNames.erasure("Dict[str, int]"));
+        assertEquals("dto.Foo", TypeNames.erasure("dto.Foo[dto.Bar]"));
+    }
+
+    /**
+     * The near miss. Erasing too eagerly passes every test that asks whether the type arguments are
+     * gone, so what has to be pinned is the name that had none: a raw type is already a type name
+     * and must come back byte for byte.
+     */
+    @Test
+    public void aNameWithNothingToEraseIsUnchanged() {
+        assertEquals("Foo", TypeNames.erasure("Foo"));
+        assertEquals("com.example.model.DTO", TypeNames.erasure("com.example.model.DTO"));
+        assertEquals("java.lang.String", TypeNames.erasure("java.lang.String"));
+        assertEquals("Foo_Bar$Baz", TypeNames.erasure("Foo_Bar$Baz"));
+    }
+
+    /**
+     * A name that opens with a bracket is not a parameterised type, and truncating it would leave
+     * the empty string -- a reference to nothing, which is worse than a reference that matches
+     * nothing.
+     */
+    @Test
+    public void aNameThatIsAllBracketsIsLeftAlone() {
+        assertEquals("<init>", TypeNames.erasure("<init>"));
+        assertEquals("[]", TypeNames.erasure("[]"));
+        assertEquals("...", TypeNames.erasure("..."));
+        assertEquals("", TypeNames.erasure(""));
+    }
+
+    @Test
+    public void nullIsNotAName() {
+        assertNull(TypeNames.erasure(null));
+    }
+
+    @Test
+    public void erasureIsIdempotent() {
+        assertEquals(TypeNames.erasure("Foo<Bar>[]"), TypeNames.erasure(TypeNames.erasure("Foo<Bar>[]")));
+    }
+}

--- a/src/test/java/com/hadi/test/java/GenericReferenceErasureTest.java
+++ b/src/test/java/com/hadi/test/java/GenericReferenceErasureTest.java
@@ -1,0 +1,224 @@
+package com.hadi.test.java;
+
+import com.hadi.clarpse.compiler.ClarpseProject;
+import com.hadi.clarpse.compiler.Lang;
+import com.hadi.clarpse.compiler.ProjectFile;
+import com.hadi.clarpse.compiler.ProjectFiles;
+import com.hadi.clarpse.reference.ComponentReference;
+import com.hadi.clarpse.sourcemodel.Component;
+import com.hadi.clarpse.sourcemodel.OOPSourceCodeModel;
+import com.hadi.clarpse.sourcemodel.OOPSourceModelConstants.TypeReferences;
+import org.junit.Test;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * A reference names a type, so what is recorded is the name of a type and not the expression the
+ * source wrote it as. A reference recorded as {@code DTO<HttpRequest>} matches no component, and
+ * the edge it stands for is absent from the model without being absent from the code.
+ */
+public class GenericReferenceErasureTest {
+
+    private static OOPSourceCodeModel model(final ProjectFile... files) throws Exception {
+        final ProjectFiles projectFiles = new ProjectFiles();
+        for (final ProjectFile file : files) {
+            projectFiles.insertFile(file);
+        }
+        return new ClarpseProject(projectFiles, Lang.JAVA).result().model();
+    }
+
+    private static Set<String> referenced(final OOPSourceCodeModel model, final String component) {
+        return model.copyOfComponent(component).orElseThrow().references().stream()
+                .map(ComponentReference::invokedComponent).collect(Collectors.toSet());
+    }
+
+    private static Set<String> referenced(final OOPSourceCodeModel model, final String component,
+                                          final TypeReferences kind) {
+        return model.copyOfComponent(component).orElseThrow().references(kind).stream()
+                .map(ComponentReference::invokedComponent).collect(Collectors.toSet());
+    }
+
+    /**
+     * The reproduction: implementers of a parameterised interface are invisible to it. The count is
+     * what makes it worth a test of its own -- an interface with implementers reporting no incoming
+     * references at all is a well-formed model that is simply missing every edge.
+     */
+    @Test
+    public void implementersOfAParameterisedInterfaceAreVisibleToIt() throws Exception {
+        final OOPSourceCodeModel model = model(
+                new ProjectFile("/com/DTO.java", "package com; public interface DTO<T> { }"),
+                new ProjectFile("/com/A.java", "package com; public class A implements DTO<String> { }"),
+                new ProjectFile("/com/B.java", "package com; public class B implements DTO<Integer> { }"));
+
+        assertTrue(referenced(model, "com.A", TypeReferences.IMPLEMENTATION).contains("com.DTO"));
+        assertTrue(referenced(model, "com.B", TypeReferences.IMPLEMENTATION).contains("com.DTO"));
+
+        final long incoming = model.components()
+                .filter(c -> c.references().stream()
+                        .anyMatch(r -> "com.DTO".equals(r.invokedComponent())))
+                .count();
+        assertEquals(2, incoming);
+    }
+
+    @Test
+    public void aParameterisedSupertypeIsNotExternalToItsOwnProject() throws Exception {
+        final OOPSourceCodeModel model = model(
+                new ProjectFile("/com/DTO.java", "package com; public interface DTO<T> { }"),
+                new ProjectFile("/com/A.java", "package com; public class A implements DTO<String> { }"));
+
+        final Component a = model.copyOfComponent("com.A").orElseThrow();
+        assertTrue(a.references().stream()
+                .filter(r -> "com.DTO".equals(r.invokedComponent()))
+                .noneMatch(ComponentReference::isExternal));
+        assertTrue(a.externalDependencies().stream()
+                .map(ComponentReference::invokedComponent)
+                .noneMatch(name -> name.startsWith("com.DTO")));
+    }
+
+    /**
+     * Extension references and declared-type references, not only implementation references.
+     */
+    @Test
+    public void extensionAndDeclaredTypeReferencesEraseToo() throws Exception {
+        final OOPSourceCodeModel model = model(
+                new ProjectFile("/com/Base.java", "package com; public class Base<T> { }"),
+                new ProjectFile("/com/Bar.java", "package com; public class Bar { }"),
+                new ProjectFile("/com/Foo.java", "package com; public class Foo<T> { }"),
+                new ProjectFile("/com/A.java",
+                        "package com; public class A extends Base<Bar> { private Foo<Bar> held; }"));
+
+        assertTrue(referenced(model, "com.A", TypeReferences.EXTENSION).contains("com.Base"));
+        assertTrue(referenced(model, "com.A.held").contains("com.Foo"));
+    }
+
+    /**
+     * The mirror problem, and the direction that over-counts rather than under-counts: one type
+     * mentioned in two spellings was two referenced types, because two strings are two strings.
+     * Pinned at a parameter site, which is where the two spellings survived into the model as
+     * {@code com.Foo} and {@code com.Foo<Bar>}.
+     */
+    @Test
+    public void aParameterisedAndARawMentionOfOneTypeAreOneReferencedType() throws Exception {
+        final OOPSourceCodeModel model = model(
+                new ProjectFile("/com/Foo.java", "package com; public class Foo<T> { }"),
+                new ProjectFile("/com/Bar.java", "package com; public class Bar { }"),
+                new ProjectFile("/com/A.java",
+                        "package com; public class A {\n"
+                        + "  public void m(Foo<Bar> parameterised, Foo raw, Foo<?> wildcard) { }\n"
+                        + "}"));
+
+        final Set<String> distinct = referenced(model, "com.A.m(Foo<Bar>, Foo, Foo<?>)").stream()
+                .filter(name -> name.startsWith("com.Foo")).collect(Collectors.toSet());
+        assertEquals(Set.of("com.Foo"), distinct);
+    }
+
+    @Test
+    public void nestedTypeArgumentsEraseToTheOutermostType() throws Exception {
+        final OOPSourceCodeModel model = model(
+                new ProjectFile("/com/Foo.java", "package com; public class Foo { }"),
+                new ProjectFile("/com/A.java",
+                        "package com; import java.util.List; import java.util.Map;\n"
+                        + "public class A { private Map<String, List<Foo>> nested; }"));
+
+        final Set<String> refs = referenced(model, "com.A.nested");
+        assertTrue(refs.contains("java.util.Map"));
+        assertFalse(refs.stream().anyMatch(name -> name.contains("<")));
+    }
+
+    @Test
+    public void wildcardsEraseLikeAnyOtherArgument() throws Exception {
+        final OOPSourceCodeModel model = model(
+                new ProjectFile("/com/Foo.java", "package com; public class Foo<T> { }"),
+                new ProjectFile("/com/Bar.java", "package com; public class Bar { }"),
+                new ProjectFile("/com/A.java",
+                        "package com; public class A {\n"
+                        + "  private Foo<?> unbounded;\n"
+                        + "  private Foo<? extends Bar> bounded;\n"
+                        + "}"));
+
+        assertTrue(referenced(model, "com.A.unbounded").contains("com.Foo"));
+        assertTrue(referenced(model, "com.A.bounded").contains("com.Foo"));
+    }
+
+    /**
+     * Arrays and varargs of parameterised types -- and of raw ones, which were recorded as
+     * {@code com.Bar[]} and matched nothing either. A parameter component's whole purpose is to
+     * name its declared type, so this is the site where the loss is total.
+     */
+    @Test
+    public void arraysAndVarargsNameTheirElementType() throws Exception {
+        final OOPSourceCodeModel model = model(
+                new ProjectFile("/com/Bar.java", "package com; public class Bar { }"),
+                new ProjectFile("/com/Foo.java", "package com; public class Foo<T> { }"),
+                new ProjectFile("/com/A.java",
+                        "package com; public class A {\n"
+                        + "  public void rawArray(Bar[] xs) { }\n"
+                        + "  public void parameterisedArray(Foo<Bar>[] xs) { }\n"
+                        + "  public void parameterisedVarargs(Foo<Bar>... xs) { }\n"
+                        + "}"));
+
+        assertEquals(Set.of("com.Bar"), referenced(model, "com.A.rawArray(Bar[]).xs"));
+        assertEquals(Set.of("com.Foo"), referenced(model, "com.A.parameterisedArray(Foo<Bar>[]).xs"));
+        assertEquals(Set.of("com.Foo"), referenced(model, "com.A.parameterisedVarargs(Foo<Bar>).xs"));
+    }
+
+    /**
+     * The near miss that erasure at the wrong layer would pass. The type arguments have to come off
+     * before the name is <em>resolved</em>, not after: {@code DTO<String>} is absent from an import
+     * map holding {@code DTO}, so every lookup misses and the fallback invents a current-package
+     * name. Erasing only what is recorded turns {@code com.DTO<String>} into {@code com.DTO} -- a
+     * component that does not exist, in a package the type was never in, now looking plausible.
+     */
+    @Test
+    public void aParameterisedTypeImportedFromAnotherPackageKeepsThatPackage() throws Exception {
+        final OOPSourceCodeModel model = model(
+                new ProjectFile("/other/DTO.java", "package other; public interface DTO<T> { }"),
+                new ProjectFile("/com/A.java",
+                        "package com; import other.DTO; public class A implements DTO<String> { }"));
+
+        assertEquals(Set.of("other.DTO"), referenced(model, "com.A", TypeReferences.IMPLEMENTATION));
+        assertFalse(model.containsComponent("com.DTO"));
+    }
+
+    /**
+     * The other near miss. Erasing too eagerly passes every test that asks whether the type
+     * arguments are gone, so a raw reference has to be pinned unchanged, and a real dependency has
+     * to still be recorded rather than erased away with the arguments.
+     */
+    @Test
+    public void rawReferencesAndOrdinaryDependenciesAreUntouched() throws Exception {
+        final OOPSourceCodeModel model = model(
+                new ProjectFile("/com/Bar.java", "package com; public class Bar { }"),
+                new ProjectFile("/com/Iface.java", "package com; public interface Iface { }"),
+                new ProjectFile("/com/A.java",
+                        "package com; public class A implements Iface { private Bar plain; }"));
+
+        assertEquals(Set.of("com.Iface"), referenced(model, "com.A", TypeReferences.IMPLEMENTATION));
+        assertEquals(Set.of("com.Bar"), referenced(model, "com.A.plain"));
+    }
+
+    @Test
+    public void noReferenceInTheModelNamesATypeExpression() throws Exception {
+        final OOPSourceCodeModel model = model(
+                new ProjectFile("/com/Bar.java", "package com; public class Bar { }"),
+                new ProjectFile("/com/Foo.java", "package com; public class Foo<T> { }"),
+                new ProjectFile("/com/DTO.java", "package com; public interface DTO<T> { }"),
+                new ProjectFile("/com/A.java",
+                        "package com; import java.util.List;\n"
+                        + "public class A implements DTO<Foo<Bar>> {\n"
+                        + "  private List<Foo<Bar>> nested;\n"
+                        + "  private Foo<Bar>[] arr;\n"
+                        + "  public void m(Bar... xs) { }\n"
+                        + "}"));
+
+        assertTrue(model.components()
+                .flatMap(c -> c.references().stream())
+                .map(ComponentReference::invokedComponent)
+                .noneMatch(name -> name.contains("<") || name.contains("[") || name.endsWith("...")));
+    }
+}

--- a/src/test/java/com/hadi/test/java/GenericTypeArgumentReferenceTest.java
+++ b/src/test/java/com/hadi/test/java/GenericTypeArgumentReferenceTest.java
@@ -1,0 +1,159 @@
+package com.hadi.test.java;
+
+import com.hadi.clarpse.compiler.ClarpseProject;
+import com.hadi.clarpse.compiler.Lang;
+import com.hadi.clarpse.compiler.ProjectFile;
+import com.hadi.clarpse.compiler.ProjectFiles;
+import com.hadi.clarpse.reference.ComponentReference;
+import com.hadi.clarpse.sourcemodel.OOPSourceCodeModel;
+import com.hadi.clarpse.sourcemodel.OOPSourceModelConstants.TypeReferences;
+import org.junit.Test;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * The type argument of a supertype is a dependency in its own right. {@code implements
+ * Repository<Order>} says two things -- that the class implements {@code Repository}, and that it
+ * depends on {@code Order} -- and only the first was recorded.
+ */
+public class GenericTypeArgumentReferenceTest {
+
+    private static OOPSourceCodeModel model(final ProjectFile... files) throws Exception {
+        final ProjectFiles projectFiles = new ProjectFiles();
+        for (final ProjectFile file : files) {
+            projectFiles.insertFile(file);
+        }
+        return new ClarpseProject(projectFiles, Lang.JAVA).result().model();
+    }
+
+    private static Set<String> referenced(final OOPSourceCodeModel model, final String component) {
+        return model.copyOfComponent(component).orElseThrow().references().stream()
+                .map(ComponentReference::invokedComponent).collect(Collectors.toSet());
+    }
+
+    @Test
+    public void anImplementedTypeSArgumentIsADependency() throws Exception {
+        final OOPSourceCodeModel model = model(
+                new ProjectFile("/com/DTO.java", "package com; public interface DTO<T> { }"),
+                new ProjectFile("/com/HttpRequest.java", "package com; public class HttpRequest { }"),
+                new ProjectFile("/com/A.java", "package com; public class A implements DTO<HttpRequest> { }"));
+
+        assertTrue(referenced(model, "com.A").contains("com.DTO"));
+        assertTrue(referenced(model, "com.A").contains("com.HttpRequest"));
+    }
+
+    @Test
+    public void anExtendedTypeSArgumentIsADependency() throws Exception {
+        final OOPSourceCodeModel model = model(
+                new ProjectFile("/com/Base.java", "package com; public class Base<T> { }"),
+                new ProjectFile("/com/Order.java", "package com; public class Order { }"),
+                new ProjectFile("/com/A.java", "package com; public class A extends Base<Order> { }"));
+
+        assertTrue(referenced(model, "com.A").contains("com.Base"));
+        assertTrue(referenced(model, "com.A").contains("com.Order"));
+    }
+
+    /**
+     * The argument is a dependency, not a supertype: a class implementing {@code DTO<HttpRequest>}
+     * does not implement {@code HttpRequest}.
+     */
+    @Test
+    public void anArgumentIsRecordedAsAPlainDependencyNotAsHeritage() throws Exception {
+        final OOPSourceCodeModel model = model(
+                new ProjectFile("/com/DTO.java", "package com; public interface DTO<T> { }"),
+                new ProjectFile("/com/HttpRequest.java", "package com; public class HttpRequest { }"),
+                new ProjectFile("/com/A.java", "package com; public class A implements DTO<HttpRequest> { }"));
+
+        assertEquals(Set.of("com.DTO"), model.copyOfComponent("com.A").orElseThrow()
+                .references(TypeReferences.IMPLEMENTATION).stream()
+                .map(ComponentReference::invokedComponent).collect(Collectors.toSet()));
+        assertTrue(model.copyOfComponent("com.A").orElseThrow()
+                .references(TypeReferences.SIMPLE).stream()
+                .map(ComponentReference::invokedComponent).collect(Collectors.toSet())
+                .contains("com.HttpRequest"));
+    }
+
+    @Test
+    public void nestedArgumentsAreEachADependency() throws Exception {
+        final OOPSourceCodeModel model = model(
+                new ProjectFile("/com/DTO.java", "package com; public interface DTO<T> { }"),
+                new ProjectFile("/com/Box.java", "package com; public class Box<T> { }"),
+                new ProjectFile("/com/Order.java", "package com; public class Order { }"),
+                new ProjectFile("/com/A.java", "package com; public class A implements DTO<Box<Order>> { }"));
+
+        final Set<String> refs = referenced(model, "com.A");
+        assertTrue(refs.contains("com.DTO"));
+        assertTrue(refs.contains("com.Box"));
+        assertTrue(refs.contains("com.Order"));
+    }
+
+    @Test
+    public void aWildcardBoundIsADependencyAndABareWildcardIsNot() throws Exception {
+        final OOPSourceCodeModel model = model(
+                new ProjectFile("/com/DTO.java", "package com; public interface DTO<T> { }"),
+                new ProjectFile("/com/Bar.java", "package com; public class Bar { }"),
+                new ProjectFile("/com/Bounded.java",
+                        "package com; public class Bounded implements DTO<Bar> { }"),
+                new ProjectFile("/com/Unbounded.java",
+                        "package com; public class Unbounded implements DTO<?> { }"));
+
+        assertTrue(referenced(model, "com.Bounded").contains("com.Bar"));
+        assertEquals(Set.of("com.DTO"), referenced(model, "com.Unbounded"));
+    }
+
+    /**
+     * The near miss. A type variable is not a type, and resolving one through the current-package
+     * fallback would invent a component named after it -- a fact-shaped name for something that
+     * does not exist, which is worse than the missing edge this change is closing.
+     */
+    @Test
+    public void aTypeVariableIsNotRecordedAsADependency() throws Exception {
+        final OOPSourceCodeModel model = model(
+                new ProjectFile("/com/Holder.java", "package com; public interface Holder<T> { }"),
+                new ProjectFile("/com/Box.java", "package com; public class Box<T> implements Holder<T> { }"));
+
+        assertEquals(Set.of("com.Holder"), referenced(model, "com.Box"));
+        assertFalse(model.containsComponent("com.T"));
+    }
+
+    @Test
+    public void anEnclosingTypeSVariableIsNotRecordedEither() throws Exception {
+        final OOPSourceCodeModel model = model(
+                new ProjectFile("/com/Holder.java", "package com; public interface Holder<T> { }"),
+                new ProjectFile("/com/Outer.java",
+                        "package com; public class Outer<E> {\n"
+                        + "  class Inner implements Holder<E> { }\n"
+                        + "}"));
+
+        assertFalse(referenced(model, "com.Outer.Inner").contains("com.E"));
+        assertTrue(referenced(model, "com.Outer.Inner").contains("com.Holder"));
+    }
+
+    @Test
+    public void aRecordSImplementedTypeSArgumentIsADependency() throws Exception {
+        final OOPSourceCodeModel model = model(
+                new ProjectFile("/com/DTO.java", "package com; public interface DTO<T> { }"),
+                new ProjectFile("/com/Order.java", "package com; public class Order { }"),
+                new ProjectFile("/com/A.java", "package com; public record A(int x) implements DTO<Order> { }"));
+
+        assertTrue(referenced(model, "com.A").contains("com.DTO"));
+        assertTrue(referenced(model, "com.A").contains("com.Order"));
+    }
+
+    /**
+     * A raw supertype has no arguments, and must gain no references it did not have.
+     */
+    @Test
+    public void aRawSupertypeGainsNothing() throws Exception {
+        final OOPSourceCodeModel model = model(
+                new ProjectFile("/com/Iface.java", "package com; public interface Iface { }"),
+                new ProjectFile("/com/A.java", "package com; public class A implements Iface { }"));
+
+        assertEquals(Set.of("com.Iface"), referenced(model, "com.A"));
+    }
+}

--- a/src/test/resources/python/generic-references/src/impl.py
+++ b/src/test/resources/python/generic-references/src/impl.py
@@ -1,0 +1,9 @@
+from .types import Bar, Base, Dto, Foo, HttpRequest
+
+
+class Impl(Base[HttpRequest], Dto[HttpRequest]):
+    parameterised: Foo[Bar]
+    raw: Bar
+
+    def ret(self) -> Foo[Bar]:
+        return None

--- a/src/test/resources/python/generic-references/src/types.py
+++ b/src/test/resources/python/generic-references/src/types.py
@@ -1,0 +1,23 @@
+from typing import Generic, TypeVar
+
+T = TypeVar('T')
+
+
+class Dto(Generic[T]):
+    pass
+
+
+class Base(Generic[T]):
+    pass
+
+
+class HttpRequest:
+    pass
+
+
+class Bar:
+    pass
+
+
+class Foo(Generic[T]):
+    pass

--- a/src/test/resources/typescript/generic-references/src/impl.ts
+++ b/src/test/resources/typescript/generic-references/src/impl.ts
@@ -1,0 +1,11 @@
+import { Bar, Base, Dto, Foo, HttpRequest } from './types';
+
+export class Impl extends Base<HttpRequest> implements Dto<HttpRequest> {
+  parameterised: Foo<Bar>;
+  raw: Bar;
+  arrayOfParameterised: Foo<Bar>[];
+
+  ret(): Foo<Bar> {
+    return null as any;
+  }
+}

--- a/src/test/resources/typescript/generic-references/src/types.ts
+++ b/src/test/resources/typescript/generic-references/src/types.ts
@@ -1,0 +1,17 @@
+export interface Dto<T> {
+  value: T;
+}
+
+export class Base<T> {
+  held: T;
+}
+
+export class HttpRequest {
+}
+
+export class Bar {
+}
+
+export class Foo<T> {
+  wrapped: T;
+}

--- a/src/test/resources/typescript/generic-references/tsconfig.json
+++ b/src/test/resources/typescript/generic-references/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["**/*.ts"]
+}


### PR DESCRIPTION
Fixes #174.

## What was wrong

A reference to a parameterised type recorded the written type expression, not the name of a type.

```
TypeImplementationReference  com.example.model.DTO<HttpRequest>
```

The model holds one component per type, named `com.example.model.DTO`, and matches references to it by name. So that reference joined to nothing, and an interface with twenty-six implementers reported **no incoming references at all**.

Both directions of the error are silent. A model that is missing an edge is well formed, and looks exactly like a model whose code has no such edge — so nothing downstream can tell "the parser lost this" from "the code does not do this". The same cause over-counts in the other direction: `Foo`, `Foo<Bar>` and `Foo<?>` mentioned on one method were three referenced types where the source has one type mentioned three times.

## The fix, in two parts

**`ComponentReference` stores the erased name.** This is the one place every reference in every language passes through, and the invariant wanted — *a reference names a type* — is a property of references rather than of any one parser.

**`JavaTreeListener.resolveType` erases before resolving.** This is the half that erasing at the reference alone would have quietly got wrong. Every lookup in that method is keyed on the name of a type: the import map, the default classes, the type solver, the on-demand imports. A written type expression is in none of them, so every lookup missed and the fallback invented a current-package name out of the whole expression — a `DTO<String>` imported from `other` came out as `com.DTO<String>`. Erasing only what gets recorded would have turned that into `com.DTO`: a component that does not exist, in a package the type was never in, and now plausible enough to be believed. There is a test for exactly this.

The reduction is one rule — a name ends at the first bracket of either kind — which covers `<T>` in Java, C# and TypeScript, `[T]` in Python, `[]` arrays and `...` varargs. It only ever removes, never rewrites, so a name with nothing to strip comes back byte for byte.

## Arrays and varargs turned out to be the same defect

`void m(Bar[] xs)` recorded `com.Bar[]`. A parameter component exists to name its declared type, so its only reference pointed at nothing. Same for `Foo<Bar>[]` and `Foo<Bar>...`.

## Per language

| | before | after |
|---|---|---|
| **Java** | broken at `extends`, `implements`, and every method and constructor parameter | fixed |
| **TypeScript** | heritage clauses resolve through the symbol and were correct; an array of a parameterised type has no symbol of its own and was named `Foo<Bar>[]` | fixed |
| **C#** | already erases generic declarations; correct | unchanged |
| **Python** | subscripts are resolved before a reference is built; correct | unchanged |

The choke point covers all four regardless.

## The three sub-decisions the issue names

1. **Type arguments as their own references** — recorded, in the second commit so it can be reverted on its own. `implements Repository<Order>` says two things, and only the first was recorded; every other type position in the Java listener already records its arguments, and TypeScript and C# already record them at heritage sites too, so Java was the odd language out. Recorded as a plain dependency, not with the flavour of the clause: a class implementing `Repository<Order>` does not implement `Order`. A type variable is **not** recorded — `class Box<T> implements Holder<T>` would otherwise invent a component `com.T`.
2. **Nested and wildcard forms** — erase to the outermost type. `Map<String, List<Foo>>` → `Map`, `Foo<?>` → `Foo`, `Foo<? extends Bar>` → `Foo`. A wildcard names no type and is not recorded; its bound is.
3. **Arrays and varargs** — erase to the element type, as above.

## Evidence

Every fix is pinned by a test that fails on the previous commit and passes on this one, verified by reverting.

- erasure: **7 of 22 new tests fail** without it (8 including the strengthened over-counting test)
- type arguments: **6 of 9 new tests fail** without it
- near-misses that pass in **both** states, so eager erasure cannot fake them: a raw `Foo` unchanged; an ordinary dependency still recorded; a type variable never invented; an enclosing type's variable never invented; a raw supertype gaining nothing

Full suite green: 722 existing tests, 0 failures, including `SmokeTest` over junit5 and clarpse's own sources.

## Version

11.1.0 — minor, not patch. The recorded names change for every consumer, and references that were classified external for want of a match are now internal. The API is untouched.
