### PR TITLE
test: a stopwatch cannot tell an exclusion from a parse, so stop asking it to

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Add the dependency (check the badge above for the latest version):
 <dependency>
   <groupId>io.github.hadi-technology</groupId>
   <artifactId>clarpse</artifactId>
-  <version>11.1.0</version>
+  <version>11.1.1</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>io.github.hadi-technology</groupId>
 	<artifactId>clarpse</artifactId>
-	<version>11.1.0</version>
+	<version>11.1.1</version>
 	<packaging>jar</packaging>
 
 	<name>${project.groupId}:${project.artifactId}</name>

--- a/src/test/java/com/hadi/test/python/PythonLargeDirExcludeTest.java
+++ b/src/test/java/com/hadi/test/python/PythonLargeDirExcludeTest.java
@@ -15,24 +15,41 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+/**
+ * Files under an excluded directory are not in the model, at a size where the exclusion has to be
+ * doing real work.
+ *
+ * <p>Deliberately has no time budget, for the reason recorded on
+ * {@link PythonLargeZipExcludeTest}: the cost of a Python compile is dominated by starting the
+ * daemon, so a budget large enough to survive a cold start is far larger than the cost of parsing
+ * the files that were supposed to be skipped. It measured which test ran first, not whether
+ * exclusion worked.
+ */
 public class PythonLargeDirExcludeTest {
 
-    @Test(timeout = 5000)
+    /**
+     * Writes {@code src/app.py} plus 300 modules under {@code <bulkDir>/lib/site-packages}.
+     */
+    private static Path buildProject(final String bulkDir) throws Exception {
+        Path root = Files.createTempDirectory("clarpse-large-py");
+        Path srcDir = root.resolve("src");
+        Files.createDirectories(srcDir);
+        Files.write(srcDir.resolve("app.py"), "class App:\n    pass\n".getBytes(StandardCharsets.UTF_8));
+
+        Path bulk = root.resolve(bulkDir + "/lib/site-packages");
+        Files.createDirectories(bulk);
+        for (int i = 0; i < 300; i++) {
+            Files.write(bulk.resolve("ignored" + i + ".py"),
+                    ("class Ignored" + i + ":\n    pass\n").getBytes(StandardCharsets.UTF_8));
+        }
+        return root;
+    }
+
+    @Test
     public void testLargeDirExcludedDirsAreIgnored() throws Exception {
         Assume.assumeTrue(NodeRuntime.isNodeAvailable());
-        Path root = Files.createTempDirectory("clarpse-large-py");
+        Path root = buildProject(".venv");
         try {
-            Path srcDir = root.resolve("src");
-            Files.createDirectories(srcDir);
-            Files.write(srcDir.resolve("app.py"), "class App:\n    pass\n".getBytes(StandardCharsets.UTF_8));
-
-            Path venvDir = root.resolve(".venv/lib/site-packages");
-            Files.createDirectories(venvDir);
-            for (int i = 0; i < 300; i++) {
-                Files.write(venvDir.resolve("ignored" + i + ".py"),
-                        ("class Ignored" + i + ":\n    pass\n").getBytes(StandardCharsets.UTF_8));
-            }
-
             ProjectFiles files = new ProjectFiles(root.toString());
             CompileResult result = new ClarpseProject(files, Lang.PYTHON).result();
             OOPSourceCodeModel model = result.model();
@@ -41,6 +58,34 @@ public class PythonLargeDirExcludeTest {
             String ignoredName = PythonTestUtil.uniqueName(".venv/lib/site-packages", "ignored0", "Ignored0");
             Assert.assertTrue(model.containsComponent(appName));
             Assert.assertFalse(model.containsComponent(ignoredName));
+            Assert.assertTrue(result.failures().isEmpty());
+        } finally {
+            FileUtils.deleteQuietly(root.toFile());
+        }
+    }
+
+    /**
+     * The same 300 modules under a directory nobody excludes, which must all be parsed.
+     *
+     * <p>This is what keeps the assertion above from being vacuous. {@code assertFalse(contains(...))}
+     * passes just as well when the parser found nothing anywhere -- a broken exclusion and a broken
+     * parser produce the same empty answer, and the test that was supposed to separate them was a
+     * stopwatch that could not. Renaming the directory is the one variable that changes, so if
+     * these 300 modules appear here and not there, the exclusion is what did it.
+     */
+    @Test
+    public void testUnexcludedDirsOfTheSameSizeAreParsed() throws Exception {
+        Assume.assumeTrue(NodeRuntime.isNodeAvailable());
+        Path root = buildProject("vendorlib");
+        try {
+            ProjectFiles files = new ProjectFiles(root.toString());
+            CompileResult result = new ClarpseProject(files, Lang.PYTHON).result();
+            OOPSourceCodeModel model = result.model();
+
+            String appName = PythonTestUtil.uniqueName("src", "app", "App");
+            String parsedName = PythonTestUtil.uniqueName("vendorlib/lib/site-packages", "ignored0", "Ignored0");
+            Assert.assertTrue(model.containsComponent(appName));
+            Assert.assertTrue(model.containsComponent(parsedName));
             Assert.assertTrue(result.failures().isEmpty());
         } finally {
             FileUtils.deleteQuietly(root.toFile());

--- a/src/test/java/com/hadi/test/python/PythonLargeZipExcludeTest.java
+++ b/src/test/java/com/hadi/test/python/PythonLargeZipExcludeTest.java
@@ -16,9 +16,24 @@ import java.nio.charset.StandardCharsets;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
+/**
+ * Files under an excluded directory are not in the model, at a size where the exclusion has to be
+ * doing real work.
+ *
+ * <p>Deliberately has no time budget. It used to have a five-second one, on the theory that
+ * reading 300 files it was supposed to ignore would take longer than ignoring them -- but a Python
+ * compile spawns a daemon and unzips a 6 MB bundle to do it, and that start-up costs whole seconds
+ * while 300 small modules cost almost nothing next to it. Measured both ways, parsing every file
+ * and parsing one took the same time to within the noise, so the budget could not tell a working
+ * exclusion from a broken one. What it could tell was whether the daemon was already warm, which
+ * is to say whether some other test had run first: it failed in isolation and passed in a full
+ * suite, on unmodified master.
+ *
+ * <p>The assertions below say directly what the budget was a proxy for, and say it exactly.
+ */
 public class PythonLargeZipExcludeTest {
 
-    @Test(timeout = 5000)
+    @Test
     public void testLargeZipExcludedDirsAreIgnored() throws Exception {
         Assume.assumeTrue(NodeRuntime.isNodeAvailable());
         ByteArrayOutputStream baos = new ByteArrayOutputStream();


### PR DESCRIPTION
Fixes #167.

## The budget was measuring the wrong thing — and could not measure the right one

Both tests had a hard five-second budget, on the theory that reading 300 files they were meant to ignore would take measurably longer than ignoring them.

It does not. A Python compile spawns a daemon and unzips a 6 MB pyright bundle to do it; that start-up is where the seconds go, and 300 small modules are lost in the noise beside it. Same fixture, same machine, the only difference being whether the bulk directory is named `.venv` or something nobody excludes:

| | run 1 | run 2 | run 3 | run 4 |
|---|---|---|---|---|
| 300 files **excluded** (1 component) | 4372 ms | 4825 ms | 3953 ms | 4455 ms |
| 301 files **parsed** (301 components) | 4397 ms | 4319 ms | | |

A completely broken exclusion finishes inside the budget. The stopwatch could not fail for the reason it existed.

## What it *could* detect

Whether the daemon had already been started once in this JVM — which is to say, whether some other test ran first. Cold, in isolation, on unmodified `master` (9b95ca9), three runs each:

```
PythonLargeZipExcludeTest   5.536s  5.420s  5.335s
PythonLargeDirExcludeTest   5.436s  5.349s  5.429s
```

Six failures out of six against a five-second budget, on a tree with no changes in it. In a full-suite run both pass, because by then an earlier Python test has paid the first-compile cost. That is exactly the shape the issue reports, and exactly why it cost a bisect to establish it was not someone's regression.

## Removing the budget rather than raising it

A larger budget would still be measuring start-up, just with enough slack to usually get away with it. A number that fails only under load is worse than no number — it spends someone's afternoon before it teaches them anything. Warming the daemon in `@BeforeClass` was the other option in the issue and I tried it first; it does not help enough either, because every compile starts its own daemon, so the warmed run still ran 10.4 s.

## Keeping the assertion honest

`assertFalse(model.containsComponent(ignoredName))` passes just as well when the parser found nothing anywhere — a broken exclusion and a broken parser give the same empty answer, and the stopwatch was supposed to be what separated them.

So there is now a second test that builds the identical 300 files under `vendorlib/` instead of `.venv/` and requires **every one of them** to be in the model. The directory name is the only variable between the two tests, so if the files appear in one and not the other, the exclusion is what did it.

## After

Isolated, cold, three runs each:

```
PythonLargeZipExcludeTest   7.858s  8.084s  7.357s   pass
PythonLargeDirExcludeTest   6.790s  8.944s  5.074s   pass
```

Every one of those would have failed the old budget.

## Version

11.1.1 — patch. Test-only change; bumped because a push to `master` publishes, and a version that already exists on Central fails the job.
